### PR TITLE
ci: ensure 'run-task' scripts are included in coverage report

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ depends =
     report: py{37,38,39,310}
 commands =
     python --version
-    pytest --cov=taskgraph --cov-append --cov-report=
+    pytest --cov=taskgraph --cov=src/taskgraph/run-task --cov-append --cov-report=
 
 [testenv:report]
 deps = -r{toxinidir}/requirements/test.txt


### PR DESCRIPTION
The 'run-task' scripts weren't previously being picked up by the
coverage report as it isn't a proper Python module. But passing in the
path to this directory explicitly to 'pytest-cov' seems to do the trick.