### PR TITLE
chore: version bump to 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [1.5.0] - 2022-05-02
+
+### Added
+- Ability to pass headers alongside requests in the `fetch-content` script
+
+### Fixed
+- An encoding error when using out of tree images
+- Windows permissions errors in `run-task` script cleanup
+
 ## [1.4.0] - 2022-04-22
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("requirements/base.in", "r") as fp:
 
 setup(
     name="taskcluster-taskgraph",
-    version="1.4.0",
+    version="1.5.0",
     description="Build taskcluster taskgraphs",
     url="https://github.com/taskcluster/taskgraph",
     packages=find_packages("src"),


### PR DESCRIPTION
Version bumping to pick up Gabriel's Windows cleanup fixes so we can try them out in `mozilla-vpn-client`.