### PR TITLE
fix: use 'parameters_loader' in generator.load_tasks_for_kind

### DIFF
--- a/src/taskgraph/generator.py
+++ b/src/taskgraph/generator.py
@@ -14,7 +14,7 @@ from .config import GraphConfig, load_graph_config
 from .graph import Graph
 from .morph import morph
 from .optimize.base import optimize_task_graph
-from .parameters import Parameters
+from .parameters import parameters_loader
 from .task import Task
 from .taskgraph import TaskGraph
 from .transforms.base import TransformConfig, TransformSequence
@@ -428,7 +428,7 @@ def load_tasks_for_kind(parameters, kind, root_dir=None):
     # make parameters read-write
     parameters = dict(parameters)
     parameters["target-kind"] = kind
-    parameters = Parameters(strict=False, **parameters)
+    parameters = parameters_loader(spec=None, strict=False, overrides=parameters)
     tgg = TaskGraphGenerator(root_dir=root_dir, parameters=parameters)
     return {
         task.task["metadata"]["name"]: task


### PR DESCRIPTION
This ensures that a project's custom parameters are registered when using this function.

Syncs a change from gecko_taskgraph.