### PR TITLE
ci: only run `github-push` tasks on main

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -108,7 +108,7 @@ tasks:
       in:
           $if: >
             tasks_for in ["action", "cron"]
-            || (tasks_for == "github-push" && head_ref[:10] != "refs/tags/")
+            || (tasks_for == "github-push" && head_branch == "refs/heads/main")
             || (isPullRequest && pullRequestAction in ["opened", "reopened", "synchronize"])
           then:
               $let:


### PR DESCRIPTION
Previously we were treating all non-main branches as level 3, which means anyone could run level 3 tasks (luckily Taskgraph doesn't really have any sensitive ones anyway).

By simply not running the tasks on non-main branch we also prevent duplicate tasks on PRs opened within the canonical repository (as opposed to a fork).