### PR TITLE
fix: permission error when cleaning up fetches directory in run-task

### DIFF
--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -882,7 +882,7 @@ def _call_windows_retry(func, args=(), retry_max=5, retry_delay=0.5):
             func(*args)
         except OSError as e:
             # Error codes are defined in:
-            # http://docs.python.org/2/library/errno.html#module-errno
+            # https://docs.python.org/3/library/errno.html#module-errno
             if e.errno not in (errno.EACCES, errno.ENOTEMPTY, errno.ENOENT):
                 raise
 

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -883,7 +883,7 @@ def _call_windows_retry(func, args=(), retry_max=5, retry_delay=0.5):
         except OSError as e:
             # Error codes are defined in:
             # http://docs.python.org/2/library/errno.html#module-errno
-            if e.errno not in (errno.EACCES, errno.ENOTEMPTY):
+            if e.errno not in (errno.EACCES, errno.ENOTEMPTY, errno.ENOENT):
                 raise
 
             if retry_count == retry_max:
@@ -921,14 +921,6 @@ def remove(path):
 
     import shutil
 
-    def _call_with_windows_retry(*args, **kwargs):
-        try:
-            _call_windows_retry(*args, **kwargs)
-        except OSError as e:
-            # The file or directory to be removed doesn't exist anymore
-            if e.errno != errno.ENOENT:
-                raise
-
     def _update_permissions(path):
         """Sets specified pemissions depending on filetype"""
         if os.path.islink(path):
@@ -946,7 +938,7 @@ def remove(path):
             # Not supported type
             return
 
-        _call_with_windows_retry(os.chmod, (path, mode))
+        _call_windows_retry(os.chmod, (path, mode))
 
     if not os.path.lexists(path):
         return
@@ -967,7 +959,7 @@ def remove(path):
     if os.path.isfile(path) or os.path.islink(path):
         # Verify the file or link is read/write for the current user
         _update_permissions(path)
-        _call_with_windows_retry(os.remove, (path,))
+        _call_windows_retry(os.remove, (path,))
 
     elif os.path.isdir(path):
         # Verify the directory is read/write/execute for the current user
@@ -977,7 +969,7 @@ def remove(path):
         for root, dirs, files in os.walk(path):
             for entry in dirs + files:
                 _update_permissions(os.path.join(root, entry))
-        _call_with_windows_retry(shutil.rmtree, (path,))
+        _call_windows_retry(shutil.rmtree, (path,))
 
 
 def main(args):

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -107,6 +107,108 @@ IS_POSIX = os.name == 'posix'
 IS_WINDOWS = os.name == 'nt'
 
 
+def _call_windows_retry(func, args=(), retry_max=5, retry_delay=0.5):
+    """
+    It's possible to see spurious errors on Windows due to various things
+    keeping a handle to the directory open (explorer, virus scanners, etc)
+    So we try a few times if it fails with a known error.
+    retry_delay is multiplied by the number of failed attempts to increase
+    the likelihood of success in subsequent attempts.
+    """
+    retry_count = 0
+    while True:
+        try:
+            func(*args)
+        except OSError as e:
+            # Error codes are defined in:
+            # https://docs.python.org/3/library/errno.html#module-errno
+            if e.errno not in (errno.EACCES, errno.ENOTEMPTY, errno.ENOENT):
+                raise
+
+            if retry_count == retry_max:
+                raise
+
+            retry_count += 1
+
+            print(
+                '%s() failed for "%s". Reason: %s (%s). Retrying...'
+                % (func.__name__, args, e.strerror, e.errno)
+            )
+            time.sleep(retry_count * retry_delay)
+        else:
+            # If no exception has been thrown it should be done
+            break
+
+
+def remove(path):
+    """Removes the specified file, link, or directory tree.
+
+    This is a replacement for shutil.rmtree that works better under
+    windows. It does the following things:
+
+     - check path access for the current user before trying to remove
+     - retry operations on some known errors due to various things keeping
+       a handle on file paths - like explorer, virus scanners, etc. The
+       known errors are errno.EACCES and errno.ENOTEMPTY, and it will
+       retry up to 5 five times with a delay of (failed_attempts * 0.5) seconds
+       between each attempt.
+
+    Note that no error will be raised if the given path does not exists.
+
+    :param path: path to be removed
+    """
+
+    def _update_permissions(path):
+        """Sets specified pemissions depending on filetype"""
+        if os.path.islink(path):
+            # Path is a symlink which we don't have to modify
+            # because it should already have all the needed permissions
+            return
+
+        stats = os.stat(path)
+
+        if os.path.isfile(path):
+            mode = stats.st_mode | stat.S_IWUSR
+        elif os.path.isdir(path):
+            mode = stats.st_mode | stat.S_IWUSR | stat.S_IXUSR
+        else:
+            # Not supported type
+            return
+
+        _call_windows_retry(os.chmod, (path, mode))
+
+    if not os.path.lexists(path):
+        return
+
+    """
+    On Windows, adds '\\\\?\\' to paths which match ^[A-Za-z]:\\.* to access
+    files or directories that exceed MAX_PATH(260) limitation or that ends
+    with a period.
+    """
+    if (
+        sys.platform in ("win32", "cygwin")
+        and len(path) >= 3
+        and path[1] == ":"
+        and path[2] == "\\"
+    ):
+        path = u"\\\\?\\%s" % path
+
+    if os.path.isfile(path) or os.path.islink(path):
+        # Verify the file or link is read/write for the current user
+        _update_permissions(path)
+        _call_windows_retry(os.remove, (path,))
+
+    elif os.path.isdir(path):
+        # Verify the directory is read/write/execute for the current user
+        _update_permissions(path)
+
+        # We're ensuring that every nested item has writable permission.
+        for root, dirs, files in os.walk(path):
+            for entry in dirs + files:
+                _update_permissions(os.path.join(root, entry))
+        _call_windows_retry(shutil.rmtree, (path,))
+
+
 def print_line(prefix, m):
     now = datetime.datetime.utcnow().isoformat().encode('utf-8')
     # slice microseconds to 3 decimals.
@@ -416,6 +518,40 @@ def configure_volume_posix(volume, user, group, running_as_root):
         set_dir_permissions(volume, user.pw_uid, group.gr_gid)
 
 
+def _clean_git_checkout(destination_path):
+    # Delete untracked files (i.e. build products)
+    print_line(b'vcs', b'cleaning git checkout...\n')
+    args = [
+        'git',
+        'clean',
+        # Two -f`s causes subdirectories with `.git`
+        # directories to be cleaned as well.
+        '-nxdff',
+    ]
+    print_line(b'vcs', b'executing %r\n' % args)
+    p = subprocess.Popen(args,
+                         # Disable buffering because we want to receive output
+                         # as it is generated so timestamps in logs are
+                         # accurate.
+                         bufsize=0,
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.STDOUT,
+                         stdin=sys.stdin.fileno(),
+                         cwd=destination_path,
+                         env=os.environ)
+    stdout = io.TextIOWrapper(p.stdout, encoding='latin1')
+    ret = p.wait()
+    if ret:
+        sys.exit(ret)
+    data = stdout.read()
+    prefix = 'Would remove '
+    filenames = [line[len(prefix):] for line in data.splitlines()]
+    print_line(b'vcs', b'removing %r\n' % filenames)
+    for filename in filenames:
+        remove(filename)
+    print_line(b'vcs', b'successfully cleaned git checkout!\n')
+
+
 def git_checkout(
     destination_path: str,
     head_repo: str,
@@ -474,15 +610,7 @@ def git_checkout(
 
     run_required_command(b'vcs', args, cwd=destination_path)
 
-    args = [
-        'git',
-        'clean',
-        # Two -f`s causes subdirectories with `.git` directories to be removed
-        # as well.
-        '-xdff',
-    ]
-
-    run_required_command(b'vcs', args, cwd=destination_path)
+    _clean_git_checkout(destination_path)
 
     args = [
         'git',
@@ -866,108 +994,6 @@ def maybe_run_resource_monitoring():
     monitor_process = Thread(target=capture_output)
     monitor_process.start()
     return process
-
-
-def _call_windows_retry(func, args=(), retry_max=5, retry_delay=0.5):
-    """
-    It's possible to see spurious errors on Windows due to various things
-    keeping a handle to the directory open (explorer, virus scanners, etc)
-    So we try a few times if it fails with a known error.
-    retry_delay is multiplied by the number of failed attempts to increase
-    the likelihood of success in subsequent attempts.
-    """
-    retry_count = 0
-    while True:
-        try:
-            func(*args)
-        except OSError as e:
-            # Error codes are defined in:
-            # https://docs.python.org/3/library/errno.html#module-errno
-            if e.errno not in (errno.EACCES, errno.ENOTEMPTY, errno.ENOENT):
-                raise
-
-            if retry_count == retry_max:
-                raise
-
-            retry_count += 1
-
-            print(
-                '%s() failed for "%s". Reason: %s (%s). Retrying...'
-                % (func.__name__, args, e.strerror, e.errno)
-            )
-            time.sleep(retry_count * retry_delay)
-        else:
-            # If no exception has been thrown it should be done
-            break
-
-
-def remove(path):
-    """Removes the specified file, link, or directory tree.
-
-    This is a replacement for shutil.rmtree that works better under
-    windows. It does the following things:
-
-     - check path access for the current user before trying to remove
-     - retry operations on some known errors due to various things keeping
-       a handle on file paths - like explorer, virus scanners, etc. The
-       known errors are errno.EACCES and errno.ENOTEMPTY, and it will
-       retry up to 5 five times with a delay of (failed_attempts * 0.5) seconds
-       between each attempt.
-
-    Note that no error will be raised if the given path does not exists.
-
-    :param path: path to be removed
-    """
-
-    def _update_permissions(path):
-        """Sets specified pemissions depending on filetype"""
-        if os.path.islink(path):
-            # Path is a symlink which we don't have to modify
-            # because it should already have all the needed permissions
-            return
-
-        stats = os.stat(path)
-
-        if os.path.isfile(path):
-            mode = stats.st_mode | stat.S_IWUSR
-        elif os.path.isdir(path):
-            mode = stats.st_mode | stat.S_IWUSR | stat.S_IXUSR
-        else:
-            # Not supported type
-            return
-
-        _call_windows_retry(os.chmod, (path, mode))
-
-    if not os.path.lexists(path):
-        return
-
-    """
-    On Windows, adds '\\\\?\\' to paths which match ^[A-Za-z]:\\.* to access
-    files or directories that exceed MAX_PATH(260) limitation or that ends
-    with a period.
-    """
-    if (
-        sys.platform in ("win32", "cygwin")
-        and len(path) >= 3
-        and path[1] == ":"
-        and path[2] == "\\"
-    ):
-        path = u"\\\\?\\%s" % path
-
-    if os.path.isfile(path) or os.path.islink(path):
-        # Verify the file or link is read/write for the current user
-        _update_permissions(path)
-        _call_windows_retry(os.remove, (path,))
-
-    elif os.path.isdir(path):
-        # Verify the directory is read/write/execute for the current user
-        _update_permissions(path)
-
-        # We're ensuring that every nested item has writable permission.
-        for root, dirs, files in os.walk(path):
-            for entry in dirs + files:
-                _update_permissions(os.path.join(root, entry))
-        _call_windows_retry(shutil.rmtree, (path,))
 
 
 def main(args):

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -919,8 +919,6 @@ def remove(path):
     :param path: path to be removed
     """
 
-    import shutil
-
     def _update_permissions(path):
         """Sets specified pemissions depending on filetype"""
         if os.path.islink(path):

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -1110,6 +1110,8 @@ def main(args):
         fetches_dir = os.environ.get('MOZ_FETCHES_DIR')
         if fetches_dir and os.path.isdir(fetches_dir):
             print_line(b'fetches', b'removing %s\n' % fetches_dir.encode('utf-8'))
+            if not os.access(fetches_dir, os.W_OK):
+                os.chmod(fetches_dir, stat.S_IWUSR)
             shutil.rmtree(fetches_dir)
             print_line(b'fetches', b'finished\n')
 

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -1212,10 +1212,7 @@ def main(args):
         fetches_dir = os.environ.get('MOZ_FETCHES_DIR')
         if fetches_dir and os.path.isdir(fetches_dir):
             print_line(b'fetches', b'removing %s\n' % fetches_dir.encode('utf-8'))
-            if IS_WINDOWS:
-                remove(fetches_dir)
-            else:
-                shutil.rmtree(fetches_dir)
+            remove(fetches_dir)
             print_line(b'fetches', b'finished\n')
 
 

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -868,24 +868,116 @@ def maybe_run_resource_monitoring():
     return process
 
 
-def onerror(func, path, exc_info):
+def _call_windows_retry(func, args=(), retry_max=5, retry_delay=0.5):
     """
-    Error handler for ``shutil.rmtree``.
-
-    If the error is due to an access error (read only file)
-    it attempts to add write permission and then retries.
-
-    If the error is for another reason it re-raises the error.
-    
-    Usage : ``shutil.rmtree(path, onerror=onerror)``
+    It's possible to see spurious errors on Windows due to various things
+    keeping a handle to the directory open (explorer, virus scanners, etc)
+    So we try a few times if it fails with a known error.
+    retry_delay is multiplied by the number of failed attempts to increase
+    the likelihood of success in subsequent attempts.
     """
-    import stat
-    # Is the error an access error?
-    if not os.access(path, os.W_OK):
-        os.chmod(path, stat.S_IWUSR)
-        func(path)
-    else:
-        raise
+    retry_count = 0
+    while True:
+        try:
+            func(*args)
+        except OSError as e:
+            # Error codes are defined in:
+            # http://docs.python.org/2/library/errno.html#module-errno
+            if e.errno not in (errno.EACCES, errno.ENOTEMPTY):
+                raise
+
+            if retry_count == retry_max:
+                raise
+
+            retry_count += 1
+
+            print(
+                '%s() failed for "%s". Reason: %s (%s). Retrying...'
+                % (func.__name__, args, e.strerror, e.errno)
+            )
+            time.sleep(retry_count * retry_delay)
+        else:
+            # If no exception has been thrown it should be done
+            break
+
+
+def remove(path):
+    """Removes the specified file, link, or directory tree.
+
+    This is a replacement for shutil.rmtree that works better under
+    windows. It does the following things:
+
+     - check path access for the current user before trying to remove
+     - retry operations on some known errors due to various things keeping
+       a handle on file paths - like explorer, virus scanners, etc. The
+       known errors are errno.EACCES and errno.ENOTEMPTY, and it will
+       retry up to 5 five times with a delay of (failed_attempts * 0.5) seconds
+       between each attempt.
+
+    Note that no error will be raised if the given path does not exists.
+
+    :param path: path to be removed
+    """
+
+    import shutil
+
+    def _call_with_windows_retry(*args, **kwargs):
+        try:
+            _call_windows_retry(*args, **kwargs)
+        except OSError as e:
+            # The file or directory to be removed doesn't exist anymore
+            if e.errno != errno.ENOENT:
+                raise
+
+    def _update_permissions(path):
+        """Sets specified pemissions depending on filetype"""
+        if os.path.islink(path):
+            # Path is a symlink which we don't have to modify
+            # because it should already have all the needed permissions
+            return
+
+        stats = os.stat(path)
+
+        if os.path.isfile(path):
+            mode = stats.st_mode | stat.S_IWUSR
+        elif os.path.isdir(path):
+            mode = stats.st_mode | stat.S_IWUSR | stat.S_IXUSR
+        else:
+            # Not supported type
+            return
+
+        _call_with_windows_retry(os.chmod, (path, mode))
+
+    if not os.path.lexists(path):
+        return
+
+    """
+    On Windows, adds '\\\\?\\' to paths which match ^[A-Za-z]:\\.* to access
+    files or directories that exceed MAX_PATH(260) limitation or that ends
+    with a period.
+    """
+    if (
+        sys.platform in ("win32", "cygwin")
+        and len(path) >= 3
+        and path[1] == ":"
+        and path[2] == "\\"
+    ):
+        path = u"\\\\?\\%s" % path
+
+    if os.path.isfile(path) or os.path.islink(path):
+        # Verify the file or link is read/write for the current user
+        _update_permissions(path)
+        _call_with_windows_retry(os.remove, (path,))
+
+    elif os.path.isdir(path):
+        # Verify the directory is read/write/execute for the current user
+        _update_permissions(path)
+
+        # We're ensuring that every nested item has writable permission.
+        for root, dirs, files in os.walk(path):
+            for entry in dirs + files:
+                _update_permissions(os.path.join(root, entry))
+        _call_with_windows_retry(shutil.rmtree, (path,))
 
 
 def main(args):
@@ -1130,7 +1222,10 @@ def main(args):
         fetches_dir = os.environ.get('MOZ_FETCHES_DIR')
         if fetches_dir and os.path.isdir(fetches_dir):
             print_line(b'fetches', b'removing %s\n' % fetches_dir.encode('utf-8'))
-            shutil.rmtree(fetches_dir, onerror=onerror)
+            if IS_WINDOWS:
+                remove(fetches_dir)
+            else:
+                shutil.rmtree(fetches_dir)
             print_line(b'fetches', b'finished\n')
 
 

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -868,6 +868,26 @@ def maybe_run_resource_monitoring():
     return process
 
 
+def onerror(func, path, exc_info):
+    """
+    Error handler for ``shutil.rmtree``.
+
+    If the error is due to an access error (read only file)
+    it attempts to add write permission and then retries.
+
+    If the error is for another reason it re-raises the error.
+    
+    Usage : ``shutil.rmtree(path, onerror=onerror)``
+    """
+    import stat
+    # Is the error an access error?
+    if not os.access(path, os.W_OK):
+        os.chmod(path, stat.S_IWUSR)
+        func(path)
+    else:
+        raise
+
+
 def main(args):
     print_line(b'setup', b'run-task started in %s\n' % os.getcwd().encode('utf-8'))
     running_as_root = IS_POSIX and os.getuid() == 0
@@ -1110,9 +1130,7 @@ def main(args):
         fetches_dir = os.environ.get('MOZ_FETCHES_DIR')
         if fetches_dir and os.path.isdir(fetches_dir):
             print_line(b'fetches', b'removing %s\n' % fetches_dir.encode('utf-8'))
-            if not os.access(fetches_dir, os.W_OK):
-                os.chmod(fetches_dir, stat.S_IWUSR)
-            shutil.rmtree(fetches_dir)
+            shutil.rmtree(fetches_dir, onerror=onerror)
             print_line(b'fetches', b'finished\n')
 
 

--- a/src/taskgraph/test/test_scripts_run_task.py
+++ b/src/taskgraph/test/test_scripts_run_task.py
@@ -178,6 +178,7 @@ def test_remove_readonly_tree(monkeypatch, run_task_mod):
     assert os.path.isdir(_tempdir.name) == True
     run_task_mod.remove(_tempdir.name)
     assert os.path.isdir(_tempdir.name) == False
+    _tempdir.cleanup()
 
 
 def test_remove_readonly_file(monkeypatch, run_task_mod):
@@ -190,6 +191,7 @@ def test_remove_readonly_file(monkeypatch, run_task_mod):
     assert os.path.isfile(_tempfile.name) == True
     run_task_mod.remove(_tempfile.name)
     assert os.path.isfile(_tempfile.name) == False
+    _tempdir.cleanup()
 
 
 def _mark_readonly(path):

--- a/src/taskgraph/test/test_scripts_run_task.py
+++ b/src/taskgraph/test/test_scripts_run_task.py
@@ -153,9 +153,9 @@ def test_collect_vcs_options(monkeypatch, run_task_mod, env, extra_expected):
 
 def test_remove_directory(monkeypatch, run_task_mod):
     _tempdir = tempfile.TemporaryDirectory()
-    assert os.path.isdir(_tempdir.name) == True
+    assert os.path.isdir(_tempdir.name) is True
     run_task_mod.remove(_tempdir.name)
-    assert os.path.isdir(_tempdir.name) == False
+    assert os.path.isdir(_tempdir.name) is False
     _tempdir.cleanup()
 
 
@@ -164,20 +164,20 @@ def test_remove_closed_file(monkeypatch, run_task_mod):
     _tempfile = tempfile.NamedTemporaryFile(dir=_tempdir.name, delete=False)
     _tempfile.write(b"foo")
     _tempfile.close()
-    assert os.path.isdir(_tempdir.name) == True
-    assert os.path.isfile(_tempfile.name) == True
+    assert os.path.isdir(_tempdir.name) is True
+    assert os.path.isfile(_tempfile.name) is True
     run_task_mod.remove(_tempdir.name)
-    assert os.path.isdir(_tempdir.name) == False
-    assert os.path.isfile(_tempfile.name) == False
+    assert os.path.isdir(_tempdir.name) is False
+    assert os.path.isfile(_tempfile.name) is False
     _tempdir.cleanup()
 
 
 def test_remove_readonly_tree(monkeypatch, run_task_mod):
     _tempdir = tempfile.TemporaryDirectory()
     _mark_readonly(_tempdir.name)
-    assert os.path.isdir(_tempdir.name) == True
+    assert os.path.isdir(_tempdir.name) is True
     run_task_mod.remove(_tempdir.name)
-    assert os.path.isdir(_tempdir.name) == False
+    assert os.path.isdir(_tempdir.name) is False
     _tempdir.cleanup()
 
 
@@ -188,9 +188,9 @@ def test_remove_readonly_file(monkeypatch, run_task_mod):
     _tempfile.close()
     _mark_readonly(_tempfile.name)
     # should change write permission and then remove file
-    assert os.path.isfile(_tempfile.name) == True
+    assert os.path.isfile(_tempfile.name) is True
     run_task_mod.remove(_tempfile.name)
-    assert os.path.isfile(_tempfile.name) == False
+    assert os.path.isfile(_tempfile.name) is False
     _tempdir.cleanup()
 
 

--- a/src/taskgraph/test/test_scripts_run_task.py
+++ b/src/taskgraph/test/test_scripts_run_task.py
@@ -156,7 +156,6 @@ def test_remove_directory(monkeypatch, run_task_mod):
     assert os.path.isdir(_tempdir.name) is True
     run_task_mod.remove(_tempdir.name)
     assert os.path.isdir(_tempdir.name) is False
-    _tempdir.cleanup()
 
 
 def test_remove_closed_file(monkeypatch, run_task_mod):
@@ -169,7 +168,6 @@ def test_remove_closed_file(monkeypatch, run_task_mod):
     run_task_mod.remove(_tempdir.name)
     assert os.path.isdir(_tempdir.name) is False
     assert os.path.isfile(_tempfile.name) is False
-    _tempdir.cleanup()
 
 
 def test_remove_readonly_tree(monkeypatch, run_task_mod):
@@ -178,7 +176,6 @@ def test_remove_readonly_tree(monkeypatch, run_task_mod):
     assert os.path.isdir(_tempdir.name) is True
     run_task_mod.remove(_tempdir.name)
     assert os.path.isdir(_tempdir.name) is False
-    _tempdir.cleanup()
 
 
 def test_remove_readonly_file(monkeypatch, run_task_mod):

--- a/src/taskgraph/test/test_scripts_run_task.py
+++ b/src/taskgraph/test/test_scripts_run_task.py
@@ -250,10 +250,17 @@ def test_clean_git_checkout(monkeypatch, run_task_mod):
         _stdin,
     )
 
+    assert os.path.isdir(root_dir.name) is True
+    assert os.path.isdir(tracked_dir.name) is True
+    assert os.path.isdir(untracked_dir.name) is True
+    assert os.path.isfile(untracked_file.name) is True
+    assert os.path.isfile(tracked_file.name) is True
+
     run_task_mod._clean_git_checkout(root_dir.name)
 
     assert os.path.isdir(root_dir.name) is True
     assert os.path.isdir(tracked_dir.name) is True
+    assert os.path.isfile(tracked_file.name) is True
+
     assert os.path.isdir(untracked_dir.name) is False
     assert os.path.isfile(untracked_file.name) is False
-    assert os.path.isfile(tracked_file.name) is True


### PR DESCRIPTION
When we run VPN tasks on [win2012 workers](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/taskcluster/ci/config.yml#L40) they run successfully but they fail to clean up fetched content.

Here's one of these [tasks](https://firefox-ci-tc.services.mozilla.com/tasks/KcekQk81SPuSzG9obKpkMw/runs/0/logs/public/logs/live.log).

Here's the error:
```
Traceback (most recent call last):
  File "run-task", line 1118, in <module>
    sys.exit(main(sys.argv[1:]))
  File "run-task", line 1113, in main
    shutil.rmtree(fetches_dir)
  File "C:\mozilla-build\python3\lib\shutil.py", line 494, in rmtree
    return _rmtree_unsafe(path, onerror)
  File "C:\mozilla-build\python3\lib\shutil.py", line 384, in _rmtree_unsafe
    _rmtree_unsafe(fullname, onerror)
  File "C:\mozilla-build\python3\lib\shutil.py", line 384, in _rmtree_unsafe
    _rmtree_unsafe(fullname, onerror)
  File "C:\mozilla-build\python3\lib\shutil.py", line 384, in _rmtree_unsafe
    _rmtree_unsafe(fullname, onerror)
  [Previous line repeated 4 more times]
  File "C:\mozilla-build\python3\lib\shutil.py", line 389, in _rmtree_unsafe
    onerror(os.unlink, fullname, sys.exc_info())
  File "C:\mozilla-build\python3\lib\shutil.py", line 387, in _rmtree_unsafe
    os.unlink(fullname)
PermissionError: [WinError 5] Access is denied: 'Z:\\task_165098658390600\\fetches\\VisualStudio\\VC\\Tools\\MSVC\\14.30.30705\\bin\\Hostx64\\x64\\Microsoft.Diagnostics.Tracing.EventSource.dll'
```

I think this code is failing because `run-task` doesn't have the access to clean up the `fetches` directory.
This is a patch where we make sure we have the access we need to the files before we try to delete them.

