### PR TITLE
refactor!: drop support for `always_target` attribute

### DIFF
--- a/src/taskgraph/generator.py
+++ b/src/taskgraph/generator.py
@@ -359,17 +359,7 @@ class TaskGraphGenerator:
             for t in full_task_graph.tasks.values()
             if t.attributes["kind"] == "docker-image"
         }
-        # include all tasks with `always_target` set
-        always_target_tasks = {
-            t.label
-            for t in full_task_graph.tasks.values()
-            if t.attributes.get("always_target")
-        }
-        logger.info(
-            "Adding %d tasks with `always_target` attribute"
-            % (len(always_target_tasks) - len(always_target_tasks & target_tasks))
-        )
-        requested_tasks = target_tasks | docker_image_tasks | always_target_tasks
+        requested_tasks = target_tasks | docker_image_tasks
         target_graph = full_task_graph.graph.transitive_closure(requested_tasks)
         target_task_graph = TaskGraph(
             {l: all_tasks[l] for l in target_graph.nodes}, target_graph

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -65,36 +65,6 @@ def test_target_task_graph(maketgg):
     )
 
 
-def test_always_target_tasks(maketgg):
-    "The target_task_graph includes tasks with 'always_target'"
-    tgg_args = {
-        "target_tasks": ["_fake-t-0", "_fake-t-1", "_ignore-t-0", "_ignore-t-1"],
-        "kinds": [
-            ("_fake", {"task-defaults": {"optimization": {"odd": None}}}),
-            (
-                "_ignore",
-                {
-                    "task-defaults": {
-                        "attributes": {"always_target": True},
-                        "optimization": {"even": None},
-                    }
-                },
-            ),
-        ],
-        "params": {"optimize_target_tasks": False},
-    }
-    tgg = maketgg(**tgg_args)
-    assert sorted(tgg.target_task_set.tasks.keys()) == sorted(
-        ["_fake-t-0", "_fake-t-1", "_ignore-t-0", "_ignore-t-1"]
-    )
-    assert sorted(tgg.target_task_graph.tasks.keys()) == sorted(
-        ["_fake-t-0", "_fake-t-1", "_ignore-t-0", "_ignore-t-1", "_ignore-t-2"]
-    )
-    assert sorted(t.label for t in tgg.optimized_task_graph.tasks.values()) == sorted(
-        ["_fake-t-0", "_fake-t-1", "_ignore-t-0", "_ignore-t-1"]
-    )
-
-
 def test_optimized_task_graph(maketgg):
     "The optimized task graph contains task ids"
     tgg = maketgg(["_fake-t-2"])


### PR DESCRIPTION
BREAKING CHANGE

This is a feature that was cargo culted from Gecko, but likely isn't useful or needed outside of Gecko. We are moving it out of `generator.py` over there, and dropping the feature here.

If consumers do end up needing something like this, they can re-implement it similar to how Gecko does. We also look into re-introducing the functionality in core Taskgraph again if needed (with nicer implementation).

Issue: #29