### PR TITLE
fix(run-task): don't explicitly pass '--require-hashes'

### DIFF
--- a/docs/howto/bootstrap-taskgraph.rst
+++ b/docs/howto/bootstrap-taskgraph.rst
@@ -142,9 +142,24 @@ accomplished using `pip's version control support`_:
 
    cd taskcluster
    echo "taskcluster-taskgraph@git+https://github.com/taskcluster/taskgraph@refs/pull/123/head" > requirements.in
-   pip-compile --generate-hashes --output-file requirements.txt requirements.in
+   pip-compile --output-file requirements.txt requirements.in
+
+Next edit your ``.taskcluster.yml`` to disable hashing since pip does not
+support `hashes with url requirements`_:
+
+.. code-block:: yaml
+
+   payload:
+      env:
+          - PIP_DISABLE_REQUIRE_HASHES: 1
+
+.. note::
+
+   Be sure to omit the ``--generate-hashes`` argument to ``pip-compile``
+   otherwise ``pip`` will implicitly turn hashing back on.
 
 This way you can push an experimental change to a PR and then install it in
 your repo's decision task.
 
 .. _pip's version control support: https://pip.pypa.io/en/stable/topics/vcs-support/
+.. _hashes with url requirements: https://github.com/pypa/pip/issues/6469

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -934,7 +934,10 @@ def install_pip_requirements(repositories):
     if not requirements:
         return
 
-    cmd = [sys.executable, '-mpip', 'install', '--require-hashes']
+    cmd = [sys.executable, '-mpip', 'install']
+    if os.environ.get("PIP_DISABLE_REQUIRE_HASHES") != "1":
+        cmd.append("--require-hashes")
+
     for path in requirements:
         cmd.extend(['-r', path])
 


### PR DESCRIPTION
Currently when installing pip dependencies via the
`<REPO>_PIP_REQUIREMENTS` environment variable, `run-task` explicitly
passes in the `--require-hashes` option. This makes it difficult to test
against pre-release versions of Taskgraph since VCS urls do not support
hashes (https://github.com/pypa/pip/issues/6469).

Luckily when `pip` encounters a requirements with `--hash`, the
`--require-hashes` flag is implied. This means that if `run-task`
doesn't explicitly pass it in, we'll be able to test against pre-release
versions of taskgraph by adding the git URL and then simply *not* using
the `--generate-hashes` flag in `pip-compile`. But in production we'd
still get hash verification.

This does loosen restrictions a bit, since previously a repo would have
no choice other than to use hashes. But now they could opt not to.
Personally I feel like this is a trade-off that should be left to repo
owners anyway.