### PR TITLE
fix: Catch `UnsupportedPlatformError` in order not to bust mach commands (bug 1793219)

### DIFF
--- a/src/taskgraph/parameters.py
+++ b/src/taskgraph/parameters.py
@@ -87,7 +87,19 @@ def _get_defaults(repo_root=None):
     except (CalledProcessError, mozilla_repo_urls.errors.InvalidRepoUrlError):
         repo_url = ""
         project = ""
-
+    except (mozilla_repo_urls.errors.UnsupportedPlatformError) as err:
+        repo_remote = repo.remote_name
+        """
+        Combine the error message printed by `UnsupportedPlatformError` with a hint
+        about what to do to fix the error: set the expected remote, as determined by
+        the `Repository` class, to a URL whose domain is supported. Include the list of
+        supported domains in the error message.
+        """
+        raise RuntimeError(
+           f"{str(err)}\n\n  Hint: your default remote is `{repo_remote}`, which points to"
+           f"{repo_url}"
+           f"\n  This script requires the `{repo_remote}` remote to point to a repository"
+           f"on one of these domains: {err.supported_platforms}")
     return {
         "base_repository": repo_url,
         "base_ref": "",

--- a/src/taskgraph/parameters.py
+++ b/src/taskgraph/parameters.py
@@ -84,23 +84,13 @@ def _get_defaults(repo_root=None):
         repo_url = repo.get_url()
         parsed_url = mozilla_repo_urls.parse(repo_url)
         project = parsed_url.repo_name
-    except (CalledProcessError, mozilla_repo_urls.errors.InvalidRepoUrlError):
+    except (
+        CalledProcessError,
+        mozilla_repo_urls.errors.InvalidRepoUrlError,
+        mozilla_repo_urls.errors.UnsupportedPlatformError,
+    ):
         repo_url = ""
         project = ""
-    except (mozilla_repo_urls.errors.UnsupportedPlatformError) as err:
-        repo_remote = repo.remote_name
-        """
-        Combine the error message printed by `UnsupportedPlatformError` with a hint
-        about what to do to fix the error: set the expected remote, as determined by
-        the `Repository` class, to a URL whose domain is supported. Include the list of
-        supported domains in the error message.
-        """
-        raise RuntimeError(
-            f"{str(err)}\n\n  Hint: your default remote is `{repo_remote}`, which points to"
-            f"{repo_url}"
-            f"\n  This script requires the `{repo_remote}` remote to point to a repository"
-            f"on one of these domains: {err.supported_platforms}"
-        )
     return {
         "base_repository": repo_url,
         "base_ref": "",

--- a/src/taskgraph/parameters.py
+++ b/src/taskgraph/parameters.py
@@ -96,10 +96,11 @@ def _get_defaults(repo_root=None):
         supported domains in the error message.
         """
         raise RuntimeError(
-           f"{str(err)}\n\n  Hint: your default remote is `{repo_remote}`, which points to"
-           f"{repo_url}"
-           f"\n  This script requires the `{repo_remote}` remote to point to a repository"
-           f"on one of these domains: {err.supported_platforms}")
+            f"{str(err)}\n\n  Hint: your default remote is `{repo_remote}`, which points to"
+            f"{repo_url}"
+            f"\n  This script requires the `{repo_remote}` remote to point to a repository"
+            f"on one of these domains: {err.supported_platforms}"
+        )
     return {
         "base_repository": repo_url,
         "base_ref": "",

--- a/src/taskgraph/parameters.py
+++ b/src/taskgraph/parameters.py
@@ -91,6 +91,7 @@ def _get_defaults(repo_root=None):
     ):
         repo_url = ""
         project = ""
+
     return {
         "base_repository": repo_url,
         "base_ref": "",


### PR DESCRIPTION
When the remote URL is rejected as unsupported, it's helpful to print a list of the platforms that are supported and explain that the default remote should be changed to point to a repository on one of these platforms.

**Note:** this patch depends on https://github.com/mozilla-releng/mozilla-repo-urls/pull/6 and shouldn't be merged until that patch is merged.