### PR TITLE
Fix the git clean checkout regression

### DIFF
--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -555,7 +555,7 @@ def _clean_git_checkout(destination_path):
         sys.exit(ret)
     data = stdout.read()
     prefix = 'Would remove '
-    filenames = [line[len(prefix):] for line in data.splitlines()]
+    filenames = [os.path.abspath(line[len(prefix):]) for line in data.splitlines()]
     print_line(b'vcs', b'DEBUG\n')
     print_line(b'vcs', b'removing %r\n' % filenames)
     print_line(b'vcs', b'DEBUG\n')

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -208,7 +208,9 @@ def remove(path):
                 _update_permissions(os.path.join(root, entry))
         _call_windows_retry(shutil.rmtree, (path,))
 
+    print_line("assert os.path.isdir(path) is False")
     assert os.path.isdir(path) is False
+    print_line("os.path.isdir(path) is False!")
 
 
 def print_line(prefix, m):

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -157,7 +157,7 @@ def remove(path):
 
     :param path: path to be removed
     """
-    print(f"remove({path})")
+    print(f"remove({path})"))
     def _update_permissions(path):
         """Sets specified pemissions depending on filetype"""
         if os.path.islink(path):
@@ -179,6 +179,7 @@ def remove(path):
         print(f"updated permissions for {path}")
 
     if not os.path.lexists(path):
+        print(f"os.path.lexists(path)")
         return
 
     """

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -204,7 +204,7 @@ def remove(path):
 
     elif os.path.isdir(path):
         # Verify the directory is read/write/execute for the current user
-        _update_permissions
+        _update_permissions(path)
         # We're ensuring that every nested item has writable permission.
         for root, dirs, files in os.walk(path):
             for entry in dirs + files:
@@ -552,14 +552,14 @@ def _clean_git_checkout(destination_path):
     data = stdout.read()
     prefix = 'Would remove '
     filenames = [line[len(prefix):] for line in data.splitlines()]
-    print_line(b'vcs', b'DEBUG %r\n' % filenames)
+    print_line(b'vcs', b'DEBUG\n')
     print_line(b'vcs', b'removing %r\n' % filenames)
-    print_line(b'vcs', b'DEBUG %r\n' % filenames)
+    print_line(b'vcs', b'DEBUG\n')
     for filename in filenames:
         remove(filename)
-    print_line(b'vcs', b'DEBUG %r\n' % filenames)
+    print_line(b'vcs', b'DEBUG\n')
     print_line(b'vcs', b'successfully cleaned git checkout!\n')
-    print_line(b'vcs', b'DEBUG %r\n' % filenames)
+    print_line(b'vcs', b'DEBUG\n')
 
 
 def git_checkout(

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -176,7 +176,6 @@ def remove(path):
             return
 
         _call_windows_retry(os.chmod, (path, mode))
-        print(f"updated permissions for {path}")
 
     if not os.path.lexists(path):
         print(f"not os.path.lexists(path)")

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -157,7 +157,7 @@ def remove(path):
 
     :param path: path to be removed
     """
-
+    print_line("remove", f"path = {path}")
     def _update_permissions(path):
         """Sets specified pemissions depending on filetype"""
         if os.path.islink(path):
@@ -178,6 +178,7 @@ def remove(path):
         _call_windows_retry(os.chmod, (path, mode))
 
     if not os.path.lexists(path):
+        print_line("remove", "os.path.lexists(path)")
         return
 
     """
@@ -194,11 +195,13 @@ def remove(path):
         path = u"\\\\?\\%s" % path
 
     if os.path.isfile(path) or os.path.islink(path):
+        print_line("remove", "os.path.isfile(path) or os.path.islink(path)")
         # Verify the file or link is read/write for the current user
         _update_permissions(path)
         _call_windows_retry(os.remove, (path,))
 
     elif os.path.isdir(path):
+        print_line("remove", "os.path.isfile(path) or os.path.islink(path)")
         # Verify the directory is read/write/execute for the current user
         _update_permissions(path)
 

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -556,7 +556,9 @@ def _clean_git_checkout(destination_path):
     print_line(b'vcs', b'removing %r\n' % filenames)
     print_line(b'vcs', b'DEBUG\n')
     for filename in filenames:
+        print(f"calling remove on {filename}")
         remove(filename)
+        print("called remove?")
     print_line(b'vcs', b'DEBUG\n')
     print_line(b'vcs', b'successfully cleaned git checkout!\n')
     print_line(b'vcs', b'DEBUG\n')

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -179,7 +179,7 @@ def remove(path):
         print(f"updated permissions for {path}")
 
     if not os.path.lexists(path):
-        print(f"os.path.lexists(path)")
+        print(f"not os.path.lexists(path)")
         return
 
     """
@@ -194,7 +194,10 @@ def remove(path):
         and path[2] == "\\"
     ):
         path = u"\\\\?\\%s" % path
-
+    print("os.path.lexists(path)", os.path.lexists(path))
+    print("os.path.isfile(path)", os.path.isfile(path))
+    print("os.path.islink(path)", os.path.islink(path))
+    print("os.path.isdir(path)", os.path.isdir(path))
     if os.path.isfile(path) or os.path.islink(path):
         # Verify the file or link is read/write for the current user
         _update_permissions(path)

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -157,7 +157,7 @@ def remove(path):
 
     :param path: path to be removed
     """
-    print_line("remove", f"path = {path}")
+    print(f"remove({path})")
     def _update_permissions(path):
         """Sets specified pemissions depending on filetype"""
         if os.path.islink(path):
@@ -176,9 +176,9 @@ def remove(path):
             return
 
         _call_windows_retry(os.chmod, (path, mode))
+        print(f"updated permissions for {path}")
 
     if not os.path.lexists(path):
-        print_line("remove", "os.path.lexists(path)")
         return
 
     """
@@ -195,25 +195,24 @@ def remove(path):
         path = u"\\\\?\\%s" % path
 
     if os.path.isfile(path) or os.path.islink(path):
-        print_line("remove", "os.path.isfile(path) or os.path.islink(path)")
         # Verify the file or link is read/write for the current user
         _update_permissions(path)
         _call_windows_retry(os.remove, (path,))
+        print("assert os.path.isfile(path) is False")
+        assert os.path.isfile(path) is False
+        print("os.path.isfile(path) is False!")
 
     elif os.path.isdir(path):
-        print_line("remove", "os.path.isfile(path) or os.path.islink(path)")
         # Verify the directory is read/write/execute for the current user
-        _update_permissions(path)
-
+        _update_permissions
         # We're ensuring that every nested item has writable permission.
         for root, dirs, files in os.walk(path):
             for entry in dirs + files:
                 _update_permissions(os.path.join(root, entry))
         _call_windows_retry(shutil.rmtree, (path,))
-
-    print_line("assert os.path.isdir(path) is False")
-    assert os.path.isdir(path) is False
-    print_line("os.path.isdir(path) is False!")
+        print("assert os.path.isdir(path) is False")
+        assert os.path.isdir(path) is False
+        print("os.path.isdir(path) is False!")
 
 
 def print_line(prefix, m):

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -550,10 +550,14 @@ def _clean_git_checkout(destination_path):
     data = stdout.read()
     prefix = 'Would remove '
     filenames = [line[len(prefix):] for line in data.splitlines()]
+    print_line(b'vcs', b'DEBUG %r\n' % filenames)
     print_line(b'vcs', b'removing %r\n' % filenames)
+    print_line(b'vcs', b'DEBUG %r\n' % filenames)
     for filename in filenames:
         remove(filename)
+    print_line(b'vcs', b'DEBUG %r\n' % filenames)
     print_line(b'vcs', b'successfully cleaned git checkout!\n')
+    print_line(b'vcs', b'DEBUG %r\n' % filenames)
 
 
 def git_checkout(

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -157,7 +157,7 @@ def remove(path):
 
     :param path: path to be removed
     """
-    print(f"remove({path})"))
+    print(f"remove({path})")
     def _update_permissions(path):
         """Sets specified pemissions depending on filetype"""
         if os.path.islink(path):

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -107,6 +107,14 @@ IS_POSIX = os.name == 'posix'
 IS_WINDOWS = os.name == 'nt'
 
 
+def print_line(prefix, m):
+    now = datetime.datetime.utcnow().isoformat().encode('utf-8')
+    # slice microseconds to 3 decimals.
+    now = now[:-3] if now[-7:-6] == b'.' else now
+    sys.stdout.buffer.write(b'[%s %sZ] %s' % (prefix, now, m))
+    sys.stdout.buffer.flush()
+
+
 def _call_windows_retry(func, args=(), retry_max=5, retry_delay=0.5):
     """
     It's possible to see spurious errors on Windows due to various things
@@ -157,7 +165,6 @@ def remove(path):
 
     :param path: path to be removed
     """
-    print(f"remove({path})")
     def _update_permissions(path):
         """Sets specified pemissions depending on filetype"""
         if os.path.islink(path):
@@ -178,7 +185,7 @@ def remove(path):
         _call_windows_retry(os.chmod, (path, mode))
 
     if not os.path.lexists(path):
-        print(f"not os.path.lexists(path)")
+        print_line(b'remove', b'WARNING: %s does not exists!\n' % path.encode('utf-8'))
         return
 
     """
@@ -193,37 +200,21 @@ def remove(path):
         and path[2] == "\\"
     ):
         path = u"\\\\?\\%s" % path
-    print("os.path.lexists(path)", os.path.lexists(path))
-    print("os.path.isfile(path)", os.path.isfile(path))
-    print("os.path.islink(path)", os.path.islink(path))
-    print("os.path.isdir(path)", os.path.isdir(path))
+
     if os.path.isfile(path) or os.path.islink(path):
         # Verify the file or link is read/write for the current user
         _update_permissions(path)
         _call_windows_retry(os.remove, (path,))
-        print("assert os.path.isfile(path) is False")
-        assert os.path.isfile(path) is False
-        print("os.path.isfile(path) is False!")
 
     elif os.path.isdir(path):
         # Verify the directory is read/write/execute for the current user
         _update_permissions(path)
+
         # We're ensuring that every nested item has writable permission.
         for root, dirs, files in os.walk(path):
             for entry in dirs + files:
                 _update_permissions(os.path.join(root, entry))
         _call_windows_retry(shutil.rmtree, (path,))
-        print("assert os.path.isdir(path) is False")
-        assert os.path.isdir(path) is False
-        print("os.path.isdir(path) is False!")
-
-
-def print_line(prefix, m):
-    now = datetime.datetime.utcnow().isoformat().encode('utf-8')
-    # slice microseconds to 3 decimals.
-    now = now[:-3] if now[-7:-6] == b'.' else now
-    sys.stdout.buffer.write(b'[%s %sZ] %s' % (prefix, now, m))
-    sys.stdout.buffer.flush()
 
 
 def run_required_command(prefix, args, *, extra_env=None, cwd=None):

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -208,6 +208,8 @@ def remove(path):
                 _update_permissions(os.path.join(root, entry))
         _call_windows_retry(shutil.rmtree, (path,))
 
+    assert os.path.isdir(path) is False
+
 
 def print_line(prefix, m):
     now = datetime.datetime.utcnow().isoformat().encode('utf-8')

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -165,6 +165,7 @@ def remove(path):
 
     :param path: path to be removed
     """
+
     def _update_permissions(path):
         """Sets specified pemissions depending on filetype"""
         if os.path.islink(path):
@@ -545,18 +546,14 @@ def _clean_git_checkout(destination_path):
         sys.exit(ret)
     data = stdout.read()
     prefix = 'Would remove '
-    filenames = [os.path.join(destination_path, line[len(prefix):]) for line in data.splitlines()]
-    print_line(b'vcs', b'DEBUG\n')
+    filenames = [line[len(prefix):] for line in data.splitlines()]
+    # filenames = [os.path.join(destination_path, line[len(prefix):]) for line in data.splitlines()]
     print_line(b'vcs', b'removing %r\n' % filenames)
-    print_line(b'vcs', b'DEBUG\n')
     for filename in filenames:
-        print(f"calling remove on {filename}")
-        print(repr(remove))
         remove(filename)
-        print("called remove?")
-    print_line(b'vcs', b'DEBUG\n')
+        if os.path.isdir(filename) or os.path.isfile(filename):
+            raise Exception(f"Failed to clean git checkout. Could not delete {filename}")
     print_line(b'vcs', b'successfully cleaned git checkout!\n')
-    print_line(b'vcs', b'DEBUG\n')
 
 
 def git_checkout(

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -555,7 +555,7 @@ def _clean_git_checkout(destination_path):
         sys.exit(ret)
     data = stdout.read()
     prefix = 'Would remove '
-    filenames = [os.path.abspath(line[len(prefix):]) for line in data.splitlines()]
+    filenames = [os.path.join(destination_path, line[len(prefix):]) for line in data.splitlines()]
     print_line(b'vcs', b'DEBUG\n')
     print_line(b'vcs', b'removing %r\n' % filenames)
     print_line(b'vcs', b'DEBUG\n')

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -546,13 +546,10 @@ def _clean_git_checkout(destination_path):
         sys.exit(ret)
     data = stdout.read()
     prefix = 'Would remove '
-    filenames = [line[len(prefix):] for line in data.splitlines()]
-    # filenames = [os.path.join(destination_path, line[len(prefix):]) for line in data.splitlines()]
+    filenames = [os.path.join(destination_path, line[len(prefix):]) for line in data.splitlines()]
     print_line(b'vcs', b'removing %r\n' % filenames)
     for filename in filenames:
         remove(filename)
-        if os.path.isdir(filename) or os.path.isfile(filename):
-            raise Exception(f"Failed to clean git checkout. Could not delete {filename}")
     print_line(b'vcs', b'successfully cleaned git checkout!\n')
 
 

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -557,6 +557,7 @@ def _clean_git_checkout(destination_path):
     print_line(b'vcs', b'DEBUG\n')
     for filename in filenames:
         print(f"calling remove on {filename}")
+        print(repr(remove))
         remove(filename)
         print("called remove?")
     print_line(b'vcs', b'DEBUG\n')

--- a/src/taskgraph/test/test_scripts_run_task.py
+++ b/src/taskgraph/test/test_scripts_run_task.py
@@ -214,8 +214,9 @@ def test_clean_git_checkout(monkeypatch, run_task_mod):
     tracked_file = tempfile.NamedTemporaryFile(dir=tracked_dir.name, delete=False)
     tracked_file.write(b"tracked")
     tracked_file.close()
+    root_dir_prefix = root_dir.name + "/"
     output = io.BytesIO(
-        f"{prefix}{untracked_dir.name}/\n{prefix}{untracked_file.name}\n".encode(
+        f"{prefix}{untracked_dir.name[len(root_dir_prefix):]}/\n{prefix}{untracked_file.name[len(root_dir_prefix):]}\n".encode(
             "latin1"
         )
     )
@@ -228,6 +229,7 @@ def test_clean_git_checkout(monkeypatch, run_task_mod):
         stdin=None,
         cwd=None,
         env=None,
+        **kwargs,
     ):
         return Mock(
             stdout=output,

--- a/src/taskgraph/test/test_scripts_run_task.py
+++ b/src/taskgraph/test/test_scripts_run_task.py
@@ -215,9 +215,11 @@ def test_clean_git_checkout(monkeypatch, run_task_mod):
     tracked_file.write(b"tracked")
     tracked_file.close()
     root_dir_prefix = root_dir.name + "/"
-    untracked_dir_rel_path = untracked_dir.name[len(root_dir_prefix):]
-    untracked_file_rel_path = untracked_file.name[len(root_dir_prefix):]
-    output_str = f"{prefix}{untracked_dir_rel_path}/\n{prefix}{untracked_file_rel_path}\n"
+    untracked_dir_rel_path = untracked_dir.name[len(root_dir_prefix) :]
+    untracked_file_rel_path = untracked_file.name[len(root_dir_prefix) :]
+    output_str = (
+        f"{prefix}{untracked_dir_rel_path}/\n{prefix}{untracked_file_rel_path}\n"
+    )
     output_bytes = output_str.encode("latin1")
     output = io.BytesIO(output_bytes)
 

--- a/src/taskgraph/test/test_scripts_run_task.py
+++ b/src/taskgraph/test/test_scripts_run_task.py
@@ -215,11 +215,9 @@ def test_clean_git_checkout(monkeypatch, run_task_mod):
     tracked_file.write(b"tracked")
     tracked_file.close()
     root_dir_prefix = root_dir.name + "/"
-    output = io.BytesIO(
-        f"{prefix}{untracked_dir.name[len(root_dir_prefix):]}/\n{prefix}{untracked_file.name[len(root_dir_prefix):]}\n".encode(
-            "latin1"
-        )
-    )
+    output_str = f"{prefix}{untracked_dir.name}/\n{prefix}{untracked_file.name}\n"
+    output_bytes = output_str.encode("latin1")
+    output = io.BytesIO(output_bytes)
 
     def _Popen(
         args,

--- a/src/taskgraph/test/test_scripts_run_task.py
+++ b/src/taskgraph/test/test_scripts_run_task.py
@@ -215,7 +215,9 @@ def test_clean_git_checkout(monkeypatch, run_task_mod):
     tracked_file.write(b"tracked")
     tracked_file.close()
     root_dir_prefix = root_dir.name + "/"
-    output_str = f"{prefix}{untracked_dir.name}/\n{prefix}{untracked_file.name}\n"
+    untracked_dir_rel_path = untracked_dir.name[len(root_dir_prefix):]
+    untracked_file_rel_path = untracked_file.name[len(root_dir_prefix):]
+    output_str = f"{prefix}{untracked_dir_rel_path}/\n{prefix}{untracked_file_rel_path}\n"
     output_bytes = output_str.encode("latin1")
     output = io.BytesIO(output_bytes)
 


### PR DESCRIPTION
This patch fixes the git clean checkout regression introduced in #22

I updated the unit test to account for this case, and I added a log warning where the remove function was failing silently.