### PR TITLE
ci: switch to the 'public_restricted' pull request policy

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -7,7 +7,7 @@
 version: 1
 reporting: checks-v1
 policy:
-    pullRequests: collaborators
+    pullRequests: public_restricted
 tasks:
     # NOTE: support for actions in ci-admin requires that the `tasks` property be an array *before* JSON-e rendering
     # takes place.
@@ -17,7 +17,7 @@ tasks:
               $if: 'tasks_for == "github-push"'
               then: '${event.pusher.email}'
               else:
-                  $if: 'tasks_for == "github-pull-request"'
+                  $if: 'tasks_for[:19] == "github-pull-request"'
                   then: '${event.pull_request.user.login}@users.noreply.github.com'
                   else:
                       $if: 'tasks_for in ["cron", "action"]'
@@ -26,7 +26,7 @@ tasks:
               $if: 'tasks_for == "github-push"'
               then: '${event.repository.html_url}'
               else:
-                  $if: 'tasks_for == "github-pull-request"'
+                  $if: 'tasks_for[:19] == "github-pull-request"'
                   then: '${event.pull_request.base.repo.html_url}'
                   else:
                       $if: 'tasks_for in ["cron", "action"]'
@@ -35,7 +35,7 @@ tasks:
               $if: 'tasks_for == "github-push"'
               then: '${event.repository.html_url}'
               else:
-                  $if: 'tasks_for == "github-pull-request"'
+                  $if: 'tasks_for[:19] == "github-pull-request"'
                   then: '${event.pull_request.head.repo.html_url}'
                   else:
                       $if: 'tasks_for in ["cron", "action"]'
@@ -44,13 +44,13 @@ tasks:
               $if: 'tasks_for == "github-push"'
               then: '${event.repository.name}'
               else:
-                  $if: 'tasks_for == "github-pull-request"'
+                  $if: 'tasks_for[:19] == "github-pull-request"'
                   then: '${event.pull_request.head.repo.name}'
                   else:
                       $if: 'tasks_for in ["cron", "action"]'
                       then: '${repository.project}'
           base_ref:
-              $if: 'tasks_for == "github-pull-request"'
+              $if: 'tasks_for[:19] == "github-pull-request"'
               then: ${event.pull_request.base.ref}
               else:
                   # event.base_ref is barely documented[1]. Testing showed it's only
@@ -67,7 +67,7 @@ tasks:
                           $if: 'tasks_for in ["cron", "action"]'
                           then: '${push.branch}'
           head_ref:
-              $if: 'tasks_for == "github-pull-request"'
+              $if: 'tasks_for[:19] == "github-pull-request"'
               then: ${event.pull_request.head.ref}
               else:
                   $if: 'tasks_for == "github-push"'
@@ -79,7 +79,7 @@ tasks:
               $if: 'tasks_for == "github-push"'
               then: '${event.before}'
               else:
-                  $if: 'tasks_for == "github-pull-request"'
+                  $if: 'tasks_for[:19] == "github-pull-request"'
                   then: '${event.pull_request.base.sha}'
                   else:
                       $if: 'tasks_for in ["cron", "action"]'
@@ -88,7 +88,7 @@ tasks:
               $if: 'tasks_for == "github-push"'
               then: '${event.after}'
               else:
-                  $if: 'tasks_for == "github-pull-request"'
+                  $if: 'tasks_for[:19] == "github-pull-request"'
                   then: '${event.pull_request.head.sha}'
                   else:
                       $if: 'tasks_for in ["cron", "action"]'
@@ -100,14 +100,16 @@ tasks:
                   $if: 'tasks_for in ["cron", "action"]'
                   then: '${ownTaskId}'
           pullRequestAction:
-              $if: 'tasks_for == "github-pull-request"'
+              $if: 'tasks_for[:19] == "github-pull-request"'
               then: ${event.action}
               else: 'UNDEFINED'
+          isPullRequest:
+              $eval: 'tasks_for[:19] == "github-pull-request"'
       in:
           $if: >
             tasks_for in ["action", "cron"]
             || (tasks_for == "github-push" && head_ref[:10] != "refs/tags/")
-            || (tasks_for == "github-pull-request" && pullRequestAction in ["opened", "reopened", "synchronize"])
+            || (isPullRequest && pullRequestAction in ["opened", "reopened", "synchronize"])
           then:
               $let:
                   level:
@@ -131,7 +133,7 @@ tasks:
                       $merge:
                           - owner: "${ownerEmail}"
                             source: "${repoUrl}/raw/${head_sha}/.taskcluster.yml"
-                          - $if: 'tasks_for in ["github-push", "github-pull-request"]'
+                          - $if: 'tasks_for == "github-push" || isPullRequest'
                             then:
                                 name: "Decision Task"
                                 description: 'The task that creates all of the other tasks in the task graph'
@@ -151,7 +153,7 @@ tasks:
                   workerType: "decision"
 
                   tags:
-                      $if: 'tasks_for in ["github-push", "github-pull-request"]'
+                      $if: 'tasks_for == "github-push" || isPullRequest'
                       then:
                           createdForUser: "${ownerEmail}"
                           kind: decision-task
@@ -168,7 +170,7 @@ tasks:
                   routes:
                       $flatten:
                           - checks
-                          - $if: 'tasks_for != "github-pull-request"'
+                          - $if: '!isPullRequest'
                             then:
                                 - "tc-treeherder.v2.${project}.${head_sha}"
                             else: []
@@ -203,9 +205,9 @@ tasks:
                           in:
                               - 'assume:repo:${repoUrl[8:]}:branch:${short_head_ref}'
                       else:
-                          $if: 'tasks_for == "github-pull-request"'
+                          $if: 'isPullRequest'
                           then:
-                              - 'assume:repo:github.com/${event.pull_request.base.repo.full_name}:pull-request'
+                              - 'assume:repo:github.com/${event.pull_request.base.repo.full_name}:${tasks_for[7:]}'
                           else:
                               $if: 'tasks_for == "action"'
                               then:
@@ -229,7 +231,7 @@ tasks:
                       $if: "tasks_for == 'cron'"
                       then: low
                       else:
-                          $if: 'tasks_for in ["github-push", "github-pull-request"]'
+                          $if: 'tasks_for == "github-push" || isPullRequest'
                           then: very-low
                           else: lowest  # tasks_for == 'action'
                   retries: 5
@@ -247,7 +249,7 @@ tasks:
                                 TASKGRAPH_HEAD_REV: '${head_sha}'
                                 TASKGRAPH_REPOSITORY_TYPE: git
                                 REPOSITORIES: {$json: {taskgraph: Taskgraph}}
-                              - $if: 'tasks_for in ["github-pull-request"]'
+                              - $if: 'isPullRequest'
                                 then:
                                     TASKGRAPH_PULL_REQUEST_NUMBER: '${event.pull_request.number}'
                               - $if: 'tasks_for == "action"'
@@ -324,7 +326,7 @@ tasks:
                                 $merge:
                                     - machine:
                                           platform: gecko-decision
-                                    - $if: 'tasks_for in ["github-push", "github-pull-request"]'
+                                    - $if: 'tasks_for == "github-push" || isPullRequest'
                                       then:
                                           symbol: D
                                       else:

--- a/taskcluster/ci/codecov/kind.yml
+++ b/taskcluster/ci/codecov/kind.yml
@@ -35,6 +35,7 @@ tasks:
                 - codecov-uploader
             tests:
                 - coverage.xml
+        run-on-tasks-for: ["github-push", "github-pull-request"]
         run:
             using: run-task
             cwd: '{checkout}'

--- a/taskcluster/test/params/main-repo-pull-request-untrusted.yml
+++ b/taskcluster/test/params/main-repo-pull-request-untrusted.yml
@@ -18,4 +18,4 @@ pushdate: 0
 pushlog_id: '0'
 repository_type: git
 target_tasks_method: default
-tasks_for: github-pull-request
+tasks_for: github-pull-request-untrusted


### PR DESCRIPTION
This means pull requests opened by non-collaborators will assume a different role and have a different set of scopes associated to them.

For taskgraph, the only task we'd want to limit is the `codecov-upload` one to avoid leaking the codecov API token. So we add a `run-on-tasks-for` key here which will filter out tasks_for == "github-pull-request-untrusted".