### PR TITLE
Bug 1786535 - Trim ".git" from tc-treeherder route's project

### DIFF
--- a/src/taskgraph/transforms/task.py
+++ b/src/taskgraph/transforms/task.py
@@ -998,6 +998,8 @@ def build_task(config, tasks):
                 # (and causes scope issues) if it doesn't match the name of the
                 # base repo
                 base_project = config.params["base_repository"].split("/")[-1]
+                if base_project.endswith(".git"):
+                    base_project = base_project[:-4]
                 th_project_suffix = "-pr"
             else:
                 base_project = config.params["project"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -100,9 +100,7 @@ def fake_load_graph_config(root_dir):
                 }
             },
             "task-priority": "low",
-            "treeherder": {
-                "group-names": []
-            },
+            "treeherder": {"group-names": []},
         },
         root_dir,
     )
@@ -117,6 +115,7 @@ def graph_config(datadir):
 
 class FakeParameters(dict):
     strict = True
+
     def is_try(self):
         return False
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -92,12 +92,16 @@ def fake_load_graph_config(root_dir):
             "workers": {
                 "aliases": {
                     "t-linux": {
-                        "provisioners": "taskgraph-t",
+                        "provisioner": "taskgraph-t",
                         "implementation": "docker-worker",
                         "os": "linux",
                         "worker-type": "linux",
                     }
                 }
+            },
+            "task-priority": "low",
+            "treeherder": {
+                "group-names": []
             },
         },
         root_dir,
@@ -113,6 +117,11 @@ def graph_config(datadir):
 
 class FakeParameters(dict):
     strict = True
+    def is_try(self):
+        return False
+
+    def file_url(self, path, pretty=False):
+        return path
 
 
 class FakeOptimization(OptimizationStrategy):
@@ -143,7 +152,9 @@ def parameters():
             "level": "1",
             "moz_build_date": 0,
             "next_version": "1.0.1",
+            "owner": "some-owner",
             "project": "some-project",
+            "pushlog_id": 1,
             "repository_type": "hg",
             "target_tasks_method": "test_method",
             "tasks_for": "hg-push",

--- a/test/test_transforms_task.py
+++ b/test/test_transforms_task.py
@@ -7,10 +7,11 @@ from pathlib import Path
 from pprint import pprint
 
 import pytest
-from .conftest import FakeParameters
 
 from taskgraph.transforms import task
 from taskgraph.transforms.base import TransformConfig
+
+from .conftest import FakeParameters
 
 TASK_DEFAULTS = {
     "description": "fake description",
@@ -54,67 +55,67 @@ def assert_github_pull_request_dot_git(task_dict):
     (
         pytest.param(
             {
-                'base_repository': 'http://hg.example.com',
-                'build_date': 0, 
-                'build_number': 1,
-                'head_repository': 'http://hg.example.com',
-                'head_rev': 'abcdef',
-                'head_ref': 'default',
-                'level': '1',
-                'moz_build_date': 0,
-                'next_version': '1.0.1',
-                'owner': 'some-owner',
-                'project': 'some-project',
-                'pushlog_id': 1,
-                'repository_type': 'hg',
-                'target_tasks_method': 'test_method',
-                'tasks_for': 'hg-push',
-                'try_mode': None,
-                'version': '1.0.0'
+                "base_repository": "http://hg.example.com",
+                "build_date": 0,
+                "build_number": 1,
+                "head_repository": "http://hg.example.com",
+                "head_rev": "abcdef",
+                "head_ref": "default",
+                "level": "1",
+                "moz_build_date": 0,
+                "next_version": "1.0.1",
+                "owner": "some-owner",
+                "project": "some-project",
+                "pushlog_id": 1,
+                "repository_type": "hg",
+                "target_tasks_method": "test_method",
+                "tasks_for": "hg-push",
+                "try_mode": None,
+                "version": "1.0.0",
             },
             id="hg-push",
         ),
         pytest.param(
             {
-                'base_repository': 'http://github.com/mozilla/example',
-                'build_date': 0, 
-                'build_number': 1,
-                'head_repository': 'http://github.com/mozilla/example',
-                'head_rev': 'abcdef',
-                'head_ref': 'default',
-                'level': '1',
-                'moz_build_date': 0,
-                'next_version': '1.0.1',
-                'owner': 'some-owner',
-                'project': 'some-project',
-                'pushlog_id': 1,
-                'repository_type': 'git',
-                'target_tasks_method': 'test_method',
-                'tasks_for': 'github-pull-request',
-                'try_mode': None,
-                'version': '1.0.0'
+                "base_repository": "http://github.com/mozilla/example",
+                "build_date": 0,
+                "build_number": 1,
+                "head_repository": "http://github.com/mozilla/example",
+                "head_rev": "abcdef",
+                "head_ref": "default",
+                "level": "1",
+                "moz_build_date": 0,
+                "next_version": "1.0.1",
+                "owner": "some-owner",
+                "project": "some-project",
+                "pushlog_id": 1,
+                "repository_type": "git",
+                "target_tasks_method": "test_method",
+                "tasks_for": "github-pull-request",
+                "try_mode": None,
+                "version": "1.0.0",
             },
             id="github-pull-request",
         ),
         pytest.param(
             {
-                'base_repository': 'git@github.com://github.com/mozilla/example.git',
-                'build_date': 0, 
-                'build_number': 1,
-                'head_repository': 'git@github.com://github.com/mozilla/example.git',
-                'head_rev': 'abcdef',
-                'head_ref': 'default',
-                'level': '1',
-                'moz_build_date': 0,
-                'next_version': '1.0.1',
-                'owner': 'some-owner',
-                'project': 'some-project',
-                'pushlog_id': 1,
-                'repository_type': 'git',
-                'target_tasks_method': 'test_method',
-                'tasks_for': 'github-pull-request',
-                'try_mode': None,
-                'version': '1.0.0'
+                "base_repository": "git@github.com://github.com/mozilla/example.git",
+                "build_date": 0,
+                "build_number": 1,
+                "head_repository": "git@github.com://github.com/mozilla/example.git",
+                "head_rev": "abcdef",
+                "head_ref": "default",
+                "level": "1",
+                "moz_build_date": 0,
+                "next_version": "1.0.1",
+                "owner": "some-owner",
+                "project": "some-project",
+                "pushlog_id": 1,
+                "repository_type": "git",
+                "target_tasks_method": "test_method",
+                "tasks_for": "github-pull-request",
+                "try_mode": None,
+                "version": "1.0.0",
             },
             id="github-pull-request-dot-git",
         ),
@@ -124,14 +125,14 @@ def test_transforms(request, run_transform, graph_config, task_params):
     # instead of make_transform_config fixture, to get custom parameters
     params = FakeParameters(task_params)
     transform_config = TransformConfig(
-            "test",
-            str(here),
-            {},
-            params,
-            {},
-            graph_config,
-            write_artifacts=False,
-        )
+        "test",
+        str(here),
+        {},
+        params,
+        {},
+        graph_config,
+        write_artifacts=False,
+    )
     task_dict = deepcopy(TASK_DEFAULTS)
 
     task_dict = run_transform(task.transforms, task_dict, config=transform_config)[0]

--- a/test/test_transforms_task.py
+++ b/test/test_transforms_task.py
@@ -1,0 +1,144 @@
+"""
+Tests for the 'task' transforms.
+"""
+
+from copy import deepcopy
+from pathlib import Path
+from pprint import pprint
+
+import pytest
+from .conftest import FakeParameters
+
+from taskgraph.transforms import task
+from taskgraph.transforms.base import TransformConfig
+
+TASK_DEFAULTS = {
+    "description": "fake description",
+    "name": "fake-task-name",
+    "worker-type": "t-linux",
+    "worker": {
+        "docker-image": "fake-image-name",
+        "max-run-time": 1800,
+    },
+    "treeherder": {
+        "tier": 1,
+        "symbol": "G",
+        "platform": "some-th-platform/some-th-collection",
+        "kind": "build",
+    },
+}
+here = Path(__file__).parent
+
+
+def assert_common(task_dict):
+    assert task_dict["label"] == "test-fake-task-name"
+    assert "task" in task_dict
+    assert "extra" in task_dict["task"]
+    assert "payload" in task_dict["task"]
+
+
+def assert_hg_push(task_dict):
+    assert_common(task_dict)
+
+
+def assert_github_pull_request(task_dict):
+    assert_common(task_dict)
+
+
+def assert_github_pull_request_dot_git(task_dict):
+    assert_common(task_dict)
+
+
+@pytest.mark.parametrize(
+    "task_params",
+    (
+        pytest.param(
+            {
+                'base_repository': 'http://hg.example.com',
+                'build_date': 0, 
+                'build_number': 1,
+                'head_repository': 'http://hg.example.com',
+                'head_rev': 'abcdef',
+                'head_ref': 'default',
+                'level': '1',
+                'moz_build_date': 0,
+                'next_version': '1.0.1',
+                'owner': 'some-owner',
+                'project': 'some-project',
+                'pushlog_id': 1,
+                'repository_type': 'hg',
+                'target_tasks_method': 'test_method',
+                'tasks_for': 'hg-push',
+                'try_mode': None,
+                'version': '1.0.0'
+            },
+            id="hg-push",
+        ),
+        pytest.param(
+            {
+                'base_repository': 'http://github.com/mozilla/example',
+                'build_date': 0, 
+                'build_number': 1,
+                'head_repository': 'http://github.com/mozilla/example',
+                'head_rev': 'abcdef',
+                'head_ref': 'default',
+                'level': '1',
+                'moz_build_date': 0,
+                'next_version': '1.0.1',
+                'owner': 'some-owner',
+                'project': 'some-project',
+                'pushlog_id': 1,
+                'repository_type': 'git',
+                'target_tasks_method': 'test_method',
+                'tasks_for': 'github-pull-request',
+                'try_mode': None,
+                'version': '1.0.0'
+            },
+            id="github-pull-request",
+        ),
+        pytest.param(
+            {
+                'base_repository': 'git@github.com://github.com/mozilla/example.git',
+                'build_date': 0, 
+                'build_number': 1,
+                'head_repository': 'git@github.com://github.com/mozilla/example.git',
+                'head_rev': 'abcdef',
+                'head_ref': 'default',
+                'level': '1',
+                'moz_build_date': 0,
+                'next_version': '1.0.1',
+                'owner': 'some-owner',
+                'project': 'some-project',
+                'pushlog_id': 1,
+                'repository_type': 'git',
+                'target_tasks_method': 'test_method',
+                'tasks_for': 'github-pull-request',
+                'try_mode': None,
+                'version': '1.0.0'
+            },
+            id="github-pull-request-dot-git",
+        ),
+    ),
+)
+def test_transforms(request, run_transform, graph_config, task_params):
+    # instead of make_transform_config fixture, to get custom parameters
+    params = FakeParameters(task_params)
+    transform_config = TransformConfig(
+            "test",
+            str(here),
+            {},
+            params,
+            {},
+            graph_config,
+            write_artifacts=False,
+        )
+    task_dict = deepcopy(TASK_DEFAULTS)
+
+    task_dict = run_transform(task.transforms, task_dict, config=transform_config)[0]
+    print("Dumping task:")
+    pprint(task_dict, indent=2)
+
+    # Call the assertion function for the given test.
+    param_id = request.node.callspec.id
+    assertion_func = globals()[f"assert_{param_id.replace('-', '_')}"]
+    assertion_func(task_dict)


### PR DESCRIPTION
firefox-android is a private github repo accessed via ssh, so the base repository looks like "git@github.com:mozilla-mobile/firefox-android.git". Existing code for constructing the tc-treeherder route's base_project on pull request extracts "firefox-android.git" from the base repo, resulting in a route like "queue:route:tc-treeherder.v2.firefox-android.git-pr..." instead of the desired "queue:route:tc-treeherder.v2.firefox-android-pr..."
