### PR TITLE
fix: encoding error when using out of tree images

### DIFF
--- a/src/taskgraph/transforms/task.py
+++ b/src/taskgraph/transforms/task.py
@@ -482,7 +482,9 @@ def build_docker_worker_payload(config, task, task_def):
             suffix = f"{cache_version}-{_run_task_suffix()}"
 
             if out_of_tree_image:
-                name_hash = hashlib.sha256(out_of_tree_image).hexdigest()
+                name_hash = hashlib.sha256(
+                    out_of_tree_image.encode("utf-8")
+                ).hexdigest()
                 suffix += name_hash[0:12]
 
         else:


### PR DESCRIPTION
The `hashlib.sha256` function requires bytes, so this has been broken since
we switched to Python 3.