### PR TITLE
refactor!: make TransformConfig.kind_dependencies_tasks a dict

### DIFF
--- a/src/taskgraph/generator.py
+++ b/src/taskgraph/generator.py
@@ -51,9 +51,9 @@ class Kind:
         config = copy.deepcopy(self.config)
 
         kind_dependencies = config.get("kind-dependencies", [])
-        kind_dependencies_tasks = [
-            task for task in loaded_tasks if task.kind in kind_dependencies
-        ]
+        kind_dependencies_tasks = {
+            task.label: task for task in loaded_tasks if task.kind in kind_dependencies
+        }
 
         inputs = loader(self.name, self.path, config, parameters, loaded_tasks)
 

--- a/src/taskgraph/transforms/base.py
+++ b/src/taskgraph/transforms/base.py
@@ -46,9 +46,9 @@ class TransformConfig:
     # the parameters for this task-graph generation run
     params = attr.ib(type=Parameters)
 
-    # a list of all the tasks associated with the kind dependencies of the
+    # a dict of all the tasks associated with the kind dependencies of the
     # current kind
-    kind_dependencies_tasks = attr.ib()
+    kind_dependencies_tasks = attr.ib(type=dict)
 
     # Global configuration of the taskgraph
     graph_config = attr.ib(type=GraphConfig)

--- a/src/taskgraph/transforms/cached_tasks.py
+++ b/src/taskgraph/transforms/cached_tasks.py
@@ -57,7 +57,7 @@ def cache_task(config, tasks):
         return
 
     digests = {}
-    for task in config.kind_dependencies_tasks:
+    for task in config.kind_dependencies_tasks.values():
         if "cached_task" in task.attributes:
             digests[task.label] = format_task_digest(task.attributes["cached_task"])
 

--- a/src/taskgraph/transforms/code_review.py
+++ b/src/taskgraph/transforms/code_review.py
@@ -17,7 +17,7 @@ def add_dependencies(config, jobs):
         job.setdefault("soft-dependencies", [])
         job["soft-dependencies"] += [
             dep_task.label
-            for dep_task in config.kind_dependencies_tasks
+            for dep_task in config.kind_dependencies_tasks.values()
             if dep_task.attributes.get("code-review") is True
         ]
         yield job

--- a/src/taskgraph/transforms/docker_image.py
+++ b/src/taskgraph/transforms/docker_image.py
@@ -67,7 +67,7 @@ transforms.add_validate(docker_image_schema)
 @transforms.add
 def fill_template(config, tasks):
     available_packages = set()
-    for task in config.kind_dependencies_tasks:
+    for task in config.kind_dependencies_tasks.values():
         if task.kind != "packages":
             continue
         name = task.label.replace("packages-", "")

--- a/src/taskgraph/transforms/job/__init__.py
+++ b/src/taskgraph/transforms/job/__init__.py
@@ -211,7 +211,7 @@ def use_fetches(config, jobs):
             if value:
                 aliases[f"{config.kind}-{value}"] = label
 
-    for task in config.kind_dependencies_tasks:
+    for task in config.kind_dependencies_tasks.values():
         if task.kind in ("fetch", "toolchain"):
             get_attribute(
                 artifact_names,
@@ -275,8 +275,8 @@ def use_fetches(config, jobs):
                 else:
                     dep_tasks = [
                         task
-                        for task in config.kind_dependencies_tasks
-                        if task.label == dep_label
+                        for label, task in config.kind_dependencies_tasks.items()
+                        if label == dep_label
                     ]
                     if len(dep_tasks) != 1:
                         raise Exception(

--- a/test/test_transforms_job.py
+++ b/test/test_transforms_job.py
@@ -162,7 +162,7 @@ def test_use_fetches(
     kind_dependencies_tasks,
 ):
     transform_config = make_transform_config(
-        kind_dependencies_tasks=kind_dependencies_tasks
+        kind_dependencies_tasks={t.label: t for t in kind_dependencies_tasks}
     )
     task = merge(TASK_DEFAULTS, task)
     result = run_transform(job.use_fetches, task, config=transform_config)[0]


### PR DESCRIPTION
BREAKING CHANGE: TransformConfig.kind_dependencies_tasks has changed
from a list to a dict.

This change syncs functionality with gecko_taskgraph. I think it's
better to go this way (rather than changing gecko_taskgraph to a list),
as a dict makes containment operations much simpler when comparing
labels. E.g:
https://searchfox.org/mozilla-central/rev/6ec440e105c2b75d5cae9d34f957a2f85a106d54/taskcluster/gecko_taskgraph/transforms/partner_attribution.py#63

Jira: RELENG-852
Issue: #28