### PR TITLE
ci: use a 'constraints' file to install packages for tests

### DIFF
--- a/taskcluster/ci/tests/kind.yml
+++ b/taskcluster/ci/tests/kind.yml
@@ -38,8 +38,7 @@ jobs:
             symbol: unit
         run:
             command: >-
-                pip install --user -r requirements/test.txt &&
-                pip install --user --no-deps . &&
+                pip install --user -c requirements/test.txt . &&
                 pyenv latest local 3.10 3.9 3.8 3.7 &&
                 tox
 
@@ -49,7 +48,7 @@ jobs:
             symbol: flake8
         run:
             command: >-
-                pip install --user -r requirements/test.txt &&
+                pip install --user -c requirements/test.txt flake8 &&
                 flake8
 
     black:
@@ -58,7 +57,7 @@ jobs:
             symbol: black
         run:
             command: >-
-                pip install --user -r requirements/test.txt &&
+                pip install --user -r requirements/test.txt black &&
                 black --check .
 
     yamllint:
@@ -67,5 +66,5 @@ jobs:
             symbol: yaml
         run:
             command: >-
-                pip install --user -r requirements/test.txt &&
+                pip install --user -c requirements/test.txt yamllint &&
                 yamllint .


### PR DESCRIPTION
Previously the tasks in CI would install everything that exists in
requirements/test.txt, which included a lot of unnecessary packages.

By instead passing in the file as a constraint via the `-c` option, we
only install the packages that are actually needed, while still
constraining them to the versions specified in the requirements.txt.