### PR TITLE
chore: version bump to 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [1.5.1] - 2022-05-06
+
+### Fixed
+- Git checkout cleaning regression
+
 ## [1.5.0] - 2022-05-02
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("requirements/base.in", "r") as fp:
 
 setup(
     name="taskcluster-taskgraph",
-    version="1.5.0",
+    version="1.5.1",
     description="Build taskcluster taskgraphs",
     url="https://github.com/taskcluster/taskgraph",
     packages=find_packages("src"),


### PR DESCRIPTION
Patch version to fix Github clean up regression.

See #22 and #44 
