### PR TITLE
ci: set PR policy back to 'collaborators'

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -7,7 +7,7 @@
 version: 1
 reporting: checks-v1
 policy:
-    pullRequests: public
+    pullRequests: collaborators
 tasks:
     # NOTE: support for actions in ci-admin requires that the `tasks` property be an array *before* JSON-e rendering
     # takes place.


### PR DESCRIPTION
We're going to be adding a codecov token as a secret, so setting the PR
policy back to collaborators to avoid leaking it.