### PR TITLE
fix: add 'if-dependencies' key to job_description_schema

### DIFF
--- a/src/taskgraph/transforms/job/__init__.py
+++ b/src/taskgraph/transforms/job/__init__.py
@@ -52,6 +52,7 @@ job_description_schema = Schema(
         Optional("job-from"): task_description_schema["job-from"],
         Optional("dependencies"): task_description_schema["dependencies"],
         Optional("soft-dependencies"): task_description_schema["soft-dependencies"],
+        Optional("if-dependencies"): task_description_schema["if-dependencies"],
         Optional("requires"): task_description_schema["requires"],
         Optional("expires-after"): task_description_schema["expires-after"],
         Optional("routes"): task_description_schema["routes"],


### PR DESCRIPTION
This key should have been forwarded from the task_description_schema,
but was accidentally ommitted.