### PR TITLE
Bug 1785439 - enforce milliseconds value in timestamp even if value i…

### DIFF
--- a/src/taskgraph/util/time.py
+++ b/src/taskgraph/util/time.py
@@ -99,9 +99,8 @@ def json_time_from_now(input_str, now=None, datetime_format=False):
     else:
         # Sorta a big hack but the json schema validator for date does not like the
         # ISO dates until 'Z' (for timezone) is added...
-        # the [:23] ensures only whole seconds or milliseconds are included,
-        # not microseconds (see bug 1381801)
-        return time.isoformat()[:23] + "Z"
+        # Microseconds are excluded (see bug 1381801)
+        return time.isoformat(timespec="milliseconds") + "Z"
 
 
 def current_json_time(datetime_format=False):
@@ -112,6 +111,5 @@ def current_json_time(datetime_format=False):
     if datetime_format is True:
         return datetime.datetime.utcnow()
     else:
-        # the [:23] ensures only whole seconds or milliseconds are included,
-        # not microseconds (see bug 1381801)
-        return datetime.datetime.utcnow().isoformat()[:23] + "Z"
+        # Microseconds are excluded (see bug 1381801)
+        return datetime.datetime.utcnow().isoformat(timespec="milliseconds") + "Z"

--- a/test/test_util_parameterization.py
+++ b/test/test_util_parameterization.py
@@ -25,7 +25,7 @@ def test_timestamps_buried_replacement():
     now = datetime.datetime(2018, 1, 1)
     input = {"key": [{"key2": [{"relative-datestamp": "1 day"}]}]}
     assert resolve_timestamps(now, input) == {
-        "key": [{"key2": ["2018-01-02T00:00:00Z"]}]
+        "key": [{"key2": ["2018-01-02T00:00:00.000Z"]}]
     }
 
 

--- a/test/test_util_time.py
+++ b/test/test_util_time.py
@@ -46,5 +46,5 @@ class FromNowTest(unittest.TestCase):
 
     def test_json_from_now(self):
         now = datetime(2014, 1, 1)
-        self.assertEqual(json_time_from_now("1 years", now), "2015-01-01T00:00:00Z")
-        self.assertEqual(json_time_from_now("6 days", now), "2014-01-07T00:00:00Z")
+        self.assertEqual(json_time_from_now("1 years", now), "2015-01-01T00:00:00.000Z")
+        self.assertEqual(json_time_from_now("6 days", now), "2014-01-07T00:00:00.000Z")

--- a/test/test_util_time.py
+++ b/test/test_util_time.py
@@ -4,11 +4,13 @@
 
 
 import unittest
+from unittest.mock import patch
 from datetime import datetime
 
 from taskgraph.util.time import (
     InvalidString,
     UnknownTimeMeasurement,
+    current_json_time,
     json_time_from_now,
     value_of,
 )
@@ -48,3 +50,11 @@ class FromNowTest(unittest.TestCase):
         now = datetime(2014, 1, 1)
         self.assertEqual(json_time_from_now("1 years", now), "2015-01-01T00:00:00.000Z")
         self.assertEqual(json_time_from_now("6 days", now), "2014-01-07T00:00:00.000Z")
+
+    def test_current_json_time(self):
+        with patch("taskgraph.util.time.datetime.datetime") as mock_datetime:
+            mock_datetime.utcnow.return_value = datetime(2014, 1, 1)
+            mock_datetime.side_effect = datetime
+
+            assert current_json_time() == "2014-01-01T00:00:00.000Z"
+            assert current_json_time(True) == datetime(2014, 1, 1)

--- a/test/test_util_time.py
+++ b/test/test_util_time.py
@@ -4,8 +4,8 @@
 
 
 import unittest
-from unittest.mock import patch
 from datetime import datetime
+from unittest.mock import patch
 
 from taskgraph.util.time import (
     InvalidString,


### PR DESCRIPTION
…s 0 to match parser expectation in graph builder.

Bug 1690947 started to parse timestamp strings provided for task expiration and
deadline which lacked the milliseconds part if the microseconds including
milliseconds had a value of 0 (because Python's `isoformat()` method got used
without enforcing the precision).

This caused the graph builder in the Gecko decision task to fail.

[jcristau: porting the fix from gecko_taskgraph to standalone]