### PR TITLE
docs: refactor contributing docs out of README

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Community Participation Guidelines
+
+This repository is governed by Mozilla's code of conduct and etiquette guidelines.
+For more details, please read the
+[Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/).
+
+## How to Report
+For more information on how to report violations of the Community Participation Guidelines, please read our '[How to Report](https://www.mozilla.org/about/governance/policies/participation/reporting/)' page.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,122 @@
+Contributing to Taskgraph
+=========================
+
+Thanks for your interest in Taskgraph! To participate in this community, please
+review our `code of conduct`_.
+
+.. _code of conduct: https://github.com/taskcluster/taskgraph/blob/main/CODE_OF_CONDUCT.md
+
+Clone the Repo
+--------------
+
+To contribute to Taskgraph or use the debugging tools, you'll need to clone the
+repository, activate a virtualenv and install dependencies:
+
+.. code-block::
+
+  # first fork taskgraph
+  git clone https://github.com/<user>/taskgraph
+  cd taskgraph
+  git remote add upstream https://github.com/taskcluster/taskgraph
+  python -m venv taskgraph && source taskgraph/bin/activate
+  pip install -r requirements/dev.txt
+  python setup.py develop
+
+Running Tests and Linters
+-------------------------
+
+Tests are run with the `pytest <https://docs.pytest.org>`_ framework:
+
+.. code-block::
+
+  pytest src
+
+We also enforce the `black`_ formatter and `flake8`_ linter in Taskgraph's CI:
+
+.. code-block::
+
+  black .
+  flake8
+
+.. _black: https://black.readthedocs.io
+.. _flake8: https://flake8.pycqa.org/en/latest/
+
+.. _working-on-taskgraph:
+
+Working with Documentation
+--------------------------
+
+The Taskgraph repo uses `Sphinx`_ to generate the documentation. To work on the
+docs, run:
+
+.. code-block::
+
+  make livehtml
+
+This will start a live server that automatically re-generates when you edit a
+documentation file. Alternatively you can generate static docs under the
+``docs/_build`` directory:
+
+.. code-block::
+
+  make html
+
+Taskgraph also uses the ``autodoc`` extension to generate an API reference.
+When new modules are created, be sure to add an ``autodoc`` directive for
+them in the source reference.
+
+.. _Sphinx: https://www.sphinx-doc.org
+
+Managing Dependencies
+---------------------
+
+.. warning::
+   Ensure you always update packages using the minimum supported Python.
+   Otherwise you may break the workflow of people trying to develop Taskgraph
+   with an older version of Python. The `pyenv`_ tool can help with managing
+   multiple Python versions at once.
+
+To help lock dependencies, Taskgraph uses a tool called `pip-compile-multi`_.
+To add or update a dependency first edit the relevant ``.in`` file under the
+``requirements`` directory. If the dependency is needed by the actual Taskgraph
+library, edit ``requirements/base.in``. If it's required by the CI system, edit
+``requirements/test.in``. And if it's only needed for developing Taskgraph,
+edit ``requirements/dev.in``.
+
+Next run the following command from the repository root:
+
+.. code-block::
+
+  pip-compile-multi -g base -g test -g dev --allow-unsafe
+
+If you'd like to add a new package without upgrading any of the existing ones,
+you can run:
+
+.. code-block::
+
+  pip-compile-multi -g base -g test -g dev --allow-unsafe --no-upgrade
+
+.. _pyenv: https://github.com/pyenv/pyenv
+.. _pip-compile-multi: https://pip-compile-multi.readthedocs.io/en/latest/
+
+Releasing
+---------
+
+In order to release a new version of Taskgraph, you will need permission to the
+`taskcluster-taskgraph`_ project in PyPI. The following are **required** steps:
+
+1. Update ``CHANGELOG.md``
+2. Update ``version`` in ``setup.py``
+3. Commit, and land the above changes
+4. Make sure your ``hg status`` is clean
+5. Checkout the latest public revision ``hg checkout -r 'last(public())'``
+6. Pull latest revision ``hg pull -u``
+7. Verify ``hg ident`` outputs the desired revision
+8. Remove previously packaged releases ``rm -rf ./dist/*``
+9. Package the app ``python setup.py sdist bdist_wheel``
+10. Upload to PyPI using `twine`_ ``twine upload dist/*`` providing your
+    username and API token
+
+.. _taskcluster-taskgraph: https://pypi.org/project/taskcluster-taskgraph/
+.. _twine: https://pypi.org/project/twine/
+

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -108,10 +108,10 @@ In order to release a new version of Taskgraph, you will need permission to the
 1. Update ``CHANGELOG.md``
 2. Update ``version`` in ``setup.py``
 3. Commit, and land the above changes
-4. Make sure your ``hg status`` is clean
-5. Checkout the latest public revision ``hg checkout -r 'last(public())'``
-6. Pull latest revision ``hg pull -u``
-7. Verify ``hg ident`` outputs the desired revision
+4. Make sure your ``git status`` is clean
+5. Checkout the latest public revision ``git checkout main``
+6. Pull latest revision ``git pull upstream main``
+7. Verify ``git show`` outputs the desired revision
 8. Remove previously packaged releases ``rm -rf ./dist/*``
 9. Package the app ``python setup.py sdist bdist_wheel``
 10. Upload to PyPI using `twine`_ ``twine upload dist/*`` providing your

--- a/README.rst
+++ b/README.rst
@@ -15,12 +15,41 @@ Taskgraph
 =========
 
 Taskgraph is a Python library to generate graphs of tasks for the `Taskcluster
-CI`_ service. It is the recommended approach for configuring your tasks once
-your project outgrows a single `.taskcluster.yml` file.
+CI`_ service. It is the recommended approach for configuring tasks once your
+project outgrows a single `.taskcluster.yml`_ file.
+
+How It Works
+------------
+
+Unlike most CI offerings, Taskcluster is a generic task execution platform.
+This means that tasks can be scheduled via its `comprehensive API`_, and aren't
+limited to being triggered in response to supported events.
+
+Taskgraph leverages this execution platform to allow CI systems to scale to any
+size or complexity.
+
+1. A *decision task* is created via Taskcluster's normal `.taskcluster.yml`_
+   file. This task invokes ``taskgraph``.
+3. Taskgraph evaluates a series of yaml based task definitions (similar to
+   those other CI offerings provide).
+4. Taskgraph applies transforms on top of these task definitions. Transforms
+   are Python functions that can programmatically alter or even clone a task
+   definition.
+5. Taskgraph applies some optional optimization logic to remove unnecessary
+   tasks.
+6. Taskgraph submits the resulting *task graph* to Taskcluster via its API.
+
+Taskgraph's combination of declarative task configuration combined with
+programmatic alteration are what allow it to support CI systems of any scale.
+Taskgraph is the library that powers the 30,000+ tasks making up `Firefox's
+CI`_.
 
 For more information and usage instructions, `see the docs`_.
 
 .. _Taskcluster CI: https://taskcluster.net/
+.. _comprehensive API: https://docs.taskcluster.net/docs/reference/platform/queue/api
+.. _.taskcluster.yml: https://docs.taskcluster.net/docs/reference/integrations/github/taskcluster-yml-v1
+.. _Firefox's CI: https://treeherder.mozilla.org/jobs?repo=mozilla-central
 .. _see the docs: https://taskcluster-taskgraph.readthedocs.io
 
 Installation
@@ -45,116 +74,9 @@ In both cases, it's recommended to use a Python `virtual environment`_.
 
 .. _virtual environment: https://docs.python.org/3/tutorial/venv.html
 
-Working on Taskgraph
---------------------
+Get Involved
+------------
 
-To contribute to Taskgraph or use the debugging tools, you'll need to clone the
-repository, activate a virtualenv and install dependencies:
+If you'd like to get involved, please see our `contributing docs`_!
 
-.. code-block::
-
-  git clone https://github.com/taskcluster/taskgraph
-  cd taskgraph
-  python -m venv taskgraph && source taskgraph/bin/activate
-  pip install -r requirements/dev.txt
-  $ python setup.py develop
-
-Running Tests and Linters
--------------------------
-
-Tests are run with the `pytest <https://docs.pytest.org>`_ framework:
-
-.. code-block::
-
-  pytest src
-
-We also enforce the `black`_ formatter and `flake8`_ linter in Taskgraph's CI:
-
-.. code-block::
-
-  black .
-  flake8
-
-.. _black: https://black.readthedocs.io
-.. _flake8: https://flake8.pycqa.org/en/latest/
-
-.. _working-on-taskgraph:
-
-Working with Documentation
---------------------------
-
-The Taskgraph repo uses `Sphinx`_ to generate the documentation. To work on the
-docs, run:
-
-.. code-block::
-
-  make livehtml
-
-This will start a live server that automatically re-generates when you edit a
-documentation file. Alternatively you can generate static docs under the
-``docs/_build`` directory:
-
-.. code-block::
-
-  make html
-
-Taskgraph also uses the ``autodoc`` extension to generate an API reference.
-When new modules are created, be sure to add an ``autodoc`` directive for
-them in the source reference.
-
-.. _Sphinx: https://www.sphinx-doc.org
-
-Managing Dependencies
----------------------
-
-.. warning::
-   Ensure you always update packages using the minimum supported Python.
-   Otherwise you may break the workflow of people trying to develop Taskgraph
-   with an older version of Python. The `pyenv`_ tool can help with managing
-   multiple Python versions at once.
-
-To help lock dependencies, Taskgraph uses a tool called `pip-compile-multi`_.
-To add or update a dependency first edit the relevant ``.in`` file under the
-``requirements`` directory. If the dependency is needed by the actual Taskgraph
-library, edit ``requirements/base.in``. If it's required by the CI system, edit
-``requirements/test.in``. And if it's only needed for developing Taskgraph,
-edit ``requirements/dev.in``.
-
-Next run the following command from the repository root:
-
-.. code-block::
-
-  pip-compile-multi -g base -g test -g dev --allow-unsafe
-
-If you'd like to add a new package without upgrading any of the existing ones,
-you can run:
-
-.. code-block::
-
-  pip-compile-multi -g base -g test -g dev --allow-unsafe --no-upgrade
-
-.. _pyenv: https://github.com/pyenv/pyenv
-.. _pip-compile-multi: https://pip-compile-multi.readthedocs.io/en/latest/
-
-Releasing
----------
-
-In order to release a new version of Taskgraph, you will need permission to the
-`taskcluster-taskgraph`_ project in PyPI.
-The following are **required** steps:
-
-  1. Update ``CHANGELOG.md``
-  2. Update ``version`` in ``setup.py``
-  3. Commit, and land the above changes
-  4. Make sure your ``hg status`` is clean
-  5. Checkout the latest public revision ``hg checkout -r 'last(public())'``
-  6. Pull latest revision ``hg pull -u``
-  7. Verify ``hg ident`` outputs the desired revision
-  8. Remove previously packaged releases ``rm -rf ./dist/*``
-  9. Package the app ``python setup.py sdist bdist_wheel``
-  10. Upload to PyPI using `twine`_ ``twine upload dist/*`` providing your
-      username and API token
-
-.. _taskcluster-taskgraph: https://pypi.org/project/taskcluster-taskgraph/
-.. _twine: https://pypi.org/project/twine/
-
+.. _contributing docs: https://github.com/taskcluster/taskgraph/blob/main/CONTRIBUTING.md

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,1 +1,1 @@
-.. include:: ../README.rst
+.. include:: ../CONTRIBUTING.rst


### PR DESCRIPTION
A README should primarily be about telling readers what the repo is about, as well as provide some links to additional docs / context. Information about how to contribute doesn't need to be front and centre and instead should be in a dedicated CONTRIBUTING file.

This also adds a 'How It Works' section to the README and the
CODE_OF_CONDUCT file.