### PR TITLE
ci: change pullRequest policy to public

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -7,7 +7,7 @@
 version: 1
 reporting: checks-v1
 policy:
-    pullRequests: collaborators
+    pullRequests: public
 tasks:
     # NOTE: support for actions in ci-admin requires that the `tasks` property be an array *before* JSON-e rendering
     # takes place.


### PR DESCRIPTION
Now that we don't need to trigger builds via the rtd webhook, Taskgraph
tasks aren't depending on any secrets and there's no reason to have the
pullRequest policy set to collaborators.