### PR TITLE
fix(docs): fix `.taskcluster.yml` payload schema

### DIFF
--- a/docs/tutorials/example-taskcluster.yml
+++ b/docs/tutorials/example-taskcluster.yml
@@ -80,8 +80,9 @@ tasks:
               payload:
                   image:
                       mozillareleases/taskgraph:decision-cf4b4b4baff57d84c1f9ec8fcd70c9839b70a7d66e6430a6c41ffe67252faa19@sha256:425e07f6813804483bc5a7258288a7684d182617ceeaa0176901ccc7702dfe28
-                  feature:
+                  features:
                       taskclusterProxy: true
+                  maxRunTime: 300
                   env:
                       $merge:
                           # run-task uses these environment variables to clone your


### PR DESCRIPTION
Fixes #97.

Following the docker-worker payload [here](https://docs.taskcluster.net/docs/reference/workers/docker-worker/payload).