### PR TITLE
Sync remaining optimization features from Gecko

### DIFF
--- a/docs/concepts/optimization.rst
+++ b/docs/concepts/optimization.rst
@@ -14,7 +14,7 @@ Optimization Strategies
 
 Each task has a single named optimization strategy, and can provide an argument
 to that strategy. Each strategy is defined as an
-:class:`~taskgraph.optimize.OptimizationStrategy`.
+:class:`~taskgraph.optimize.base.OptimizationStrategy`.
 
 Each task has a ``task.optimization`` property describing the optimization
 strategy that applies, specified as a dictionary mapping strategy to argument. For
@@ -24,6 +24,9 @@ example::
 
 Strategy implementations are shared across all tasks, so they may cache
 commonly-used information as instance variables.
+
+See :doc:`/reference/optimization-strategies` for an overview of the strategies
+that are included with Taskgraph.
 
 Optimization Process
 --------------------

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -6,4 +6,5 @@ Reference
 
    cli
    parameters
+   optimization-strategies
    source/modules

--- a/docs/reference/optimization-strategies.rst
+++ b/docs/reference/optimization-strategies.rst
@@ -39,6 +39,12 @@ index-search
 Given a list of index paths, this strategy will replace the target task with
 the first one that exists.
 
+In order for the indexed task to be considered for replacement, it must:
+
+1. Exist.
+2. Not have a ``state`` of ``failed`` or ``exception``.
+3. Not expire before the earliest deadline of all tasks depending on it.
+
 Example:
 
 .. code-block:: yaml

--- a/docs/reference/optimization-strategies.rst
+++ b/docs/reference/optimization-strategies.rst
@@ -36,8 +36,9 @@ Strategies for Replacing Tasks
 index-search
 ~~~~~~~~~~~~
 
-Given a list of index paths, this strategy will replace the target task with
-the first one that exists.
+Given a list of index paths, the :class:`index-search
+<taskgraph.optimize.strategies.IndexSearch>` strategy will replace the target
+task with the first one that exists.
 
 In order for the indexed task to be considered for replacement, it must:
 
@@ -53,3 +54,35 @@ Example:
      optimization:
        index-search:
          - my.index.route
+
+Composite Strategies
+--------------------
+
+These strategies operate on one or more substrategies. Composite
+strategies may contain other composite strategies.
+
+Alias
+~~~~~
+
+The :class:`~taskgraph.optimize.base.Alias` strategy contains a single
+substrategy and provides an alternative name for it. This can be useful for
+swapping the strategy used for a particular set of tasks without needing to
+modify all of their task definitions.
+
+All
+~~~
+
+The :class:`~taskgraph.optimize.base.All` strategy will only optimize a task if
+all of its substrategies say to optimize it.
+
+Any
+~~~
+
+The :class:`~taskgraph.optimize.base.Any` strategy will optimize a task if any
+of its substrategies say to optimize it.
+
+Not
+~~~
+
+The :class:`~taskgraph.optimize.base.Not` strategy contains a single substrategy
+and will negate it.

--- a/docs/reference/optimization-strategies.rst
+++ b/docs/reference/optimization-strategies.rst
@@ -1,0 +1,49 @@
+Optimization Strategies
+=======================
+
+Taskgraph provides some built-in strategies that can be used during the
+:doc:`optimzation process </concepts/optimization>`.
+
+Strategies for Removing Tasks
+-----------------------------
+
+skip-unless-changed
+~~~~~~~~~~~~~~~~~~~
+
+.. note::
+
+   This strategy is only implemented for Mercurial repositories hosted on
+   ``hg.mozilla.org``.
+
+The :class:`skip-unless-changed
+<taskgraph.optimize.strategies.SkipUnlessChanged>` strategy will optimize the
+target task away *unless* a specified file is modified. Glob patterns are
+supported.
+
+Example:
+
+.. code-block:: yaml
+
+   my-task:
+     optimization:
+       skip-unless-changed:
+         - some/file.txt
+         - docs/**
+
+Strategies for Replacing Tasks
+------------------------------
+
+index-search
+~~~~~~~~~~~~
+
+Given a list of index paths, this strategy will replace the target task with
+the first one that exists.
+
+Example:
+
+.. code-block:: yaml
+
+   my-task:
+     optimization:
+       index-search:
+         - my.index.route

--- a/docs/reference/source/taskgraph.actions.rst
+++ b/docs/reference/source/taskgraph.actions.rst
@@ -1,6 +1,9 @@
 taskgraph.actions package
 =========================
 
+Submodules
+----------
+
 taskgraph.actions.add\_new\_jobs module
 ---------------------------------------
 

--- a/docs/reference/source/taskgraph.loader.rst
+++ b/docs/reference/source/taskgraph.loader.rst
@@ -1,6 +1,9 @@
 taskgraph.loader package
 ========================
 
+Submodules
+----------
+
 taskgraph.loader.transform module
 ---------------------------------
 

--- a/docs/reference/source/taskgraph.optimize.rst
+++ b/docs/reference/source/taskgraph.optimize.rst
@@ -1,0 +1,29 @@
+taskgraph.optimize package
+==========================
+
+Submodules
+----------
+
+taskgraph.optimize.base module
+------------------------------
+
+.. automodule:: taskgraph.optimize.base
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+taskgraph.optimize.strategies module
+------------------------------------
+
+.. automodule:: taskgraph.optimize.strategies
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: taskgraph.optimize
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/source/taskgraph.rst
+++ b/docs/reference/source/taskgraph.rst
@@ -1,13 +1,20 @@
 taskgraph package
 =================
 
+Subpackages
+-----------
+
 .. toctree::
    :maxdepth: 4
 
    taskgraph.actions
    taskgraph.loader
+   taskgraph.optimize
    taskgraph.transforms
    taskgraph.util
+
+Submodules
+----------
 
 taskgraph.config module
 -----------------------
@@ -89,14 +96,6 @@ taskgraph.morph module
    :undoc-members:
    :show-inheritance:
 
-taskgraph.optimize module
--------------------------
-
-.. automodule:: taskgraph.optimize
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 taskgraph.parameters module
 ---------------------------
 
@@ -125,6 +124,14 @@ taskgraph.taskgraph module
 --------------------------
 
 .. automodule:: taskgraph.taskgraph
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: taskgraph
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/reference/source/taskgraph.transforms.job.rst
+++ b/docs/reference/source/taskgraph.transforms.job.rst
@@ -1,6 +1,9 @@
 taskgraph.transforms.job package
 ================================
 
+Submodules
+----------
+
 taskgraph.transforms.job.common module
 --------------------------------------
 

--- a/docs/reference/source/taskgraph.transforms.rst
+++ b/docs/reference/source/taskgraph.transforms.rst
@@ -1,6 +1,9 @@
 taskgraph.transforms package
 ============================
 
+Subpackages
+-----------
+
 .. toctree::
    :maxdepth: 4
 

--- a/docs/reference/source/taskgraph.util.rst
+++ b/docs/reference/source/taskgraph.util.rst
@@ -1,6 +1,9 @@
 taskgraph.util package
 ======================
 
+Submodules
+----------
+
 taskgraph.util.archive module
 -----------------------------
 
@@ -101,6 +104,14 @@ taskgraph.util.schema module
 ----------------------------
 
 .. automodule:: taskgraph.util.schema
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+taskgraph.util.shell module
+---------------------------
+
+.. automodule:: taskgraph.util.shell
    :members:
    :undoc-members:
    :show-inheritance:

--- a/src/taskgraph/actions/retrigger.py
+++ b/src/taskgraph/actions/retrigger.py
@@ -215,11 +215,11 @@ def rerun_action(parameters, graph_config, input, task_group_id, task_id):
 
 
 def _rerun_task(task_id, label):
-    status = taskcluster.status_task(task_id)
-    if status not in RERUN_STATES:
+    state = taskcluster.state_task(task_id)
+    if state not in RERUN_STATES:
         logger.warning(
             "No need to rerun {}: state '{}' not in {}!".format(
-                label, status, RERUN_STATES
+                label, state, RERUN_STATES
             )
         )
         return

--- a/src/taskgraph/actions/util.py
+++ b/src/taskgraph/actions/util.py
@@ -14,7 +14,7 @@ from requests.exceptions import HTTPError
 
 from taskgraph import create
 from taskgraph.decision import read_artifact, rename_artifact, write_artifact
-from taskgraph.optimize import optimize_task_graph
+from taskgraph.optimize.base import optimize_task_graph
 from taskgraph.taskgraph import TaskGraph
 from taskgraph.util.taskcluster import (
     CONCURRENCY,

--- a/src/taskgraph/generator.py
+++ b/src/taskgraph/generator.py
@@ -369,9 +369,8 @@ class TaskGraphGenerator:
             "Adding %d tasks with `always_target` attribute"
             % (len(always_target_tasks) - len(always_target_tasks & target_tasks))
         )
-        target_graph = full_task_graph.graph.transitive_closure(
-            target_tasks | docker_image_tasks | always_target_tasks
-        )
+        requested_tasks = target_tasks | docker_image_tasks | always_target_tasks
+        target_graph = full_task_graph.graph.transitive_closure(requested_tasks)
         target_task_graph = TaskGraph(
             {l: all_tasks[l] for l in target_graph.nodes}, target_graph
         )
@@ -386,6 +385,7 @@ class TaskGraphGenerator:
             do_not_optimize = set(target_task_set.graph.nodes).union(do_not_optimize)
         optimized_task_graph, label_to_taskid = optimize_task_graph(
             target_task_graph,
+            requested_tasks,
             parameters,
             do_not_optimize,
             self._decision_task_id,

--- a/src/taskgraph/generator.py
+++ b/src/taskgraph/generator.py
@@ -13,7 +13,7 @@ from . import filter_tasks
 from .config import GraphConfig, load_graph_config
 from .graph import Graph
 from .morph import morph
-from .optimize import optimize_task_graph
+from .optimize.base import optimize_task_graph
 from .parameters import Parameters
 from .task import Task
 from .taskgraph import TaskGraph

--- a/src/taskgraph/optimize/__init__.py
+++ b/src/taskgraph/optimize/__init__.py
@@ -1,0 +1,1 @@
+from .base import OptimizationStrategy, register_strategy  # noqa: F401

--- a/src/taskgraph/optimize/__init__.py
+++ b/src/taskgraph/optimize/__init__.py
@@ -1,1 +1,8 @@
-from .base import OptimizationStrategy, register_strategy  # noqa: F401
+from .base import (  # noqa: F401
+    Alias,
+    All,
+    Any,
+    Not,
+    OptimizationStrategy,
+    register_strategy,
+)

--- a/src/taskgraph/optimize/strategies.py
+++ b/src/taskgraph/optimize/strategies.py
@@ -1,0 +1,59 @@
+import logging
+import os
+
+from taskgraph import files_changed
+from taskgraph.optimize.base import OptimizationStrategy, register_strategy
+from taskgraph.util.taskcluster import find_task_id
+
+logger = logging.getLogger(__name__)
+
+
+@register_strategy("index-search")
+class IndexSearch(OptimizationStrategy):
+
+    # A task with no dependencies remaining after optimization will be replaced
+    # if artifacts exist for the corresponding index_paths.
+    # Otherwise, we're in one of the following cases:
+    # - the task has un-optimized dependencies
+    # - the artifacts have expired
+    # - some changes altered the index_paths and new artifacts need to be
+    # created.
+    # In every of those cases, we need to run the task to create or refresh
+    # artifacts.
+
+    def should_replace_task(self, task, params, index_paths):
+        "Look for a task with one of the given index paths"
+        for index_path in index_paths:
+            try:
+                task_id = find_task_id(
+                    index_path, use_proxy=bool(os.environ.get("TASK_ID"))
+                )
+                return task_id
+            except KeyError:
+                # 404 will end up here and go on to the next index path
+                pass
+
+        return False
+
+
+@register_strategy("skip-unless-changed")
+class SkipUnlessChanged(OptimizationStrategy):
+    def should_remove_task(self, task, params, file_patterns):
+        if params.get("repository_type") != "hg":
+            raise RuntimeError(
+                "SkipUnlessChanged optimization only works with mercurial repositories"
+            )
+
+        # pushlog_id == -1 - this is the case when run from a cron.yml job
+        if params.get("pushlog_id") == -1:
+            return False
+
+        changed = files_changed.check(params, file_patterns)
+        if not changed:
+            logger.debug(
+                'no files found matching a pattern in `skip-unless-changed` for "{}"'.format(
+                    task.label
+                )
+            )
+            return True
+        return False

--- a/src/taskgraph/util/taskcluster.py
+++ b/src/taskgraph/util/taskcluster.py
@@ -259,13 +259,44 @@ def cancel_task(task_id, use_proxy=False):
 
 
 def status_task(task_id, use_proxy=False):
-    """Gets the status of a task given a task_id. In testing mode, just logs that it would
-    have retrieved status."""
+    """Gets the status of a task given a task_id.
+
+    In testing mode, just logs that it would have retrieved status.
+
+    Args:
+        task_id (str): A task id.
+        use_proxy (bool): Whether to use taskcluster-proxy (default: False)
+
+    Returns:
+        dict: A dictionary object as defined here:
+          https://docs.taskcluster.net/docs/reference/platform/queue/api#status
+    """
     if testing:
         logger.info(f"Would have gotten status for {task_id}.")
     else:
         resp = _do_request(get_task_url(task_id, use_proxy) + "/status")
-        status = resp.json().get("status", {}).get("state") or "unknown"
+        status = resp.json().get("status", {})
+        return status
+
+
+def state_task(task_id, use_proxy=False):
+    """Gets the state of a task given a task_id.
+
+    In testing mode, just logs that it would have retrieved state. This is a subset of the
+    data returned by :func:`status_task`.
+
+    Args:
+        task_id (str): A task id.
+        use_proxy (bool): Whether to use taskcluster-proxy (default: False)
+
+    Returns:
+        str: The state of the task, one of
+          ``pending, running, completed, failed, exception, unknown``.
+    """
+    if testing:
+        logger.info(f"Would have gotten state for {task_id}.")
+    else:
+        status = status_task(task_id, use_proxy=use_proxy).get("state") or "unknown"
         return status
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,11 +5,11 @@ import pytest
 from responses import RequestsMock
 
 from taskgraph import generator
-from taskgraph import optimize as optimize_mod
 from taskgraph import target_tasks as target_tasks_mod
 from taskgraph.config import GraphConfig
 from taskgraph.generator import Kind, TaskGraphGenerator
 from taskgraph.optimize import OptimizationStrategy
+from taskgraph.optimize import base as optimize_mod
 from taskgraph.transforms.base import TransformConfig
 from taskgraph.util.templates import merge
 
@@ -152,16 +152,12 @@ def maketgg(monkeypatch, parameters):
         def target_tasks_method(full_task_graph, parameters, graph_config):
             return target_tasks
 
-        def make_fake_strategies():
-            return {
-                mode: FakeOptimization(mode)
-                for mode in ("always", "never", "even", "odd")
-            }
+        fake_strategies = {
+            mode: FakeOptimization(mode) for mode in ("always", "never", "even", "odd")
+        }
 
         target_tasks_mod._target_task_methods["test_method"] = target_tasks_method
-        monkeypatch.setattr(
-            optimize_mod, "_make_default_strategies", make_fake_strategies
-        )
+        monkeypatch.setattr(optimize_mod, "registry", fake_strategies)
 
         parameters["_kinds"] = kinds
         parameters.update(params)

--- a/test/test_optimize_strategies.py
+++ b/test/test_optimize_strategies.py
@@ -1,0 +1,36 @@
+# Any copyright is dedicated to the public domain.
+# http://creativecommons.org/publicdomain/zero/1.0/
+
+import os
+from datetime import datetime
+from time import mktime
+
+import pytest
+
+from taskgraph.optimize.strategies import IndexSearch
+
+
+@pytest.fixture
+def params():
+    return {
+        "branch": "integration/autoland",
+        "head_repository": "https://hg.mozilla.org/integration/autoland",
+        "head_rev": "abcdef",
+        "project": "autoland",
+        "pushlog_id": 1,
+        "pushdate": mktime(datetime.now().timetuple()),
+    }
+
+
+def test_index_search(responses, params):
+    taskid = "abc"
+    index_path = "foo.bar.latest"
+    responses.add(
+        responses.GET,
+        f"{os.environ['TASKCLUSTER_ROOT_URL']}/api/index/v1/task/{index_path}",
+        json={"taskId": taskid},
+        status=200,
+    )
+
+    opt = IndexSearch()
+    assert opt.should_replace_task({}, params, (index_path,)) == "abc"

--- a/test/test_util_taskcluster.py
+++ b/test/test_util_taskcluster.py
@@ -265,7 +265,17 @@ def test_status_task(responses, root_url):
         f"{root_url}/api/queue/v1/task/{tid}/status",
         json={"status": {"state": "running"}},
     )
-    assert tc.status_task(tid) == "running"
+    assert tc.status_task(tid) == {"state": "running"}
+
+
+def test_state_task(responses, root_url):
+    tid = "123"
+    responses.add(
+        responses.GET,
+        f"{root_url}/api/queue/v1/task/{tid}/status",
+        json={"status": {"state": "running"}},
+    )
+    assert tc.state_task(tid) == "running"
 
 
 def test_rerun_task(responses, proxy_root_url):


### PR DESCRIPTION
The optimization logic between Gecko and standalone is nearly the same, but Gecko has a few extra features that would be nice to incorporate into Taskgraph. This PR will make the logic identical such that Gecko can remove its copy.

This contains several backwards incompatible changes, as such I'll be doing a major version bump after this lands.

I recommend reviewing this commit by commit.