### PR TITLE
refactor!: rename 'job*' keys in transform loader to 'task*'

### DIFF
--- a/docs/concepts/kind.rst
+++ b/docs/concepts/kind.rst
@@ -45,8 +45,8 @@ these are written in snake case and the corresponding python functions aren't).
       - taskgraph.transforms.cached_tasks:transforms
       - taskgraph.transforms.task:transforms
 
-  jobs:
-      android-build:  <-- this android-build image job (or task) is dependent on the the base image below, and will be referenced in a build kind.
+  tasks:
+      android-build:  <-- this android-build image task is dependent on the the base image below, and will be referenced in a build kind.
           symbol: I(agb)
           parent: base
       base:

--- a/docs/howto/docker.rst
+++ b/docs/howto/docker.rst
@@ -191,7 +191,7 @@ with the following contents:
        - taskgraph.transforms.cached_tasks:transforms
        - taskgraph.transforms.task:transforms
 
-   jobs:
+   tasks:
        custom:
            symbol: I(custom-image)
 

--- a/docs/tutorials/creating-a-task-graph.rst
+++ b/docs/tutorials/creating-a-task-graph.rst
@@ -104,17 +104,17 @@ you have a ``hello`` kind. For this next section we'll be editing
         - myrepo_taskgraph.transforms.hello:transforms
         - taskgraph.transforms.task:transforms
 
-#. Finally we define the task under the (confusingly named) ``jobs`` key.
-   The format for the initial definition here can vary wildly from one kind
-   to another, it all depends on the transforms that are used. It's conventional
-   for transforms to define a schema (but not required). So often you can look
-   at the first transform file to see what schema is expected of your job. But
-   since we haven't created the first transforms yet, let's define our task
-   like this for now:
+#. Finally we define the task under the ``tasks`` key. The format for the
+   initial definition here can vary wildly from one kind to another, it all
+   depends on the transforms that are used. It's conventional for transforms to
+   define a schema (but not required). So often you can look at the first
+   transform file to see what schema is expected of your job. But since we
+   haven't created the first transforms yet, let's define our task like this
+   for now:
 
    .. code-block:: yaml
 
-    jobs:
+    tasks:
         taskcluster:
             description: "Says hello to Taskcluster"
             text: "Taskcluster!"
@@ -127,7 +127,7 @@ Here is the combined ``kind.yml`` file:
  transforms:
      - myrepo_taskgraph.transforms.hello:transforms
      - taskgraph.transforms.task:transforms
- jobs:
+ tasks:
      taskcluster:
          description: "Says hello to Taskcluster"
          text: "Taskcluster!"
@@ -205,7 +205,7 @@ Next run the following command at the root of your repo:
  taskgraph full
 
 If all goes well, you should see some log output followed by a single task
-called ``hello-taskcluster``. Try adding a second task to your ``jobs`` key
+called ``hello-taskcluster``. Try adding a second task to your ``tasks`` key
 in the ``kind.yml`` file and re-generating the graph. You should see both
 task labels!
 

--- a/src/taskgraph/transforms/docker_image.py
+++ b/src/taskgraph/transforms/docker_image.py
@@ -41,7 +41,7 @@ docker_image_schema = Schema(
         Optional("symbol"): str,
         # relative path (from config.path) to the file the docker image was defined
         # in.
-        Optional("job-from"): str,
+        Optional("task-from"): str,
         # Arguments to use for the Dockerfile.
         Optional("args"): {str: str},
         # Name of the docker image definition under taskcluster/docker, when

--- a/src/taskgraph/transforms/fetch.py
+++ b/src/taskgraph/transforms/fetch.py
@@ -28,7 +28,7 @@ FETCH_SCHEMA = Schema(
         Required("name"): str,
         # Relative path (from config.path) to the file the task was defined
         # in.
-        Optional("job-from"): str,
+        Optional("task-from"): str,
         # Description of the task.
         Required("description"): str,
         Optional("docker-image"): object,

--- a/src/taskgraph/transforms/job/__init__.py
+++ b/src/taskgraph/transforms/job/__init__.py
@@ -40,7 +40,7 @@ job_description_schema = Schema(
         # taskcluster/taskgraph/transforms/task.py for the schema details.
         Required("description"): task_description_schema["description"],
         Optional("attributes"): task_description_schema["attributes"],
-        Optional("job-from"): task_description_schema["job-from"],
+        Optional("task-from"): task_description_schema["task-from"],
         Optional("dependencies"): task_description_schema["dependencies"],
         Optional("soft-dependencies"): task_description_schema["soft-dependencies"],
         Optional("if-dependencies"): task_description_schema["if-dependencies"],

--- a/src/taskgraph/transforms/task.py
+++ b/src/taskgraph/transforms/task.py
@@ -58,7 +58,7 @@ task_description_schema = Schema(
         # attributes for this task
         Optional("attributes"): {str: object},
         # relative path (from config.path) to the file task was defined in
-        Optional("job-from"): str,
+        Optional("task-from"): str,
         # dependencies of this task, keyed by name; these are passed through
         # verbatim and subject to the interpretation of the Task's get_dependencies
         # method.
@@ -975,7 +975,7 @@ def build_task(config, tasks):
             if groupSymbol != "?":
                 treeherder["groupSymbol"] = groupSymbol
                 if groupSymbol not in group_names:
-                    path = os.path.join(config.path, task.get("job-from", ""))
+                    path = os.path.join(config.path, task.get("task-from", ""))
                     raise Exception(UNKNOWN_GROUP_NAME.format(groupSymbol, path))
                 treeherder["groupName"] = group_names[groupSymbol]
             treeherder["symbol"] = symbol

--- a/src/taskgraph/util/docker.py
+++ b/src/taskgraph/util/docker.py
@@ -13,8 +13,8 @@ import urllib.parse
 
 import requests_unixsocket
 
-from .archive import create_tar_gz_from_files
-from .memoize import memoize
+from taskgraph.util.archive import create_tar_gz_from_files
+from taskgraph.util.memoize import memoize
 
 IMAGE_DIR = os.path.join(".", "taskcluster", "docker")
 
@@ -305,7 +305,7 @@ def image_paths():
     config = load_yaml("taskcluster", "ci", "docker-image", "kind.yml")
     return {
         k: os.path.join(IMAGE_DIR, v.get("definition", k))
-        for k, v in config["jobs"].items()
+        for k, v in config["tasks"].items()
     }
 
 

--- a/taskcluster/ci/codecov/kind.yml
+++ b/taskcluster/ci/codecov/kind.yml
@@ -12,7 +12,7 @@ kind-dependencies:
     - fetch
     - tests
 
-jobs:
+tasks:
     upload:
         description: "Upload coverage.xml to codecov.io"
         worker-type: t-linux

--- a/taskcluster/ci/doc/kind.yml
+++ b/taskcluster/ci/doc/kind.yml
@@ -9,7 +9,7 @@ transforms:
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 
-job-defaults:
+task-defaults:
     worker-type: t-linux
     worker:
         docker-image: {in-tree: python3.7}
@@ -23,7 +23,7 @@ job-defaults:
         cwd: '{checkout}'
         cache-dotcache: true
 
-jobs:
+tasks:
     generate:
         description: "Generate documentation and fail on warnings"
         treeherder:

--- a/taskcluster/ci/docker-image/kind.yml
+++ b/taskcluster/ci/docker-image/kind.yml
@@ -15,7 +15,7 @@ transforms:
 # (to use subdirectory clones of the proper directory), at which point we can
 # generate tasks for every docker image in the directory, secure in the
 # knowledge that unnecessary images will be omitted from the target task graph
-jobs:
+tasks:
     decision:
         symbol: I(d)
     # This image should be moved to a mobile-taskgraph project

--- a/taskcluster/ci/fetch/kind.yml
+++ b/taskcluster/ci/fetch/kind.yml
@@ -9,7 +9,7 @@ transforms:
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 
-jobs:
+tasks:
     codecov-uploader:
         description: uploader for codecov.io
         fetch:

--- a/taskcluster/ci/tests/kind.yml
+++ b/taskcluster/ci/tests/kind.yml
@@ -9,7 +9,7 @@ transforms:
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 
-job-defaults:
+task-defaults:
     attributes:
         retrigger: true
         code-review: true
@@ -31,7 +31,7 @@ job-defaults:
         cwd: '{checkout}'
         cache-dotcache: true
 
-jobs:
+tasks:
     unit:
         description: "Run `unit tests` to validate the latest changes"
         treeherder:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -52,8 +52,8 @@ def fake_loader(kind, path, config, parameters, loaded_tasks):
             },
             "dependencies": dependencies,
         }
-        if "job-defaults" in config:
-            task = merge(config["job-defaults"], task)
+        if "task-defaults" in config:
+            task = merge(config["task-defaults"], task)
         yield task
 
 

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -70,11 +70,11 @@ def test_always_target_tasks(maketgg):
     tgg_args = {
         "target_tasks": ["_fake-t-0", "_fake-t-1", "_ignore-t-0", "_ignore-t-1"],
         "kinds": [
-            ("_fake", {"job-defaults": {"optimization": {"odd": None}}}),
+            ("_fake", {"task-defaults": {"optimization": {"odd": None}}}),
             (
                 "_ignore",
                 {
-                    "job-defaults": {
+                    "task-defaults": {
                         "attributes": {"always_target": True},
                         "optimization": {"even": None},
                     }


### PR DESCRIPTION
This is a straight rename from job -> task in keys in the kind.yml
files.

Issue: #25