### PR TITLE
fix: run initial verifications after 'taskgraph.register'

### DIFF
--- a/src/taskgraph/generator.py
+++ b/src/taskgraph/generator.py
@@ -249,15 +249,15 @@ class TaskGraphGenerator:
                     continue
 
     def _run(self):
-        # Initial verifications that don't depend on any generation state.
-        verifications("initial")
-
         logger.info("Loading graph configuration.")
         graph_config = load_graph_config(self.root_dir)
 
         yield ("graph_config", graph_config)
 
         graph_config.register()
+
+        # Initial verifications that don't depend on any generation state.
+        verifications("initial")
 
         if callable(self._parameters):
             parameters = self._parameters(graph_config)


### PR DESCRIPTION
This ensures projects that extend Taskgraph have an opportunity to set things up before we start running verifications (which often cause many modules to be imported.

This syncs a change with Gecko taskgraph.