### PR TITLE
test: add a test for job/toolchain.py

### DIFF
--- a/src/taskgraph/test/conftest.py
+++ b/src/taskgraph/test/conftest.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import pytest
 from responses import RequestsMock
@@ -12,7 +12,7 @@ from taskgraph.optimize import OptimizationStrategy
 from taskgraph.transforms.base import TransformConfig
 from taskgraph.util.templates import merge
 
-here = os.path.abspath(os.path.dirname(__file__))
+here = Path(__file__).parent
 
 
 @pytest.fixture
@@ -119,6 +119,7 @@ def parameters():
             "head_rev": "abcdef",
             "head_ref": "abcdef",
             "level": 1,
+            "moz_build_date": 0,
             "project": "",
             "repository_type": "hg",
             "target_tasks_method": "test_method",
@@ -161,18 +162,20 @@ def maketgg(monkeypatch, parameters):
 
 @pytest.fixture
 def transform_config(parameters):
-    graph_config = fake_load_graph_config(os.path.join("taskcluster", "ci"))
+    graph_config = fake_load_graph_config(str(here / "data" / "taskcluster" / "ci"))
     return TransformConfig(
-        "test", here, {}, parameters, {}, graph_config, write_artifacts=False
+        "test", str(here), {}, parameters, {}, graph_config, write_artifacts=False
     )
 
 
 @pytest.fixture
 def run_transform(transform_config):
-    def inner(func, tasks):
+    def inner(func, tasks, config=None):
         if not isinstance(tasks, list):
             tasks = [tasks]
 
-        return list(func(transform_config, tasks))
+        if not config:
+            config = transform_config
+        return list(func(config, tasks))
 
     return inner

--- a/src/taskgraph/test/data/taskcluster/scripts/toolchain/run.sh
+++ b/src/taskgraph/test/data/taskcluster/scripts/toolchain/run.sh
@@ -1,0 +1,1 @@
+echo "Hello World"

--- a/src/taskgraph/test/test_transforms_job_toolchain.py
+++ b/src/taskgraph/test/test_transforms_job_toolchain.py
@@ -1,0 +1,109 @@
+"""
+Tests for the 'toolchain' transforms.
+"""
+from pprint import pprint
+from unittest.mock import patch
+
+import pytest
+
+from taskgraph.transforms.job import make_task_description
+from taskgraph.util import hash
+from taskgraph.util.templates import merge
+
+TASK_DEFAULTS = {
+    "description": "fake description",
+    "label": "fake-task-label",
+    "worker-type": "t-linux",
+    "worker": {
+        "implementation": "docker-worker",
+        "os": "linux",
+        "env": {},
+    },
+    "run": {
+        "using": "toolchain-script",
+        "script": "run.sh",
+        "toolchain-artifact": "public/build/artifact.zip",
+    },
+}
+
+
+@pytest.fixture
+def run_job_using(monkeypatch, run_transform):
+    def fake_find_files(_):
+        return ["taskcluster/scripts/toolchain/run.sh"]
+
+    monkeypatch.setattr(hash, "_find_files", fake_find_files)
+
+    def inner(task):
+        task = merge(TASK_DEFAULTS, task)
+        with patch(
+            "taskgraph.transforms.job.toolchain.configure_taskdesc_for_run"
+        ) as m:
+            run_transform(make_task_description, task)
+            return m.call_args[0]
+
+    return inner
+
+
+def assert_basic(task):
+    assert task == {
+        "attributes": {
+            "toolchain-alias": "foo",
+            "toolchain-artifact": "public/build/artifact.zip",
+        },
+        "cache": {
+            "digest-data": [
+                "a81c34908c02a5b6a14607465397c0f82d5c406b3e2e73f2c29644016d7bb031",
+                "toolchain-build",
+            ],
+            "name": "fake-task-label",
+            "type": "toolchains.v3",
+        },
+        "dependencies": {},
+        "description": "fake description",
+        "extra": {},
+        "label": "fake-task-label",
+        "routes": [],
+        "scopes": [],
+        "soft-dependencies": [],
+        "worker": {
+            "artifacts": [
+                {
+                    "name": "public/build",
+                    "path": "/builds/worker/artifacts/",
+                    "type": "directory",
+                }
+            ],
+            "chain-of-trust": True,
+            "docker-image": {"in-tree": "toolchain-build"},
+            "env": {
+                "MOZ_BUILD_DATE": 0,
+                "MOZ_SCM_LEVEL": 1,
+                "UPLOAD_DIR": "/builds/worker/artifacts/",
+            },
+            "implementation": "docker-worker",
+            "os": "linux",
+        },
+        "worker-type": "t-linux",
+    }
+
+
+@pytest.mark.parametrize(
+    "task",
+    (
+        pytest.param(
+            {
+                "run": {
+                    "toolchain-alias": "foo",
+                }
+            },
+            id="basic",
+        ),
+    ),
+)
+def test_toolchain(request, run_job_using, task):
+    task = run_job_using(task)[2]
+    pprint(task)
+    param_id = request.node.callspec.id
+    assert_func = globals()[f"assert_{param_id}"]
+    assert_func(task)


### PR DESCRIPTION
This is in preparation for supporting `generic-worker` in toolchains.