### PR TITLE
fix: use 'zipfile' module to extract fetches on Windows

### DIFF
--- a/src/taskgraph/run-task/fetch-content
+++ b/src/taskgraph/run-task/fetch-content
@@ -329,15 +329,22 @@ def extract_archive(path, dest_dir, typ):
         if sys.platform == 'win32':
             tar = tarfile.open(fileobj=ifh, mode='r|')
             tar.extractall(str(dest_dir))
-            args = []
+            args = None
         else:
             args = ['tar', 'xf', '-']
             pipe_stdin = True
     elif typ == 'zip':
-        # unzip from stdin has wonky behavior. We don't use a pipe for it.
-        ifh = open(os.devnull, 'rb')
-        args = ['unzip', '-o', str(path)]
-        pipe_stdin = False
+        # On Windows, the unzip program also can't handle natively generated
+        # zip files which contain backslash path separators.
+        if sys.platform == "win32":
+            with zipfile.ZipFile(str(path)) as archive:
+                archive.extractall(str(dest_dir))
+            args = None
+        else:
+            # unzip from stdin has wonky behavior. We don't use a pipe for it.
+            ifh = open(os.devnull, 'rb')
+            args = ['unzip', '-o', str(path)]
+            pipe_stdin = False
     else:
         raise ValueError('unknown archive format: %s' % path)
 


### PR DESCRIPTION
Zipfiles generated natively on Windows use backslash path separators for
their internal path structure. The `unzip` utility in Linux is unable to
interpret this and creates files with `\` in their name rather than
directories.

Even if a task is running on Windows, the `unzip` utility is bundled
with `mozilla-build` and runs in the shell there. So it is still unable
to extract the archive properly.

This patch switches to extracting with the `zipfile` stdlib rather than
the `unzip` utility when running from Windows.

Note that the bug can still exist if a task running on Linux attempts to
consume a zipfile created from a task on Windows.