### PR TITLE
fix: allow json-e keys in schema identifiers

### DIFF
--- a/src/taskgraph/util/schema.py
+++ b/src/taskgraph/util/schema.py
@@ -162,7 +162,7 @@ WHITELISTED_SCHEMA_IDENTIFIERS = [
 
 
 def check_schema(schema):
-    identifier_re = re.compile("^[a-z][a-z0-9-]*$")
+    identifier_re = re.compile(r"^\$?[a-z][a-z0-9-]*$")
 
     def whitelisted(path):
         return any(f(path) for f in WHITELISTED_SCHEMA_IDENTIFIERS)


### PR DESCRIPTION
This syncs a change from `gecko_taskgraph`.

Jira: RELENG-888