### PR TITLE
feat(run-task): set 'TASK_WORKDIR' environment variable

### DIFF
--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -1001,7 +1001,8 @@ def maybe_run_resource_monitoring():
 
 
 def main(args):
-    print_line(b'setup', b'run-task started in %s\n' % os.getcwd().encode('utf-8'))
+    os.environ["TASK_WORKDIR"] = os.getcwd()
+    print_line(b'setup', b'run-task started in %s\n' % os.environ["TASK_WORKDIR"].encode('utf-8'))
     running_as_root = IS_POSIX and os.getuid() == 0
 
     # Arguments up to '--' are ours. After are for the main task


### PR DESCRIPTION
It's often useful to know what the working directory of a task is in
order to find things like the artifacts or fetches dir.

Using the cwd doesn't work if either `--task-cwd` is specified or some
earlier step in a command changed to a new directory. Storing this
information in the env can help simplify things.