### PR TITLE
Bug 1796139 - deduplicate fetch-content with gecko

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [tool.black]
 line-length = 88
 extend-exclude = """(\
-  src/taskgraph/run-task|\
   taskcluster/scripts/external_tools)\
   """
 

--- a/src/taskgraph/run-task/fetch-content
+++ b/src/taskgraph/run-task/fetch-content
@@ -16,6 +16,7 @@ import multiprocessing
 import os
 import pathlib
 import random
+import re
 import stat
 import subprocess
 import sys
@@ -580,6 +581,14 @@ def git_checkout_archive(
     if repo.startswith("https://github.com/"):
         if not include_dot_git and not _github_submodule_required(repo, commit):
             log("Using github archive service to speedup archive creation")
+            # Always log sha1 info, either from commit or resolved from repo.
+            if re.match(r"^[a-fA-F0-9]{40}$", commit):
+                revision = commit
+            else:
+                ref_output = subprocess.check_output(["git", "ls-remote", repo,
+                                                      'refs/heads/' + commit])
+                revision, _ = ref_output.decode().split(maxsplit=1)
+            log("Fetching revision {}".format(revision))
             return _git_checkout_github_archive(dest_path, repo, commit, prefix)
 
     with tempfile.TemporaryDirectory() as td:

--- a/src/taskgraph/run-task/fetch-content
+++ b/src/taskgraph/run-task/fetch-content
@@ -31,6 +31,11 @@ try:
 except ImportError:
     zstandard = None
 
+try:
+    import certifi
+except ImportError:
+    certifi = None
+
 
 CONCURRENCY = multiprocessing.cpu_count()
 
@@ -179,7 +184,7 @@ def stream_download(url, sha256=None, size=None, headers=None):
         req_headers[key.strip()] = val.strip()
 
     req = urllib.request.Request(url, None, req_headers)
-    with urllib.request.urlopen(req) as fh:
+    with urllib.request.urlopen(req, cafile=certifi.where()) if certifi else urllib.request.urlopen(req) as fh:
         if not url.endswith('.gz') and fh.info().get('Content-Encoding') == 'gzip':
             fh = gzip.GzipFile(fileobj=fh)
 

--- a/src/taskgraph/run-task/fetch-content
+++ b/src/taskgraph/run-task/fetch-content
@@ -51,13 +51,13 @@ class IntegrityError(Exception):
 
 def ZstdCompressor(*args, **kwargs):
     if not zstandard:
-        raise ValueError('zstandard Python package not available')
+        raise ValueError("zstandard Python package not available")
     return zstandard.ZstdCompressor(*args, **kwargs)
 
 
 def ZstdDecompressor(*args, **kwargs):
     if not zstandard:
-        raise ValueError('zstandard Python package not available')
+        raise ValueError("zstandard Python package not available")
     return zstandard.ZstdDecompressor(*args, **kwargs)
 
 
@@ -72,7 +72,7 @@ def rename_after_close(fname, *args, **kwargs):
     manager.
     """
     path = pathlib.Path(fname)
-    tmp = path.with_name('%s.tmp' % path.name)
+    tmp = path.with_name("%s.tmp" % path.name)
     try:
         with tmp.open(*args, **kwargs) as fh:
             yield fh
@@ -132,7 +132,9 @@ def retrier(attempts=5, sleeptime=10, max_sleeptime=300, sleepscale=1.5, jitter=
     jitter = jitter or 0  # py35 barfs on the next line if jitter is None
     if jitter > sleeptime:
         # To prevent negative sleep times
-        raise Exception('jitter ({}) must be less than sleep time ({})'.format(jitter, sleeptime))
+        raise Exception(
+            "jitter ({}) must be less than sleep time ({})".format(jitter, sleeptime)
+        )
 
     sleeptime_real = sleeptime
     for _ in range(attempts):
@@ -154,7 +156,9 @@ def retrier(attempts=5, sleeptime=10, max_sleeptime=300, sleepscale=1.5, jitter=
 
         # Don't need to sleep the last time
         if _ < attempts - 1:
-            log("sleeping for %.2fs (attempt %i/%i)" % (sleeptime_real, _ + 1, attempts))
+            log(
+                "sleeping for %.2fs (attempt %i/%i)" % (sleeptime_real, _ + 1, attempts)
+            )
             time.sleep(sleeptime_real)
 
 
@@ -171,7 +175,7 @@ def stream_download(url, sha256=None, size=None, headers=None):
     content, it should be streamed to a file or memory and only operated
     on after the generator is exhausted without raising.
     """
-    log('Downloading %s' % url)
+    log("Downloading %s" % url)
     headers = headers or []
 
     h = hashlib.sha256()
@@ -184,8 +188,10 @@ def stream_download(url, sha256=None, size=None, headers=None):
         req_headers[key.strip()] = val.strip()
 
     req = urllib.request.Request(url, None, req_headers)
-    with urllib.request.urlopen(req, cafile=certifi.where()) if certifi else urllib.request.urlopen(req) as fh:
-        if not url.endswith('.gz') and fh.info().get('Content-Encoding') == 'gzip':
+    with urllib.request.urlopen(
+        req, cafile=certifi.where()
+    ) if certifi else urllib.request.urlopen(req) as fh:
+        if not url.endswith(".gz") and fh.info().get("Content-Encoding") == "gzip":
             fh = gzip.GzipFile(fileobj=fh)
 
         while True:
@@ -201,22 +207,26 @@ def stream_download(url, sha256=None, size=None, headers=None):
     duration = time.time() - t0
     digest = h.hexdigest()
 
-    log('%s resolved to %d bytes with sha256 %s in %.3fs' % (
-        url, length, digest, duration))
+    log(
+        "%s resolved to %d bytes with sha256 %s in %.3fs"
+        % (url, length, digest, duration)
+    )
 
     if size:
         if size == length:
-            log('Verified size of %s' % url)
+            log("Verified size of %s" % url)
         else:
-            raise IntegrityError('size mismatch on %s: wanted %d; got %d' % (
-                url, size, length))
+            raise IntegrityError(
+                "size mismatch on %s: wanted %d; got %d" % (url, size, length)
+            )
 
     if sha256:
         if digest == sha256:
-            log('Verified sha256 integrity of %s' % url)
+            log("Verified sha256 integrity of %s" % url)
         else:
-            raise IntegrityError('sha256 mismatch on %s: wanted %s; got %s' % (
-                url, sha256, digest))
+            raise IntegrityError(
+                "sha256 mismatch on %s: wanted %s; got %s" % (url, sha256, digest)
+            )
 
 
 def download_to_path(url, path, sha256=None, size=None, headers=None):
@@ -232,10 +242,12 @@ def download_to_path(url, path, sha256=None, size=None, headers=None):
 
     for _ in retrier(attempts=5, sleeptime=60):
         try:
-            log('Downloading %s to %s' % (url, path))
+            log("Downloading %s to %s" % (url, path))
 
-            with rename_after_close(path, 'wb') as fh:
-                for chunk in stream_download(url, sha256=sha256, size=size, headers=headers):
+            with rename_after_close(path, "wb") as fh:
+                for chunk in stream_download(
+                    url, sha256=sha256, size=size, headers=headers
+                ):
                     fh.write(chunk)
 
             return
@@ -254,7 +266,7 @@ def download_to_memory(url, sha256=None, size=None):
     data = b""
     for _ in retrier(attempts=5, sleeptime=60):
         try:
-            log('Downloading %s' % (url))
+            log("Downloading %s" % (url))
 
             for chunk in stream_download(url, sha256=sha256, size=size):
                 data += chunk
@@ -269,65 +281,64 @@ def download_to_memory(url, sha256=None, size=None):
     raise Exception("Download failed, no more retries!")
 
 
-def gpg_verify_path(path: pathlib.Path, public_key_data: bytes,
-                    signature_data: bytes):
+def gpg_verify_path(path: pathlib.Path, public_key_data: bytes, signature_data: bytes):
     """Verify that a filesystem path verifies using GPG.
 
     Takes a Path defining a file to verify. ``public_key_data`` contains
     bytes with GPG public key data. ``signature_data`` contains a signed
     GPG document to use with ``gpg --verify``.
     """
-    log('Validating GPG signature of %s' % path)
-    log('GPG key data:\n%s' % public_key_data.decode('ascii'))
+    log("Validating GPG signature of %s" % path)
+    log("GPG key data:\n%s" % public_key_data.decode("ascii"))
 
     with tempfile.TemporaryDirectory() as td:
         try:
             # --batch since we're running unattended.
-            gpg_args = ['gpg', '--homedir', td, '--batch']
+            gpg_args = ["gpg", "--homedir", td, "--batch"]
 
-            log('Importing GPG key...')
-            subprocess.run(gpg_args + ['--import'],
-                           input=public_key_data,
-                           check=True)
+            log("Importing GPG key...")
+            subprocess.run(gpg_args + ["--import"], input=public_key_data, check=True)
 
-            log('Verifying GPG signature...')
-            subprocess.run(gpg_args + ['--verify', '-', '%s' % path],
-                           input=signature_data,
-                           check=True)
+            log("Verifying GPG signature...")
+            subprocess.run(
+                gpg_args + ["--verify", "-", "%s" % path],
+                input=signature_data,
+                check=True,
+            )
 
-            log('GPG signature verified!')
+            log("GPG signature verified!")
         finally:
             # There is a race between the agent self-terminating and
             # shutil.rmtree() from the temporary directory cleanup that can
             # lead to exceptions. Kill the agent before cleanup to prevent this.
             env = dict(os.environ)
-            env['GNUPGHOME'] = td
-            subprocess.run(['gpgconf', '--kill', 'gpg-agent'], env=env)
+            env["GNUPGHOME"] = td
+            subprocess.run(["gpgconf", "--kill", "gpg-agent"], env=env)
 
 
 def open_tar_stream(path: pathlib.Path):
     """"""
-    if path.suffix == '.bz2':
-        return bz2.open(str(path), 'rb')
-    elif path.suffix == '.gz':
-        return gzip.open(str(path), 'rb')
-    elif path.suffix == '.xz':
-        return lzma.open(str(path), 'rb')
-    elif path.suffix == '.zst':
+    if path.suffix == ".bz2":
+        return bz2.open(str(path), "rb")
+    elif path.suffix == ".gz":
+        return gzip.open(str(path), "rb")
+    elif path.suffix == ".xz":
+        return lzma.open(str(path), "rb")
+    elif path.suffix == ".zst":
         dctx = ZstdDecompressor()
-        return dctx.stream_reader(path.open('rb'))
-    elif path.suffix == '.tar':
-        return path.open('rb')
+        return dctx.stream_reader(path.open("rb"))
+    elif path.suffix == ".tar":
+        return path.open("rb")
     else:
-        raise ValueError('unknown archive format for tar file: %s' % path)
+        raise ValueError("unknown archive format for tar file: %s" % path)
 
 
 def archive_type(path: pathlib.Path):
     """Attempt to identify a path as an extractable archive."""
-    if path.suffixes[-2:-1] == ['.tar']:
-        return 'tar'
-    elif path.suffix == '.zip':
-        return 'zip'
+    if path.suffixes[-2:-1] == [".tar"]:
+        return "tar"
+    elif path.suffix == ".zip":
+        return "zip"
     else:
         return None
 
@@ -339,12 +350,12 @@ def extract_archive(path, dest_dir, typ):
     path = path.resolve()
     dest_dir = dest_dir.resolve()
 
-    log('Extracting %s to %s' % (path, dest_dir))
+    log("Extracting %s to %s" % (path, dest_dir))
     t0 = time.time()
 
     # We pipe input to the decompressor program so that we can apply
     # custom decompressors that the program may not know about.
-    if typ == 'tar':
+    if typ == "tar":
         ifh = open_tar_stream(path)
         # On Windows, the tar program doesn't support things like symbolic
         # links, while Windows actually support them. The tarfile module in
@@ -352,24 +363,25 @@ def extract_archive(path, dest_dir, typ):
         # the tar program on Linux, only use tarfile on Windows (tarfile is
         # also not much slower on Windows, presumably because of the
         # notoriously bad I/O).
-        if sys.platform == 'win32':
-            tar = tarfile.open(fileobj=ifh, mode='r|')
+        if sys.platform == "win32":
+            tar = tarfile.open(fileobj=ifh, mode="r|")
             tar.extractall(str(dest_dir))
             args = []
         else:
-            args = ['tar', 'xf', '-']
+            args = ["tar", "xf", "-"]
             pipe_stdin = True
-    elif typ == 'zip':
+    elif typ == "zip":
         # unzip from stdin has wonky behavior. We don't use a pipe for it.
-        ifh = open(os.devnull, 'rb')
-        args = ['unzip', '-o', str(path)]
+        ifh = open(os.devnull, "rb")
+        args = ["unzip", "-o", str(path)]
         pipe_stdin = False
     else:
-        raise ValueError('unknown archive format: %s' % path)
+        raise ValueError("unknown archive format: %s" % path)
 
     if args:
-        with ifh, subprocess.Popen(args, cwd=str(dest_dir), bufsize=0,
-                                   stdin=subprocess.PIPE) as p:
+        with ifh, subprocess.Popen(
+            args, cwd=str(dest_dir), bufsize=0, stdin=subprocess.PIPE
+        ) as p:
             while True:
                 if not pipe_stdin:
                     break
@@ -381,46 +393,50 @@ def extract_archive(path, dest_dir, typ):
                 p.stdin.write(chunk)
 
         if p.returncode:
-            raise Exception('%r exited %d' % (args, p.returncode))
+            raise Exception("%r exited %d" % (args, p.returncode))
 
-    log('%s extracted in %.3fs' % (path, time.time() - t0))
+    log("%s extracted in %.3fs" % (path, time.time() - t0))
 
 
-def repack_archive(orig: pathlib.Path, dest: pathlib.Path,
-                   strip_components=0, prefix=''):
+def repack_archive(
+    orig: pathlib.Path, dest: pathlib.Path, strip_components=0, prefix=""
+):
     assert orig != dest
-    log('Repacking as %s' % dest)
+    log("Repacking as %s" % dest)
     orig_typ = archive_type(orig)
     typ = archive_type(dest)
     if not orig_typ:
-        raise Exception('Archive type not supported for %s' % orig.name)
+        raise Exception("Archive type not supported for %s" % orig.name)
     if not typ:
-        raise Exception('Archive type not supported for %s' % dest.name)
+        raise Exception("Archive type not supported for %s" % dest.name)
 
-    if dest.suffixes[-2:] != ['.tar', '.zst']:
-        raise Exception('Only producing .tar.zst archives is supported.')
+    if dest.suffixes[-2:] != [".tar", ".zst"]:
+        raise Exception("Only producing .tar.zst archives is supported.")
 
     if strip_components or prefix:
+
         def filter(name):
             if strip_components:
-                stripped = '/'.join(name.split('/')[strip_components:])
+                stripped = "/".join(name.split("/")[strip_components:])
                 if not stripped:
                     raise Exception(
-                        'Stripping %d components would remove files'
-                        % strip_components)
+                        "Stripping %d components would remove files" % strip_components
+                    )
                 name = stripped
             return prefix + name
+
     else:
         filter = None
 
-    with rename_after_close(dest, 'wb') as fh:
+    with rename_after_close(dest, "wb") as fh:
         ctx = ZstdCompressor()
-        if orig_typ == 'zip':
-            assert typ == 'tar'
+        if orig_typ == "zip":
+            assert typ == "tar"
             zip = zipfile.ZipFile(orig)
             # Convert the zip stream to a tar on the fly.
-            with ctx.stream_writer(fh) as compressor, \
-                    tarfile.open(fileobj=compressor, mode='w:') as tar:
+            with ctx.stream_writer(fh) as compressor, tarfile.open(
+                fileobj=compressor, mode="w:"
+            ) as tar:
                 for zipinfo in zip.infolist():
                     if zipinfo.is_dir():
                         continue
@@ -434,7 +450,8 @@ def repack_archive(orig: pathlib.Path, dest: pathlib.Path,
                     # care about accuracy, but rather about reproducibility,
                     # so we pick UTC.
                     time = datetime.datetime(
-                        *zipinfo.date_time, tzinfo=datetime.timezone.utc)
+                        *zipinfo.date_time, tzinfo=datetime.timezone.utc
+                    )
                     tarinfo.mtime = time.timestamp()
                     # 0 is MS-DOS, 3 is UNIX. Only in the latter case do we
                     # get anything useful for the tar file mode.
@@ -450,21 +467,21 @@ def repack_archive(orig: pathlib.Path, dest: pathlib.Path,
                     elif stat.S_ISREG(mode) or stat.S_IFMT(mode) == 0:
                         tar.addfile(tarinfo, zip.open(filename))
                     else:
-                        raise Exception('Unsupported file mode %o'
-                                        % stat.S_IFMT(mode))
+                        raise Exception("Unsupported file mode %o" % stat.S_IFMT(mode))
 
-        elif orig_typ == 'tar':
-            if typ == 'zip':
-                raise Exception('Repacking a tar to zip is not supported')
-            assert typ == 'tar'
+        elif orig_typ == "tar":
+            if typ == "zip":
+                raise Exception("Repacking a tar to zip is not supported")
+            assert typ == "tar"
 
             ifh = open_tar_stream(orig)
             if filter:
                 # To apply the filter, we need to open the tar stream and
                 # tweak it.
-                origtar = tarfile.open(fileobj=ifh, mode='r|')
-                with ctx.stream_writer(fh) as compressor, \
-                        tarfile.open(fileobj=compressor, mode='w:') as tar:
+                origtar = tarfile.open(fileobj=ifh, mode="r|")
+                with ctx.stream_writer(fh) as compressor, tarfile.open(
+                    fileobj=compressor, mode="w:"
+                ) as tar:
                     for tarinfo in origtar:
                         if tarinfo.isdir():
                             continue
@@ -486,7 +503,7 @@ def fetch_and_extract(url, dest_dir, extract=True, sha256=None, size=None):
     the destination directory.
     """
 
-    basename = urllib.parse.urlparse(url).path.split('/')[-1]
+    basename = urllib.parse.urlparse(url).path.split("/")[-1]
     dest_path = dest_dir / basename
 
     download_to_path(url, dest_path, sha256=sha256, size=size)
@@ -497,7 +514,7 @@ def fetch_and_extract(url, dest_dir, extract=True, sha256=None, size=None):
     typ = archive_type(dest_path)
     if typ:
         extract_archive(dest_path, dest_dir, typ)
-        log('Removing %s' % dest_path)
+        log("Removing %s" % dest_path)
         dest_path.unlink()
 
 
@@ -513,58 +530,76 @@ def fetch_urls(downloads):
             f.result()
 
 
-def git_checkout_archive(dest_path: pathlib.Path, repo: str, commit: str,
-                         prefix=None, ssh_key=None):
+def git_checkout_archive(
+    dest_path: pathlib.Path, repo: str, commit: str, prefix=None, ssh_key=None
+):
     """Produce an archive of the files comprising a Git checkout."""
     dest_path.parent.mkdir(parents=True, exist_ok=True)
 
-    if dest_path.suffixes[-2:] != ['.tar', '.zst']:
-        raise Exception('Only producing .tar.zst archives is supported.')
+    if dest_path.suffixes[-2:] != [".tar", ".zst"]:
+        raise Exception("Only producing .tar.zst archives is supported.")
 
     with tempfile.TemporaryDirectory() as td:
         temp_dir = pathlib.Path(td)
 
         if not prefix:
-            prefix = repo.rstrip('/').rsplit('/', 1)[-1]
+            prefix = repo.rstrip("/").rsplit("/", 1)[-1]
         git_dir = temp_dir / prefix
 
         # This could be faster with a shallow clone. However, Git requires a ref
         # to initiate a clone. Since the commit-ish may not refer to a ref, we
         # simply perform a full clone followed by a checkout.
-        print('cloning %s to %s' % (repo, git_dir))
+        print("cloning %s to %s" % (repo, git_dir))
 
         env = os.environ.copy()
         keypath = ""
         if ssh_key:
-            taskcluster_secret_url = api(os.environ.get('TASKCLUSTER_PROXY_URL'), "secrets", "v1", "secret/{keypath}".format(keypath=ssh_key))
-            taskcluster_secret = b''.join(stream_download(taskcluster_secret_url))
+            taskcluster_secret_url = api(
+                os.environ.get("TASKCLUSTER_PROXY_URL"),
+                "secrets",
+                "v1",
+                "secret/{keypath}".format(keypath=ssh_key),
+            )
+            taskcluster_secret = b"".join(stream_download(taskcluster_secret_url))
             taskcluster_secret = json.loads(taskcluster_secret)
-            sshkey = taskcluster_secret['secret']['ssh_privkey']
+            sshkey = taskcluster_secret["secret"]["ssh_privkey"]
 
             keypath = temp_dir.joinpath("ssh-key")
             keypath.write_text(sshkey)
             keypath.chmod(0o600)
 
-            env = {"GIT_SSH_COMMAND": "ssh -o 'StrictHostKeyChecking no' -i {keypath}".format(keypath=keypath)}
+            env = {
+                "GIT_SSH_COMMAND": "ssh -o 'StrictHostKeyChecking no' -i {keypath}".format(
+                    keypath=keypath
+                )
+            }
 
-        subprocess.run(['git', 'clone', '-n', repo, str(git_dir)],
-                       check=True, env=env)
+        subprocess.run(["git", "clone", "-n", repo, str(git_dir)], check=True, env=env)
 
-        subprocess.run(['git', 'checkout', commit],
-                       cwd=str(git_dir), check=True)
+        subprocess.run(["git", "checkout", commit], cwd=str(git_dir), check=True)
 
-        subprocess.run(['git', 'submodule', 'update', '--init'],
-                       cwd=str(git_dir), check=True)
+        subprocess.run(
+            ["git", "submodule", "update", "--init"], cwd=str(git_dir), check=True
+        )
 
         if keypath:
             os.remove(keypath)
 
-        print('creating archive %s of commit %s' % (dest_path, commit))
-        proc = subprocess.Popen([
-            'tar', 'cf', '-', '--exclude=.git', '-C', str(temp_dir), prefix,
-        ], stdout=subprocess.PIPE)
+        print("creating archive %s of commit %s" % (dest_path, commit))
+        proc = subprocess.Popen(
+            [
+                "tar",
+                "cf",
+                "-",
+                "--exclude=.git",
+                "-C",
+                str(temp_dir),
+                prefix,
+            ],
+            stdout=subprocess.PIPE,
+        )
 
-        with rename_after_close(dest_path, 'wb') as out:
+        with rename_after_close(dest_path, "wb") as out:
             ctx = ZstdCompressor()
             ctx.copy_stream(proc.stdout, out)
 
@@ -575,8 +610,13 @@ def command_git_checkout_archive(args):
     dest = pathlib.Path(args.dest)
 
     try:
-        git_checkout_archive(dest, args.repo, args.commit,
-                             prefix=args.path_prefix, ssh_key=args.ssh_key_secret)
+        git_checkout_archive(
+            dest,
+            args.repo,
+            args.commit,
+            prefix=args.path_prefix,
+            ssh_key=args.ssh_key_secret,
+        )
     except Exception:
         try:
             dest.unlink()
@@ -591,25 +631,26 @@ def command_static_url(args):
     gpg_env_key = args.gpg_key_env
 
     if bool(gpg_sig_url) != bool(gpg_env_key):
-        print('--gpg-sig-url and --gpg-key-env must both be defined')
+        print("--gpg-sig-url and --gpg-key-env must both be defined")
         return 1
 
     if gpg_sig_url:
-        gpg_signature = b''.join(stream_download(gpg_sig_url))
-        gpg_key = os.environb[gpg_env_key.encode('ascii')]
+        gpg_signature = b"".join(stream_download(gpg_sig_url))
+        gpg_key = os.environb[gpg_env_key.encode("ascii")]
 
     dest = pathlib.Path(args.dest)
     dest.parent.mkdir(parents=True, exist_ok=True)
 
-    basename = urllib.parse.urlparse(args.url).path.split('/')[-1]
-    if basename.endswith(''.join(dest.suffixes)):
+    basename = urllib.parse.urlparse(args.url).path.split("/")[-1]
+    if basename.endswith("".join(dest.suffixes)):
         dl_dest = dest
     else:
         dl_dest = dest.parent / basename
 
     try:
-        download_to_path(args.url, dl_dest, sha256=args.sha256, size=args.size,
-                         headers=args.headers)
+        download_to_path(
+            args.url, dl_dest, sha256=args.sha256, size=args.size, headers=args.headers
+        )
 
         if gpg_sig_url:
             gpg_verify_path(dl_dest, gpg_key, gpg_signature)
@@ -625,123 +666,147 @@ def command_static_url(args):
         raise
 
     if dl_dest != dest:
-        log('Removing %s' % dl_dest)
+        log("Removing %s" % dl_dest)
         dl_dest.unlink()
 
 
 def api(root_url, service, version, path):
     # taskcluster-lib-urls is not available when this script runs, so
     # simulate its behavior:
-    return '{root_url}/api/{service}/{version}/{path}'.format(
-            root_url=root_url, service=service, version=version, path=path)
+    return "{root_url}/api/{service}/{version}/{path}".format(
+        root_url=root_url, service=service, version=version, path=path
+    )
 
 
 def get_hash(fetch, root_url):
-    path = 'task/{task}/artifacts/{artifact}'.format(
-        task=fetch['task'], artifact='public/chain-of-trust.json')
-    url = api(root_url, 'queue', 'v1', path)
+    path = "task/{task}/artifacts/{artifact}".format(
+        task=fetch["task"], artifact="public/chain-of-trust.json"
+    )
+    url = api(root_url, "queue", "v1", path)
     cot = json.loads(download_to_memory(url))
-    return cot['artifacts'][fetch['artifact']]['sha256']
+    return cot["artifacts"][fetch["artifact"]]["sha256"]
 
 
 def command_task_artifacts(args):
     start = time.monotonic()
-    fetches = json.loads(os.environ['MOZ_FETCHES'])
+    fetches = json.loads(os.environ["MOZ_FETCHES"])
     downloads = []
     for fetch in fetches:
         extdir = pathlib.Path(args.dest)
-        if 'dest' in fetch:
+        if "dest" in fetch:
             # Note: normpath doesn't like pathlib.Path in python 3.5
-            extdir = pathlib.Path(os.path.normpath(str(extdir.joinpath(fetch['dest']))))
+            extdir = pathlib.Path(os.path.normpath(str(extdir.joinpath(fetch["dest"]))))
         extdir.mkdir(parents=True, exist_ok=True)
-        root_url = os.environ['TASKCLUSTER_ROOT_URL']
+        root_url = os.environ["TASKCLUSTER_ROOT_URL"]
         sha256 = None
-        if fetch.get('verify-hash'):
+        if fetch.get("verify-hash"):
             sha256 = get_hash(fetch, root_url)
-        if fetch['artifact'].startswith('public/'):
-            path = 'task/{task}/artifacts/{artifact}'.format(
-                    task=fetch['task'], artifact=fetch['artifact'])
-            url = api(root_url, 'queue', 'v1', path)
+        if fetch["artifact"].startswith("public/"):
+            path = "task/{task}/artifacts/{artifact}".format(
+                task=fetch["task"], artifact=fetch["artifact"]
+            )
+            url = api(root_url, "queue", "v1", path)
         else:
-            url = ('{proxy_url}/api/queue/v1/task/{task}/artifacts/{artifact}').format(
-                    proxy_url=os.environ['TASKCLUSTER_PROXY_URL'],
-                    task=fetch['task'],
-                    artifact=fetch['artifact'])
-        downloads.append((url, extdir, fetch['extract'], sha256))
+            url = ("{proxy_url}/api/queue/v1/task/{task}/artifacts/{artifact}").format(
+                proxy_url=os.environ["TASKCLUSTER_PROXY_URL"],
+                task=fetch["task"],
+                artifact=fetch["artifact"],
+            )
+        downloads.append((url, extdir, fetch["extract"], sha256))
 
     fetch_urls(downloads)
     end = time.monotonic()
 
     perfherder_data = {
-        'framework': {'name': 'build_metrics'},
-        'suites': [{
-            'name': 'fetch_content',
-            'value': end - start,
-            'lowerIsBetter': True,
-            'shouldAlert': False,
-            'subtests': [],
-        }],
+        "framework": {"name": "build_metrics"},
+        "suites": [
+            {
+                "name": "fetch_content",
+                "value": end - start,
+                "lowerIsBetter": True,
+                "shouldAlert": False,
+                "subtests": [],
+            }
+        ],
     }
-    print('PERFHERDER_DATA: {}'.format(json.dumps(perfherder_data)), file=sys.stderr)
+    print("PERFHERDER_DATA: {}".format(json.dumps(perfherder_data)), file=sys.stderr)
 
 
 def main():
     parser = argparse.ArgumentParser()
-    subparsers = parser.add_subparsers(title='sub commands')
+    subparsers = parser.add_subparsers(title="sub commands")
 
     git_checkout = subparsers.add_parser(
-        'git-checkout-archive',
-        help='Obtain an archive of files from a Git repository checkout')
+        "git-checkout-archive",
+        help="Obtain an archive of files from a Git repository checkout",
+    )
     git_checkout.set_defaults(func=command_git_checkout_archive)
-    git_checkout.add_argument('--path-prefix',
-                              help='Prefix for paths in produced archive')
-    git_checkout.add_argument('repo',
-                              help='URL to Git repository to be cloned')
-    git_checkout.add_argument('commit',
-                              help='Git commit to check out')
-    git_checkout.add_argument('dest',
-                              help='Destination path of archive')
-    git_checkout.add_argument('--ssh-key-secret',
-                              help='The scope path of the ssh key to used for checkout')
+    git_checkout.add_argument(
+        "--path-prefix", help="Prefix for paths in produced archive"
+    )
+    git_checkout.add_argument("repo", help="URL to Git repository to be cloned")
+    git_checkout.add_argument("commit", help="Git commit to check out")
+    git_checkout.add_argument("dest", help="Destination path of archive")
+    git_checkout.add_argument(
+        "--ssh-key-secret", help="The scope path of the ssh key to used for checkout"
+    )
 
-    url = subparsers.add_parser('static-url', help='Download a static URL')
+    url = subparsers.add_parser("static-url", help="Download a static URL")
     url.set_defaults(func=command_static_url)
-    url.add_argument('--sha256', required=True,
-                     help='SHA-256 of downloaded content')
-    url.add_argument('--size', required=True, type=int,
-                     help='Size of downloaded content, in bytes')
-    url.add_argument('--gpg-sig-url',
-                     help='URL containing signed GPG document validating '
-                          'URL to fetch')
-    url.add_argument('--gpg-key-env',
-                     help='Environment variable containing GPG key to validate')
-    url.add_argument('--strip-components', type=int, default=0,
-                     help='Number of leading components to strip from file '
-                          'names in the downloaded archive')
-    url.add_argument('--add-prefix', default='',
-                     help='Prefix to add to file names in the downloaded '
-                          'archive')
-    url.add_argument('-H', '--header', default=[], action='append', dest='headers',
-                     help='Header to send as part of the request, can be passed '
-                          'multiple times')
-    url.add_argument('url', help='URL to fetch')
-    url.add_argument('dest', help='Destination path')
+    url.add_argument("--sha256", required=True, help="SHA-256 of downloaded content")
+    url.add_argument(
+        "--size", required=True, type=int, help="Size of downloaded content, in bytes"
+    )
+    url.add_argument(
+        "--gpg-sig-url",
+        help="URL containing signed GPG document validating " "URL to fetch",
+    )
+    url.add_argument(
+        "--gpg-key-env", help="Environment variable containing GPG key to validate"
+    )
+    url.add_argument(
+        "--strip-components",
+        type=int,
+        default=0,
+        help="Number of leading components to strip from file "
+        "names in the downloaded archive",
+    )
+    url.add_argument(
+        "--add-prefix",
+        default="",
+        help="Prefix to add to file names in the downloaded " "archive",
+    )
+    url.add_argument(
+        "-H",
+        "--header",
+        default=[],
+        action="append",
+        dest="headers",
+        help="Header to send as part of the request, can be passed " "multiple times",
+    )
+    url.add_argument("url", help="URL to fetch")
+    url.add_argument("dest", help="Destination path")
 
-    artifacts = subparsers.add_parser('task-artifacts',
-                                      help='Fetch task artifacts')
+    artifacts = subparsers.add_parser("task-artifacts", help="Fetch task artifacts")
     artifacts.set_defaults(func=command_task_artifacts)
-    artifacts.add_argument('-d', '--dest', default=os.environ.get('MOZ_FETCHES_DIR'),
-                           help='Destination directory which will contain all '
-                                'artifacts (defaults to $MOZ_FETCHES_DIR)')
+    artifacts.add_argument(
+        "-d",
+        "--dest",
+        default=os.environ.get("MOZ_FETCHES_DIR"),
+        help="Destination directory which will contain all "
+        "artifacts (defaults to $MOZ_FETCHES_DIR)",
+    )
 
     args = parser.parse_args()
 
     if not args.dest:
-        parser.error('no destination directory specified, either pass in --dest '
-                     'or set $MOZ_FETCHES_DIR')
+        parser.error(
+            "no destination directory specified, either pass in --dest "
+            "or set $MOZ_FETCHES_DIR"
+        )
 
     return args.func(args)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/src/taskgraph/run-task/fetch-content
+++ b/src/taskgraph/run-task/fetch-content
@@ -536,24 +536,23 @@ def fetch_urls(downloads):
             f.result()
 
 
-def _git_checkout_github_archive(dest_path: pathlib.Path, repo: str,
-                                 commit: str, prefix: str):
-    'Use github archive generator to speed up github git repo cloning'
-    repo = repo.rstrip('/')
-    github_url = '{repo}/archive/{commit}.tar.gz'.format(**locals())
+def _git_checkout_github_archive(
+    dest_path: pathlib.Path, repo: str, commit: str, prefix: str
+):
+    "Use github archive generator to speed up github git repo cloning"
+    repo = repo.rstrip("/")
+    github_url = "{repo}/archive/{commit}.tar.gz".format(**locals())
 
     with tempfile.TemporaryDirectory() as td:
         temp_dir = pathlib.Path(td)
-        dl_dest = temp_dir / 'archive.tar.gz'
+        dl_dest = temp_dir / "archive.tar.gz"
         download_to_path(github_url, dl_dest)
-        repack_archive(dl_dest, dest_path,
-                       strip_components=1,
-                       prefix=prefix + '/')
+        repack_archive(dl_dest, dest_path, strip_components=1, prefix=prefix + "/")
 
 
 def _github_submodule_required(repo: str, commit: str):
-    'Use github API to check if submodules are used'
-    url = '{repo}/blob/{commit}/.gitmodules'.format(**locals())
+    "Use github API to check if submodules are used"
+    url = "{repo}/blob/{commit}/.gitmodules".format(**locals())
     try:
         status_code = urllib.request.urlopen(url).getcode()
         return status_code == 200
@@ -578,7 +577,7 @@ def git_checkout_archive(
     if dest_path.suffixes[-2:] != [".tar", ".zst"]:
         raise Exception("Only producing .tar.zst archives is supported.")
 
-    if repo.startswith('https://github.com/'):
+    if repo.startswith("https://github.com/"):
         if not include_dot_git and not _github_submodule_required(repo, commit):
             log("Using github archive service to speedup archive creation")
             return _git_checkout_github_archive(dest_path, repo, commit, prefix)

--- a/src/taskgraph/run-task/fetch-content
+++ b/src/taskgraph/run-task/fetch-content
@@ -587,7 +587,10 @@ def git_checkout_archive(
 
         subprocess.run(["git", "clone", "-n", repo, str(git_dir)], check=True, env=env)
 
-        subprocess.run(["git", "checkout", commit], cwd=str(git_dir), check=True)
+        # Always use a detached head so that git prints out what it checked out.
+        subprocess.run(
+            ["git", "checkout", "--detach", commit], cwd=str(git_dir), check=True
+        )
 
         # When including the .git, we want --depth 1, but a direct clone would not
         # necessarily be able to give us the right commit.

--- a/src/taskgraph/run-task/fetch-content
+++ b/src/taskgraph/run-task/fetch-content
@@ -536,6 +536,31 @@ def fetch_urls(downloads):
             f.result()
 
 
+def _git_checkout_github_archive(dest_path: pathlib.Path, repo: str,
+                                 commit: str, prefix: str):
+    'Use github archive generator to speed up github git repo cloning'
+    repo = repo.rstrip('/')
+    github_url = '{repo}/archive/{commit}.tar.gz'.format(**locals())
+
+    with tempfile.TemporaryDirectory() as td:
+        temp_dir = pathlib.Path(td)
+        dl_dest = temp_dir / 'archive.tar.gz'
+        download_to_path(github_url, dl_dest)
+        repack_archive(dl_dest, dest_path,
+                       strip_components=1,
+                       prefix=prefix + '/')
+
+
+def _github_submodule_required(repo: str, commit: str):
+    'Use github API to check if submodules are used'
+    url = '{repo}/blob/{commit}/.gitmodules'.format(**locals())
+    try:
+        status_code = urllib.request.urlopen(url).getcode()
+        return status_code == 200
+    except:
+        return False
+
+
 def git_checkout_archive(
     dest_path: pathlib.Path,
     repo: str,
@@ -547,14 +572,20 @@ def git_checkout_archive(
     """Produce an archive of the files comprising a Git checkout."""
     dest_path.parent.mkdir(parents=True, exist_ok=True)
 
+    if not prefix:
+        prefix = repo.rstrip("/").rsplit("/", 1)[-1]
+
     if dest_path.suffixes[-2:] != [".tar", ".zst"]:
         raise Exception("Only producing .tar.zst archives is supported.")
+
+    if repo.startswith('https://github.com/'):
+        if not include_dot_git and not _github_submodule_required(repo, commit):
+            log("Using github archive service to speedup archive creation")
+            return _git_checkout_github_archive(dest_path, repo, commit, prefix)
 
     with tempfile.TemporaryDirectory() as td:
         temp_dir = pathlib.Path(td)
 
-        if not prefix:
-            prefix = repo.rstrip("/").rsplit("/", 1)[-1]
         git_dir = temp_dir / prefix
 
         # This could be faster with a shallow clone. However, Git requires a ref

--- a/src/taskgraph/run-task/fetch-content
+++ b/src/taskgraph/run-task/fetch-content
@@ -248,6 +248,27 @@ def download_to_path(url, path, sha256=None, size=None, headers=None):
     raise Exception("Download failed, no more retries!")
 
 
+def download_to_memory(url, sha256=None, size=None):
+    """Download a URL to memory, possibly with verification."""
+
+    data = b""
+    for _ in retrier(attempts=5, sleeptime=60):
+        try:
+            log('Downloading %s' % (url))
+
+            for chunk in stream_download(url, sha256=sha256, size=size):
+                data += chunk
+
+            return data
+        except IntegrityError:
+            raise
+        except Exception as e:
+            log("Download failed: {}".format(e))
+            continue
+
+    raise Exception("Download failed, no more retries!")
+
+
 def gpg_verify_path(path: pathlib.Path, public_key_data: bytes,
                     signature_data: bytes):
     """Verify that a filesystem path verifies using GPG.
@@ -612,6 +633,14 @@ def api(root_url, service, version, path):
             root_url=root_url, service=service, version=version, path=path)
 
 
+def get_hash(fetch, root_url):
+    path = 'task/{task}/artifacts/{artifact}'.format(
+        task=fetch['task'], artifact='public/chain-of-trust.json')
+    url = api(root_url, 'queue', 'v1', path)
+    cot = json.loads(download_to_memory(url))
+    return cot['artifacts'][fetch['artifact']]['sha256']
+
+
 def command_task_artifacts(args):
     start = time.monotonic()
     fetches = json.loads(os.environ['MOZ_FETCHES'])
@@ -623,6 +652,9 @@ def command_task_artifacts(args):
             extdir = pathlib.Path(os.path.normpath(str(extdir.joinpath(fetch['dest']))))
         extdir.mkdir(parents=True, exist_ok=True)
         root_url = os.environ['TASKCLUSTER_ROOT_URL']
+        sha256 = None
+        if fetch.get('verify-hash'):
+            sha256 = get_hash(fetch, root_url)
         if fetch['artifact'].startswith('public/'):
             path = 'task/{task}/artifacts/{artifact}'.format(
                     task=fetch['task'], artifact=fetch['artifact'])
@@ -632,7 +664,7 @@ def command_task_artifacts(args):
                     proxy_url=os.environ['TASKCLUSTER_PROXY_URL'],
                     task=fetch['task'],
                     artifact=fetch['artifact'])
-        downloads.append((url, extdir, fetch['extract']))
+        downloads.append((url, extdir, fetch['extract'], sha256))
 
     fetch_urls(downloads)
     end = time.monotonic()

--- a/src/taskgraph/run-task/fetch-content
+++ b/src/taskgraph/run-task/fetch-content
@@ -537,7 +537,12 @@ def fetch_urls(downloads):
 
 
 def git_checkout_archive(
-    dest_path: pathlib.Path, repo: str, commit: str, prefix=None, ssh_key=None
+    dest_path: pathlib.Path,
+    repo: str,
+    commit: str,
+    prefix=None,
+    ssh_key=None,
+    include_dot_git=False,
 ):
     """Produce an archive of the files comprising a Git checkout."""
     dest_path.parent.mkdir(parents=True, exist_ok=True)
@@ -584,20 +589,50 @@ def git_checkout_archive(
 
         subprocess.run(["git", "checkout", commit], cwd=str(git_dir), check=True)
 
+        # When including the .git, we want --depth 1, but a direct clone would not
+        # necessarily be able to give us the right commit.
+        if include_dot_git:
+            initial_clone = git_dir.with_name(git_dir.name + ".orig")
+            git_dir.rename(initial_clone)
+            subprocess.run(
+                [
+                    "git",
+                    "clone",
+                    "file://" + str(initial_clone),
+                    str(git_dir),
+                    "--depth",
+                    "1",
+                ],
+                check=True,
+            )
+            subprocess.run(
+                ["git", "remote", "set-url", "origin", repo],
+                cwd=str(git_dir),
+                check=True,
+            )
+
+        # --depth 1 can induce more work on the server side, so only use it for
+        # submodule initialization when we want to keep the .git directory.
+        depth = ["--depth", "1"] if include_dot_git else []
         subprocess.run(
-            ["git", "submodule", "update", "--init"], cwd=str(git_dir), check=True
+            ["git", "submodule", "update", "--init"] + depth,
+            cwd=str(git_dir),
+            check=True,
         )
 
         if keypath:
             os.remove(keypath)
 
         print("creating archive %s of commit %s" % (dest_path, commit))
+        exclude_dot_git = [] if include_dot_git else ["--exclude=.git"]
         proc = subprocess.Popen(
             [
                 "tar",
                 "cf",
                 "-",
-                "--exclude=.git",
+            ]
+            + exclude_dot_git
+            + [
                 "-C",
                 str(temp_dir),
                 prefix,
@@ -622,6 +657,7 @@ def command_git_checkout_archive(args):
             args.commit,
             prefix=args.path_prefix,
             ssh_key=args.ssh_key_secret,
+            include_dot_git=args.include_dot_git,
         )
     except Exception:
         try:
@@ -755,6 +791,9 @@ def main():
     git_checkout.add_argument("dest", help="Destination path of archive")
     git_checkout.add_argument(
         "--ssh-key-secret", help="The scope path of the ssh key to used for checkout"
+    )
+    git_checkout.add_argument(
+        "--include-dot-git", action="store_true", help="Include the .git directory"
     )
 
     url = subparsers.add_parser("static-url", help="Download a static URL")

--- a/src/taskgraph/run-task/fetch-content
+++ b/src/taskgraph/run-task/fetch-content
@@ -508,10 +508,13 @@ def git_checkout_archive(dest_path: pathlib.Path, repo: str, commit: str,
         # to initiate a clone. Since the commit-ish may not refer to a ref, we
         # simply perform a full clone followed by a checkout.
         print('cloning %s to %s' % (repo, git_dir))
-        subprocess.run(['git', 'clone', '--recurse-submodules', repo, str(git_dir)],
+        subprocess.run(['git', 'clone', '-n', repo, str(git_dir)],
                        check=True)
 
-        subprocess.run(['git', 'checkout', '--recurse-submodules', commit],
+        subprocess.run(['git', 'checkout', commit],
+                       cwd=str(git_dir), check=True)
+
+        subprocess.run(['git', 'submodule', 'update', '--init'],
                        cwd=str(git_dir), check=True)
 
         print('creating archive %s of commit %s' % (dest_path, commit))

--- a/src/taskgraph/run-task/fetch-content
+++ b/src/taskgraph/run-task/fetch-content
@@ -587,9 +587,6 @@ def command_static_url(args):
 def api(root_url, service, version, path):
     # taskcluster-lib-urls is not available when this script runs, so
     # simulate its behavior:
-    if root_url == 'https://taskcluster.net':
-        return 'https://{service}.taskcluster.net/{version}/{path}'.format(
-                service=service, version=version, path=path)
     return '{root_url}/api/{service}/{version}/{path}'.format(
             root_url=root_url, service=service, version=version, path=path)
 

--- a/src/taskgraph/run-task/fetch-content
+++ b/src/taskgraph/run-task/fetch-content
@@ -480,12 +480,18 @@ def repack_archive(
                 # tweak it.
                 origtar = tarfile.open(fileobj=ifh, mode="r|")
                 with ctx.stream_writer(fh) as compressor, tarfile.open(
-                    fileobj=compressor, mode="w:"
+                    fileobj=compressor,
+                    mode="w:",
+                    format=origtar.format,
                 ) as tar:
                     for tarinfo in origtar:
                         if tarinfo.isdir():
                             continue
                         tarinfo.name = filter(tarinfo.name)
+                        if "path" in tarinfo.pax_headers:
+                            tarinfo.pax_headers["path"] = filter(
+                                tarinfo.pax_headers["path"]
+                            )
                         if tarinfo.isfile():
                             tar.addfile(tarinfo, origtar.extractfile(tarinfo))
                         else:

--- a/src/taskgraph/run-task/fetch-content
+++ b/src/taskgraph/run-task/fetch-content
@@ -469,7 +469,10 @@ def repack_archive(orig: pathlib.Path, dest: pathlib.Path,
                         if tarinfo.isdir():
                             continue
                         tarinfo.name = filter(tarinfo.name)
-                        tar.addfile(tarinfo, origtar.extractfile(tarinfo))
+                        if tarinfo.isfile():
+                            tar.addfile(tarinfo, origtar.extractfile(tarinfo))
+                        else:
+                            tar.addfile(tarinfo)
             else:
                 # We only change compression here. The tar stream is unchanged.
                 ctx.copy_stream(ifh, fh)

--- a/src/taskgraph/run-task/fetch-content
+++ b/src/taskgraph/run-task/fetch-content
@@ -598,7 +598,8 @@ def command_task_artifacts(args):
     for fetch in fetches:
         extdir = pathlib.Path(args.dest)
         if 'dest' in fetch:
-            extdir = extdir.joinpath(fetch['dest'])
+            # Note: normpath doesn't like pathlib.Path in python 3.5
+            extdir = pathlib.Path(os.path.normpath(str(extdir.joinpath(fetch['dest']))))
         extdir.mkdir(parents=True, exist_ok=True)
         root_url = os.environ['TASKCLUSTER_ROOT_URL']
         if fetch['artifact'].startswith('public/'):

--- a/src/taskgraph/run-task/fetch-content
+++ b/src/taskgraph/run-task/fetch-content
@@ -490,7 +490,7 @@ def fetch_urls(downloads):
 
 
 def git_checkout_archive(dest_path: pathlib.Path, repo: str, commit: str,
-                         prefix=None):
+                         prefix=None, ssh_key=None):
     """Produce an archive of the files comprising a Git checkout."""
     dest_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -508,14 +508,32 @@ def git_checkout_archive(dest_path: pathlib.Path, repo: str, commit: str,
         # to initiate a clone. Since the commit-ish may not refer to a ref, we
         # simply perform a full clone followed by a checkout.
         print('cloning %s to %s' % (repo, git_dir))
+
+        env = os.environ.copy()
+        keypath = ""
+        if ssh_key:
+            taskcluster_secret_url = api(os.environ.get('TASKCLUSTER_PROXY_URL'), "secrets", "v1", "secret/{keypath}".format(keypath=ssh_key))
+            taskcluster_secret = b''.join(stream_download(taskcluster_secret_url))
+            taskcluster_secret = json.loads(taskcluster_secret)
+            sshkey = taskcluster_secret['secret']['ssh_privkey']
+
+            keypath = temp_dir.joinpath("ssh-key")
+            keypath.write_text(sshkey)
+            keypath.chmod(0o600)
+
+            env = {"GIT_SSH_COMMAND": "ssh -o 'StrictHostKeyChecking no' -i {keypath}".format(keypath=keypath)}
+
         subprocess.run(['git', 'clone', '-n', repo, str(git_dir)],
-                       check=True)
+                       check=True, env=env)
 
         subprocess.run(['git', 'checkout', commit],
                        cwd=str(git_dir), check=True)
 
         subprocess.run(['git', 'submodule', 'update', '--init'],
                        cwd=str(git_dir), check=True)
+
+        if keypath:
+            os.remove(keypath)
 
         print('creating archive %s of commit %s' % (dest_path, commit))
         proc = subprocess.Popen([
@@ -534,7 +552,7 @@ def command_git_checkout_archive(args):
 
     try:
         git_checkout_archive(dest, args.repo, args.commit,
-                             prefix=args.path_prefix)
+                             prefix=args.path_prefix, ssh_key=args.ssh_key_secret)
     except Exception:
         try:
             dest.unlink()
@@ -648,6 +666,8 @@ def main():
                               help='Git commit to check out')
     git_checkout.add_argument('dest',
                               help='Destination path of archive')
+    git_checkout.add_argument('--ssh-key-secret',
+                              help='The scope path of the ssh key to used for checkout')
 
     url = subparsers.add_parser('static-url', help='Download a static URL')
     url.set_defaults(func=command_static_url)

--- a/src/taskgraph/run-task/robustcheckout.py
+++ b/src/taskgraph/run-task/robustcheckout.py
@@ -9,6 +9,7 @@ from a source repo using best practices to ensure optimal clone
 times and storage efficiency.
 """
 
+from __future__ import absolute_import
 
 import contextlib
 import json
@@ -40,8 +41,8 @@ from mercurial import (
 # Causes worker to purge caches on process exit and for task to retry.
 EXIT_PURGE_CACHE = 72
 
-testedwith = b'4.5 4.6 4.7 4.8 4.9 5.0 5.1 5.2 5.3 5.4 5.5'
-minimumhgversion = b'4.5'
+testedwith = b"4.5 4.6 4.7 4.8 4.9 5.0 5.1 5.2 5.3 5.4 5.5 5.6 5.7 5.8 5.9"
+minimumhgversion = b"4.5"
 
 cmdtable = {}
 command = registrar.command(cmdtable)
@@ -49,41 +50,60 @@ command = registrar.command(cmdtable)
 configtable = {}
 configitem = registrar.configitem(configtable)
 
-configitem(b'robustcheckout', b'retryjittermin', default=configitems.dynamicdefault)
-configitem(b'robustcheckout', b'retryjittermax', default=configitems.dynamicdefault)
+configitem(b"robustcheckout", b"retryjittermin", default=configitems.dynamicdefault)
+configitem(b"robustcheckout", b"retryjittermax", default=configitems.dynamicdefault)
 
 
 def getsparse():
     from mercurial import sparse
+
     return sparse
 
 
 def peerlookup(remote, v):
-    # TRACKING hg46 4.6 added commandexecutor API.
-    if util.safehasattr(remote, 'commandexecutor'):
-        with remote.commandexecutor() as e:
-            return e.callcommand(b'lookup', {b'key': v}).result()
-    else:
-        return remote.lookup(v)
+    with remote.commandexecutor() as e:
+        return e.callcommand(b"lookup", {b"key": v}).result()
 
 
-@command(b'robustcheckout', [
-    (b'', b'upstream', b'', b'URL of upstream repo to clone from'),
-    (b'r', b'revision', b'', b'Revision to check out'),
-    (b'b', b'branch', b'', b'Branch to check out'),
-    (b'', b'purge', False, b'Whether to purge the working directory'),
-    (b'', b'sharebase', b'', b'Directory where shared repos should be placed'),
-    (b'', b'networkattempts', 3, b'Maximum number of attempts for network '
-                                 b'operations'),
-    (b'', b'sparseprofile', b'', b'Sparse checkout profile to use (path in repo)'),
-    (b'U', b'noupdate', False, b'the clone will include an empty working directory\n'
-                               b'(only a repository)'),
+@command(
+    b"robustcheckout",
+    [
+        (b"", b"upstream", b"", b"URL of upstream repo to clone from"),
+        (b"r", b"revision", b"", b"Revision to check out"),
+        (b"b", b"branch", b"", b"Branch to check out"),
+        (b"", b"purge", False, b"Whether to purge the working directory"),
+        (b"", b"sharebase", b"", b"Directory where shared repos should be placed"),
+        (
+            b"",
+            b"networkattempts",
+            3,
+            b"Maximum number of attempts for network " b"operations",
+        ),
+        (b"", b"sparseprofile", b"", b"Sparse checkout profile to use (path in repo)"),
+        (
+            b"U",
+            b"noupdate",
+            False,
+            b"the clone will include an empty working directory\n"
+            b"(only a repository)",
+        ),
     ],
-    b'[OPTION]... URL DEST',
-    norepo=True)
-def robustcheckout(ui, url, dest, upstream=None, revision=None, branch=None,
-                   purge=False, sharebase=None, networkattempts=None,
-                   sparseprofile=None, noupdate=False):
+    b"[OPTION]... URL DEST",
+    norepo=True,
+)
+def robustcheckout(
+    ui,
+    url,
+    dest,
+    upstream=None,
+    revision=None,
+    branch=None,
+    purge=False,
+    sharebase=None,
+    networkattempts=None,
+    sparseprofile=None,
+    noupdate=False,
+):
     """Ensure a working copy has the specified revision checked out.
 
     Repository data is automatically pooled into the common directory
@@ -115,21 +135,28 @@ def robustcheckout(ui, url, dest, upstream=None, revision=None, branch=None,
     4.3 or newer and the ``sparse`` extension must be enabled.
     """
     if not revision and not branch:
-        raise error.Abort(b'must specify one of --revision or --branch')
+        raise error.Abort(b"must specify one of --revision or --branch")
 
     if revision and branch:
-        raise error.Abort(b'cannot specify both --revision and --branch')
+        raise error.Abort(b"cannot specify both --revision and --branch")
 
     # Require revision to look like a SHA-1.
     if revision:
-        if len(revision) < 12 or len(revision) > 40 or not re.match(b'^[a-f0-9]+$', revision):
-            raise error.Abort(b'--revision must be a SHA-1 fragment 12-40 '
-                              b'characters long')
+        if (
+            len(revision) < 12
+            or len(revision) > 40
+            or not re.match(b"^[a-f0-9]+$", revision)
+        ):
+            raise error.Abort(
+                b"--revision must be a SHA-1 fragment 12-40 " b"characters long"
+            )
 
-    sharebase = sharebase or ui.config(b'share', b'pool')
+    sharebase = sharebase or ui.config(b"share", b"pool")
     if not sharebase:
-        raise error.Abort(b'share base directory not defined; refusing to operate',
-                          hint=b'define share.pool config option or pass --sharebase')
+        raise error.Abort(
+            b"share base directory not defined; refusing to operate",
+            hint=b"define share.pool config option or pass --sharebase",
+        )
 
     # Sparse profile support was added in Mercurial 4.3, where it was highly
     # experimental. Because of the fragility of it, we only support sparse
@@ -139,16 +166,17 @@ def robustcheckout(ui, url, dest, upstream=None, revision=None, branch=None,
     # fast if we can't satisfy the desired checkout request.
     if sparseprofile:
         try:
-            extensions.find(b'sparse')
+            extensions.find(b"sparse")
         except KeyError:
-            raise error.Abort(b'sparse extension must be enabled to use '
-                              b'--sparseprofile')
+            raise error.Abort(
+                b"sparse extension must be enabled to use " b"--sparseprofile"
+            )
 
-    ui.warn(b'(using Mercurial %s)\n' % util.version())
+    ui.warn(b"(using Mercurial %s)\n" % util.version())
 
     # worker.backgroundclose only makes things faster if running anti-virus,
     # which our automation doesn't. Disable it.
-    ui.setconfig(b'worker', b'backgroundclose', False)
+    ui.setconfig(b"worker", b"backgroundclose", False)
 
     # By default the progress bar starts after 3s and updates every 0.1s. We
     # change this so it shows and updates every 1.0s.
@@ -156,9 +184,9 @@ def robustcheckout(ui, url, dest, upstream=None, revision=None, branch=None,
     # even if there is no known TTY.
     # We make the config change here instead of in a config file because
     # otherwise we're at the whim of whatever configs are used in automation.
-    ui.setconfig(b'progress', b'delay', 1.0)
-    ui.setconfig(b'progress', b'refresh', 1.0)
-    ui.setconfig(b'progress', b'assume-tty', True)
+    ui.setconfig(b"progress", b"delay", 1.0)
+    ui.setconfig(b"progress", b"refresh", 1.0)
+    ui.setconfig(b"progress", b"assume-tty", True)
 
     sharebase = os.path.realpath(sharebase)
 
@@ -167,9 +195,21 @@ def robustcheckout(ui, url, dest, upstream=None, revision=None, branch=None,
     start = time.time()
 
     try:
-        return _docheckout(ui, url, dest, upstream, revision, branch, purge,
-                           sharebase, optimes, behaviors, networkattempts,
-                           sparse_profile=sparseprofile, noupdate=noupdate)
+        return _docheckout(
+            ui,
+            url,
+            dest,
+            upstream,
+            revision,
+            branch,
+            purge,
+            sharebase,
+            optimes,
+            behaviors,
+            networkattempts,
+            sparse_profile=sparseprofile,
+            noupdate=noupdate,
+        )
     finally:
         overall = time.time() - start
 
@@ -177,89 +217,118 @@ def robustcheckout(ui, url, dest, upstream=None, revision=None, branch=None,
         # the various "flavors" of operations.
 
         # ``overall`` is always the total operation time.
-        optimes.append(('overall', overall))
+        optimes.append(("overall", overall))
 
         def record_op(name):
             # If special behaviors due to "corrupt" storage occur, we vary the
             # name to convey that.
-            if 'remove-store' in behaviors:
-                name += '_rmstore'
-            if 'remove-wdir' in behaviors:
-                name += '_rmwdir'
+            if "remove-store" in behaviors:
+                name += "_rmstore"
+            if "remove-wdir" in behaviors:
+                name += "_rmwdir"
 
             optimes.append((name, overall))
 
         # We break out overall operations primarily by their network interaction
         # We have variants within for working directory operations.
-        if 'clone' in behaviors and 'create-store' in behaviors:
-            record_op('overall_clone')
+        if "clone" in behaviors and "create-store" in behaviors:
+            record_op("overall_clone")
 
-            if 'sparse-update' in behaviors:
-                record_op('overall_clone_sparsecheckout')
+            if "sparse-update" in behaviors:
+                record_op("overall_clone_sparsecheckout")
             else:
-                record_op('overall_clone_fullcheckout')
+                record_op("overall_clone_fullcheckout")
 
-        elif 'pull' in behaviors or 'clone' in behaviors:
-            record_op('overall_pull')
+        elif "pull" in behaviors or "clone" in behaviors:
+            record_op("overall_pull")
 
-            if 'sparse-update' in behaviors:
-                record_op('overall_pull_sparsecheckout')
+            if "sparse-update" in behaviors:
+                record_op("overall_pull_sparsecheckout")
             else:
-                record_op('overall_pull_fullcheckout')
+                record_op("overall_pull_fullcheckout")
 
-            if 'empty-wdir' in behaviors:
-                record_op('overall_pull_emptywdir')
+            if "empty-wdir" in behaviors:
+                record_op("overall_pull_emptywdir")
             else:
-                record_op('overall_pull_populatedwdir')
+                record_op("overall_pull_populatedwdir")
 
         else:
-            record_op('overall_nopull')
+            record_op("overall_nopull")
 
-            if 'sparse-update' in behaviors:
-                record_op('overall_nopull_sparsecheckout')
+            if "sparse-update" in behaviors:
+                record_op("overall_nopull_sparsecheckout")
             else:
-                record_op('overall_nopull_fullcheckout')
+                record_op("overall_nopull_fullcheckout")
 
-            if 'empty-wdir' in behaviors:
-                record_op('overall_nopull_emptywdir')
+            if "empty-wdir" in behaviors:
+                record_op("overall_nopull_emptywdir")
             else:
-                record_op('overall_nopull_populatedwdir')
+                record_op("overall_nopull_populatedwdir")
 
         server_url = urllibcompat.urlreq.urlparse(url).netloc
 
-        if 'TASKCLUSTER_INSTANCE_TYPE' in os.environ:
+        if "TASKCLUSTER_INSTANCE_TYPE" in os.environ:
             perfherder = {
-                'framework': {
-                    'name': 'vcs',
+                "framework": {
+                    "name": "vcs",
                 },
-                'suites': [],
+                "suites": [],
             }
             for op, duration in optimes:
-                perfherder['suites'].append({
-                    'name': op,
-                    'value': duration,
-                    'lowerIsBetter': True,
-                    'shouldAlert': False,
-                    'serverUrl': server_url.decode('utf-8'),
-                    'hgVersion': util.version().decode('utf-8'),
-                    'extraOptions': [os.environ['TASKCLUSTER_INSTANCE_TYPE']],
-                    'subtests': [],
-                })
-            ui.write(b'PERFHERDER_DATA: %s\n' %
-                     pycompat.bytestr(json.dumps(perfherder, sort_keys=True)))
+                perfherder["suites"].append(
+                    {
+                        "name": op,
+                        "value": duration,
+                        "lowerIsBetter": True,
+                        "shouldAlert": False,
+                        "serverUrl": server_url.decode("utf-8"),
+                        "hgVersion": util.version().decode("utf-8"),
+                        "extraOptions": [os.environ["TASKCLUSTER_INSTANCE_TYPE"]],
+                        "subtests": [],
+                    }
+                )
+            ui.write(
+                b"PERFHERDER_DATA: %s\n"
+                % pycompat.bytestr(json.dumps(perfherder, sort_keys=True))
+            )
 
-def _docheckout(ui, url, dest, upstream, revision, branch, purge, sharebase,
-                optimes, behaviors, networkattemptlimit, networkattempts=None,
-                sparse_profile=None, noupdate=False):
+
+def _docheckout(
+    ui,
+    url,
+    dest,
+    upstream,
+    revision,
+    branch,
+    purge,
+    sharebase,
+    optimes,
+    behaviors,
+    networkattemptlimit,
+    networkattempts=None,
+    sparse_profile=None,
+    noupdate=False,
+):
     if not networkattempts:
         networkattempts = [1]
 
     def callself():
-        return _docheckout(ui, url, dest, upstream, revision, branch, purge,
-                           sharebase, optimes, behaviors, networkattemptlimit,
-                           networkattempts=networkattempts,
-                           sparse_profile=sparse_profile,
-                           noupdate=noupdate)
+        return _docheckout(
+            ui,
+            url,
+            dest,
+            upstream,
+            revision,
+            branch,
+            purge,
+            sharebase,
+            optimes,
+            behaviors,
+            networkattemptlimit,
+            networkattempts=networkattempts,
+            sparse_profile=sparse_profile,
+            noupdate=noupdate,
+        )
 
     @contextlib.contextmanager
     def timeit(op, behavior):
@@ -275,12 +344,11 @@ def _docheckout(ui, url, dest, upstream, revision, branch, purge, sharebase,
             elapsed = time.time() - start
 
             if errored:
-                op += '_errored'
+                op += "_errored"
 
             optimes.append((op, elapsed))
 
-    ui.write(b'ensuring %s@%s is available at %s\n' % (url, revision or branch,
-                                                      dest))
+    ui.write(b"ensuring %s@%s is available at %s\n" % (url, revision or branch, dest))
 
     # We assume that we're the only process on the machine touching the
     # repository paths that we were told to use. This means our recovery
@@ -293,70 +361,75 @@ def _docheckout(ui, url, dest, upstream, revision, branch, purge, sharebase,
     destvfs = vfs.vfs(dest, audit=False, realpath=True)
 
     def deletesharedstore(path=None):
-        storepath = path or destvfs.read(b'.hg/sharedpath').strip()
-        if storepath.endswith(b'.hg'):
+        storepath = path or destvfs.read(b".hg/sharedpath").strip()
+        if storepath.endswith(b".hg"):
             storepath = os.path.dirname(storepath)
 
         storevfs = vfs.vfs(storepath, audit=False)
         storevfs.rmtree(forcibly=True)
 
-    if destvfs.exists() and not destvfs.exists(b'.hg'):
-        raise error.Abort(b'destination exists but no .hg directory')
+    if destvfs.exists() and not destvfs.exists(b".hg"):
+        raise error.Abort(b"destination exists but no .hg directory")
 
     # Refuse to enable sparse checkouts on existing checkouts. The reasoning
     # here is that another consumer of this repo may not be sparse aware. If we
     # enabled sparse, we would lock them out.
-    if destvfs.exists() and sparse_profile and not destvfs.exists(b'.hg/sparse'):
-        raise error.Abort(b'cannot enable sparse profile on existing '
-                          b'non-sparse checkout',
-                          hint=b'use a separate working directory to use sparse')
+    if destvfs.exists() and sparse_profile and not destvfs.exists(b".hg/sparse"):
+        raise error.Abort(
+            b"cannot enable sparse profile on existing " b"non-sparse checkout",
+            hint=b"use a separate working directory to use sparse",
+        )
 
     # And the other direction for symmetry.
-    if not sparse_profile and destvfs.exists(b'.hg/sparse'):
-        raise error.Abort(b'cannot use non-sparse checkout on existing sparse '
-                          b'checkout',
-                          hint=b'use a separate working directory to use sparse')
+    if not sparse_profile and destvfs.exists(b".hg/sparse"):
+        raise error.Abort(
+            b"cannot use non-sparse checkout on existing sparse " b"checkout",
+            hint=b"use a separate working directory to use sparse",
+        )
 
     # Require checkouts to be tied to shared storage because efficiency.
-    if destvfs.exists(b'.hg') and not destvfs.exists(b'.hg/sharedpath'):
-        ui.warn(b'(destination is not shared; deleting)\n')
-        with timeit('remove_unshared_dest', 'remove-wdir'):
+    if destvfs.exists(b".hg") and not destvfs.exists(b".hg/sharedpath"):
+        ui.warn(b"(destination is not shared; deleting)\n")
+        with timeit("remove_unshared_dest", "remove-wdir"):
             destvfs.rmtree(forcibly=True)
 
     # Verify the shared path exists and is using modern pooled storage.
-    if destvfs.exists(b'.hg/sharedpath'):
-        storepath = destvfs.read(b'.hg/sharedpath').strip()
+    if destvfs.exists(b".hg/sharedpath"):
+        storepath = destvfs.read(b".hg/sharedpath").strip()
 
-        ui.write(b'(existing repository shared store: %s)\n' % storepath)
+        ui.write(b"(existing repository shared store: %s)\n" % storepath)
 
         if not os.path.exists(storepath):
-            ui.warn(b'(shared store does not exist; deleting destination)\n')
-            with timeit('removed_missing_shared_store', 'remove-wdir'):
+            ui.warn(b"(shared store does not exist; deleting destination)\n")
+            with timeit("removed_missing_shared_store", "remove-wdir"):
                 destvfs.rmtree(forcibly=True)
-        elif not re.search(br'[a-f0-9]{40}/\.hg$', storepath.replace(b'\\', b'/')):
-            ui.warn(b'(shared store does not belong to pooled storage; '
-                    b'deleting destination to improve efficiency)\n')
-            with timeit('remove_unpooled_store', 'remove-wdir'):
+        elif not re.search(b"[a-f0-9]{40}/\.hg$", storepath.replace(b"\\", b"/")):
+            ui.warn(
+                b"(shared store does not belong to pooled storage; "
+                b"deleting destination to improve efficiency)\n"
+            )
+            with timeit("remove_unpooled_store", "remove-wdir"):
                 destvfs.rmtree(forcibly=True)
 
-    if destvfs.isfileorlink(b'.hg/wlock'):
-        ui.warn(b'(dest has an active working directory lock; assuming it is '
-                b'left over from a previous process and that the destination '
-                b'is corrupt; deleting it just to be sure)\n')
-        with timeit('remove_locked_wdir', 'remove-wdir'):
+    if destvfs.isfileorlink(b".hg/wlock"):
+        ui.warn(
+            b"(dest has an active working directory lock; assuming it is "
+            b"left over from a previous process and that the destination "
+            b"is corrupt; deleting it just to be sure)\n"
+        )
+        with timeit("remove_locked_wdir", "remove-wdir"):
             destvfs.rmtree(forcibly=True)
 
     def handlerepoerror(e):
-        if pycompat.bytestr(e) == _(b'abandoned transaction found'):
-            ui.warn(b'(abandoned transaction found; trying to recover)\n')
+        if pycompat.bytestr(e) == _(b"abandoned transaction found"):
+            ui.warn(b"(abandoned transaction found; trying to recover)\n")
             repo = hg.repository(ui, dest)
             if not repo.recover():
-                ui.warn(b'(could not recover repo state; '
-                        b'deleting shared store)\n')
-                with timeit('remove_unrecovered_shared_store', 'remove-store'):
+                ui.warn(b"(could not recover repo state; " b"deleting shared store)\n")
+                with timeit("remove_unrecovered_shared_store", "remove-store"):
                     deletesharedstore()
 
-            ui.warn(b'(attempting checkout from beginning)\n')
+            ui.warn(b"(attempting checkout from beginning)\n")
             return callself()
 
         raise
@@ -366,11 +439,14 @@ def _docheckout(ui, url, dest, upstream, revision, branch, purge, sharebase,
 
     def handlenetworkfailure():
         if networkattempts[0] >= networkattemptlimit:
-            raise error.Abort(b'reached maximum number of network attempts; '
-                              b'giving up\n')
+            raise error.Abort(
+                b"reached maximum number of network attempts; " b"giving up\n"
+            )
 
-        ui.warn(b'(retrying after network failure on attempt %d of %d)\n' %
-                (networkattempts[0], networkattemptlimit))
+        ui.warn(
+            b"(retrying after network failure on attempt %d of %d)\n"
+            % (networkattempts[0], networkattemptlimit)
+        )
 
         # Do a backoff on retries to mitigate the thundering herd
         # problem. This is an exponential backoff with a multipler
@@ -380,10 +456,10 @@ def _docheckout(ui, url, dest, upstream, revision, branch, purge, sharebase,
         # 2) 5.5 - 9.5
         # 3) 11.5 - 15.5
         backoff = (2 ** networkattempts[0] - 1) * 1.5
-        jittermin = ui.configint(b'robustcheckout', b'retryjittermin', 1000)
-        jittermax = ui.configint(b'robustcheckout', b'retryjittermax', 5000)
+        jittermin = ui.configint(b"robustcheckout", b"retryjittermin", 1000)
+        jittermax = ui.configint(b"robustcheckout", b"retryjittermax", 5000)
         backoff += float(random.randint(jittermin, jittermax)) / 1000.0
-        ui.warn(b'(waiting %.2fs before retry)\n' % backoff)
+        ui.warn(b"(waiting %.2fs before retry)\n" % backoff)
         time.sleep(backoff)
 
         networkattempts[0] += 1
@@ -394,19 +470,19 @@ def _docheckout(ui, url, dest, upstream, revision, branch, purge, sharebase,
         Returns True if caller should call ``callself()`` to retry.
         """
         if isinstance(e, error.Abort):
-            if e.args[0] == _(b'repository is unrelated'):
-                ui.warn(b'(repository is unrelated; deleting)\n')
+            if e.args[0] == _(b"repository is unrelated"):
+                ui.warn(b"(repository is unrelated; deleting)\n")
                 destvfs.rmtree(forcibly=True)
                 return True
-            elif e.args[0].startswith(_(b'stream ended unexpectedly')):
-                ui.warn(b'%s\n' % e.args[0])
+            elif e.args[0].startswith(_(b"stream ended unexpectedly")):
+                ui.warn(b"%s\n" % e.args[0])
                 # Will raise if failure limit reached.
                 handlenetworkfailure()
                 return True
         # TODO test this branch
         elif isinstance(e, error.ResponseError):
-            if e.args[0].startswith(_(b'unexpected response from remote server:')):
-                ui.warn(b'(unexpected response from remote server; retrying)\n')
+            if e.args[0].startswith(_(b"unexpected response from remote server:")):
+                ui.warn(b"(unexpected response from remote server; retrying)\n")
                 destvfs.rmtree(forcibly=True)
                 # Will raise if failure limit reached.
                 handlenetworkfailure()
@@ -415,20 +491,28 @@ def _docheckout(ui, url, dest, upstream, revision, branch, purge, sharebase,
             # Assume all SSL errors are due to the network, as Mercurial
             # should convert non-transport errors like cert validation failures
             # to error.Abort.
-            ui.warn(b'ssl error: %s\n' % e)
+            ui.warn(b"ssl error: %s\n" % pycompat.bytestr(str(e)))
             handlenetworkfailure()
             return True
         elif isinstance(e, urllibcompat.urlerr.urlerror):
             if isinstance(e.reason, socket.error):
-                ui.warn(b'socket error: %s\n' % pycompat.bytestr(e.reason))
+                ui.warn(b"socket error: %s\n" % pycompat.bytestr(str(e.reason)))
                 handlenetworkfailure()
                 return True
             else:
-                ui.warn(b'unhandled URLError; reason type: %s; value: %s\n' % (
-                    e.reason.__class__.__name__, e.reason))
+                ui.warn(
+                    b"unhandled URLError; reason type: %s; value: %s\n"
+                    % (
+                        pycompat.bytestr(e.reason.__class__.__name__),
+                        pycompat.bytestr(str(e.reason)),
+                    )
+                )
         else:
-            ui.warn(b'unhandled exception during network operation; type: %s; '
-                    b'value: %s\n' % (e.__class__.__name__, e))
+            ui.warn(
+                b"unhandled exception during network operation; type: %s; "
+                b"value: %s\n"
+                % (pycompat.bytestr(e.__class__.__name__), pycompat.bytestr(str(e)))
+            )
 
         return False
 
@@ -440,59 +524,69 @@ def _docheckout(ui, url, dest, upstream, revision, branch, purge, sharebase,
 
     try:
         clonepeer = hg.peer(ui, {}, cloneurl)
-        rootnode = peerlookup(clonepeer, b'0')
+        rootnode = peerlookup(clonepeer, b"0")
     except error.RepoLookupError:
-        raise error.Abort(b'unable to resolve root revision from clone '
-                          b'source')
+        raise error.Abort(b"unable to resolve root revision from clone " b"source")
     except (error.Abort, ssl.SSLError, urllibcompat.urlerr.urlerror) as e:
         if handlepullerror(e):
             return callself()
         raise
 
     if rootnode == nullid:
-        raise error.Abort(b'source repo appears to be empty')
+        raise error.Abort(b"source repo appears to be empty")
 
     storepath = os.path.join(sharebase, hex(rootnode))
     storevfs = vfs.vfs(storepath, audit=False)
 
-    if storevfs.isfileorlink(b'.hg/store/lock'):
-        ui.warn(b'(shared store has an active lock; assuming it is left '
-                b'over from a previous process and that the store is '
-                b'corrupt; deleting store and destination just to be '
-                b'sure)\n')
+    if storevfs.isfileorlink(b".hg/store/lock"):
+        ui.warn(
+            b"(shared store has an active lock; assuming it is left "
+            b"over from a previous process and that the store is "
+            b"corrupt; deleting store and destination just to be "
+            b"sure)\n"
+        )
         if destvfs.exists():
-            with timeit('remove_dest_active_lock', 'remove-wdir'):
+            with timeit("remove_dest_active_lock", "remove-wdir"):
                 destvfs.rmtree(forcibly=True)
 
-        with timeit('remove_shared_store_active_lock', 'remove-store'):
+        with timeit("remove_shared_store_active_lock", "remove-store"):
             storevfs.rmtree(forcibly=True)
 
-    if storevfs.exists() and not storevfs.exists(b'.hg/requires'):
-        ui.warn(b'(shared store missing requires file; this is a really '
-                b'odd failure; deleting store and destination)\n')
+    if storevfs.exists() and not storevfs.exists(b".hg/requires"):
+        ui.warn(
+            b"(shared store missing requires file; this is a really "
+            b"odd failure; deleting store and destination)\n"
+        )
         if destvfs.exists():
-            with timeit('remove_dest_no_requires', 'remove-wdir'):
+            with timeit("remove_dest_no_requires", "remove-wdir"):
                 destvfs.rmtree(forcibly=True)
 
-        with timeit('remove_shared_store_no_requires', 'remove-store'):
+        with timeit("remove_shared_store_no_requires", "remove-store"):
             storevfs.rmtree(forcibly=True)
 
-    if storevfs.exists(b'.hg/requires'):
-        requires = set(storevfs.read(b'.hg/requires').splitlines())
+    if storevfs.exists(b".hg/requires"):
+        requires = set(storevfs.read(b".hg/requires").splitlines())
+        # "share-safe" (enabled by default as of hg 6.1) moved most
+        # requirements to a new file, so we need to look there as well to avoid
+        # deleting and re-cloning each time
+        if b"share-safe" in requires:
+            requires |= set(storevfs.read(b".hg/store/requires").splitlines())
         # FUTURE when we require generaldelta, this is where we can check
         # for that.
-        required = {b'dotencode', b'fncache'}
+        required = {b"dotencode", b"fncache"}
 
         missing = required - requires
         if missing:
-            ui.warn(b'(shared store missing requirements: %s; deleting '
-                    b'store and destination to ensure optimal behavior)\n' %
-                    b', '.join(sorted(missing)))
+            ui.warn(
+                b"(shared store missing requirements: %s; deleting "
+                b"store and destination to ensure optimal behavior)\n"
+                % b", ".join(sorted(missing))
+            )
             if destvfs.exists():
-                with timeit('remove_dest_missing_requires', 'remove-wdir'):
+                with timeit("remove_dest_missing_requires", "remove-wdir"):
                     destvfs.rmtree(forcibly=True)
 
-            with timeit('remove_shared_store_missing_requires', 'remove-store'):
+            with timeit("remove_shared_store_missing_requires", "remove-store"):
                 storevfs.rmtree(forcibly=True)
 
     created = False
@@ -500,7 +594,7 @@ def _docheckout(ui, url, dest, upstream, revision, branch, purge, sharebase,
     if not destvfs.exists():
         # Ensure parent directories of destination exist.
         # Mercurial 3.8 removed ensuredirs and made makedirs race safe.
-        if util.safehasattr(util, 'ensuredirs'):
+        if util.safehasattr(util, "ensuredirs"):
             makedirs = util.ensuredirs
         else:
             makedirs = util.makedirs
@@ -509,17 +603,23 @@ def _docheckout(ui, url, dest, upstream, revision, branch, purge, sharebase,
         makedirs(sharebase, notindexed=True)
 
         if upstream:
-            ui.write(b'(cloning from upstream repo %s)\n' % upstream)
+            ui.write(b"(cloning from upstream repo %s)\n" % upstream)
 
         if not storevfs.exists():
-            behaviors.add(b'create-store')
+            behaviors.add(b"create-store")
 
         try:
-            with timeit('clone', 'clone'):
-                shareopts = {b'pool': sharebase, b'mode': b'identity'}
-                res = hg.clone(ui, {}, clonepeer, dest=dest, update=False,
-                               shareopts=shareopts,
-                               stream=True)
+            with timeit("clone", "clone"):
+                shareopts = {b"pool": sharebase, b"mode": b"identity"}
+                res = hg.clone(
+                    ui,
+                    {},
+                    clonepeer,
+                    dest=dest,
+                    update=False,
+                    shareopts=shareopts,
+                    stream=True,
+                )
         except (error.Abort, ssl.SSLError, urllibcompat.urlerr.urlerror) as e:
             if handlepullerror(e):
                 return callself()
@@ -527,18 +627,18 @@ def _docheckout(ui, url, dest, upstream, revision, branch, purge, sharebase,
         except error.RepoError as e:
             return handlerepoerror(e)
         except error.RevlogError as e:
-            ui.warn(b'(repo corruption: %s; deleting shared store)\n' % e)
-            with timeit('remove_shared_store_revlogerror', 'remote-store'):
+            ui.warn(b"(repo corruption: %s; deleting shared store)\n" % e)
+            with timeit("remove_shared_store_revlogerror", "remote-store"):
                 deletesharedstore()
             return callself()
 
         # TODO retry here.
         if res is None:
-            raise error.Abort(b'clone failed')
+            raise error.Abort(b"clone failed")
 
         # Verify it is using shared pool storage.
-        if not destvfs.exists(b'.hg/sharedpath'):
-            raise error.Abort(b'clone did not create a shared repo')
+        if not destvfs.exists(b".hg/sharedpath"):
+            raise error.Abort(b"clone did not create a shared repo")
 
         created = True
 
@@ -559,15 +659,16 @@ def _docheckout(ui, url, dest, upstream, revision, branch, purge, sharebase,
 
         if ctx:
             if not ctx.hex().startswith(revision):
-                raise error.Abort(b'--revision argument is ambiguous',
-                                  hint=b'must be the first 12+ characters of a '
-                                       b'SHA-1 fragment')
+                raise error.Abort(
+                    b"--revision argument is ambiguous",
+                    hint=b"must be the first 12+ characters of a " b"SHA-1 fragment",
+                )
 
             checkoutrevision = ctx.hex()
             havewantedrev = True
 
     if not havewantedrev:
-        ui.write(b'(pulling to obtain %s)\n' % (revision or branch,))
+        ui.write(b"(pulling to obtain %s)\n" % (revision or branch,))
 
         remote = None
         try:
@@ -575,17 +676,18 @@ def _docheckout(ui, url, dest, upstream, revision, branch, purge, sharebase,
             pullrevs = [peerlookup(remote, revision or branch)]
             checkoutrevision = hex(pullrevs[0])
             if branch:
-                ui.warn(b'(remote resolved %s to %s; '
-                        b'result is not deterministic)\n' %
-                        (branch, checkoutrevision))
+                ui.warn(
+                    b"(remote resolved %s to %s; "
+                    b"result is not deterministic)\n" % (branch, checkoutrevision)
+                )
 
             if checkoutrevision in repo:
-                ui.warn(b'(revision already present locally; not pulling)\n')
+                ui.warn(b"(revision already present locally; not pulling)\n")
             else:
-                with timeit('pull', 'pull'):
+                with timeit("pull", "pull"):
                     pullop = exchange.pull(repo, remote, heads=pullrevs)
                     if not pullop.rheads:
-                        raise error.Abort(b'unable to pull requested revision')
+                        raise error.Abort(b"unable to pull requested revision")
         except (error.Abort, ssl.SSLError, urllibcompat.urlerr.urlerror) as e:
             if handlepullerror(e):
                 return callself()
@@ -593,7 +695,7 @@ def _docheckout(ui, url, dest, upstream, revision, branch, purge, sharebase,
         except error.RepoError as e:
             return handlerepoerror(e)
         except error.RevlogError as e:
-            ui.warn(b'(repo corruption: %s; deleting shared store)\n' % e)
+            ui.warn(b"(repo corruption: %s; deleting shared store)\n" % e)
             deletesharedstore()
             return callself()
         finally:
@@ -605,47 +707,46 @@ def _docheckout(ui, url, dest, upstream, revision, branch, purge, sharebase,
 
     # Avoid any working directory manipulations if `-U`/`--noupdate` was passed
     if noupdate:
-        ui.write(b'(skipping update since `-U` was passed)\n')
+        ui.write(b"(skipping update since `-U` was passed)\n")
         return None
 
     # Purge if requested. We purge before update because this way we're
     # guaranteed to not have conflicts on `hg update`.
     if purge and not created:
-        ui.write(b'(purging working directory)\n')
-        purgeext = extensions.find(b'purge')
+        ui.write(b"(purging working directory)\n")
+        purge = getattr(commands, "purge", None)
+        if not purge:
+            purge = extensions.find(b"purge").purge
 
         # Mercurial 4.3 doesn't purge files outside the sparse checkout.
         # See https://bz.mercurial-scm.org/show_bug.cgi?id=5626. Force
         # purging by monkeypatching the sparse matcher.
         try:
-            old_sparse_fn = getattr(repo.dirstate, '_sparsematchfn', None)
+            old_sparse_fn = getattr(repo.dirstate, "_sparsematchfn", None)
             if old_sparse_fn is not None:
-                # TRACKING hg50
-                # Arguments passed to `matchmod.always` were unused and have been removed
-                if util.versiontuple(n=2) >= (5, 0):
-                    repo.dirstate._sparsematchfn = lambda: matchmod.always()
-                else:
-                    repo.dirstate._sparsematchfn = lambda: matchmod.always(repo.root, '')
+                repo.dirstate._sparsematchfn = lambda: matchmod.always()
 
-            with timeit('purge', 'purge'):
-                if purgeext.purge(ui, repo, all=True, abort_on_err=True,
-                                  # The function expects all arguments to be
-                                  # defined.
-                                  **{'print': None,
-                                     'print0': None,
-                                     'dirs': None,
-                                     'files': None}):
-                    raise error.Abort(b'error purging')
+            with timeit("purge", "purge"):
+                if purge(
+                    ui,
+                    repo,
+                    all=True,
+                    abort_on_err=True,
+                    # The function expects all arguments to be
+                    # defined.
+                    **{"print": None, "print0": None, "dirs": None, "files": None}
+                ):
+                    raise error.Abort(b"error purging")
         finally:
             if old_sparse_fn is not None:
                 repo.dirstate._sparsematchfn = old_sparse_fn
 
     # Update the working directory.
 
-    if repo[b'.'].node() == nullid:
-        behaviors.add('empty-wdir')
+    if repo[b"."].node() == nullid:
+        behaviors.add("empty-wdir")
     else:
-        behaviors.add('populated-wdir')
+        behaviors.add("populated-wdir")
 
     if sparse_profile:
         sparsemod = getsparse()
@@ -655,58 +756,70 @@ def _docheckout(ui, url, dest, upstream, revision, branch, purge, sharebase,
         try:
             repo.filectx(sparse_profile, changeid=checkoutrevision).data()
         except error.ManifestLookupError:
-            raise error.Abort(b'sparse profile %s does not exist at revision '
-                              b'%s' % (sparse_profile, checkoutrevision))
+            raise error.Abort(
+                b"sparse profile %s does not exist at revision "
+                b"%s" % (sparse_profile, checkoutrevision)
+            )
 
-        # TRACKING hg48 - parseconfig takes `action` param
-        if util.versiontuple(n=2) >= (4, 8):
-            old_config = sparsemod.parseconfig(repo.ui, repo.vfs.tryread(b'sparse'), b'sparse')
-        else:
-            old_config = sparsemod.parseconfig(repo.ui, repo.vfs.tryread(b'sparse'))
+        old_config = sparsemod.parseconfig(
+            repo.ui, repo.vfs.tryread(b"sparse"), b"sparse"
+        )
 
         old_includes, old_excludes, old_profiles = old_config
 
-        if old_profiles == {sparse_profile} and not old_includes and not \
-                old_excludes:
-            ui.write(b'(sparse profile %s already set; no need to update '
-                     b'sparse config)\n' % sparse_profile)
+        if old_profiles == {sparse_profile} and not old_includes and not old_excludes:
+            ui.write(
+                b"(sparse profile %s already set; no need to update "
+                b"sparse config)\n" % sparse_profile
+            )
         else:
             if old_includes or old_excludes or old_profiles:
-                ui.write(b'(replacing existing sparse config with profile '
-                         b'%s)\n' % sparse_profile)
+                ui.write(
+                    b"(replacing existing sparse config with profile "
+                    b"%s)\n" % sparse_profile
+                )
             else:
-                ui.write(b'(setting sparse config to profile %s)\n' %
-                         sparse_profile)
+                ui.write(b"(setting sparse config to profile %s)\n" % sparse_profile)
 
             # If doing an incremental update, this will perform two updates:
             # one to change the sparse profile and another to update to the new
             # revision. This is not desired. But there's not a good API in
             # Mercurial to do this as one operation.
-            with repo.wlock(), timeit('sparse_update_config',
-                                      'sparse-update-config'):
-                fcounts = map(len, sparsemod._updateconfigandrefreshwdir(
-                    repo, [], [], [sparse_profile], force=True))
+            with repo.wlock(), repo.dirstate.parentchange(), timeit(
+                "sparse_update_config", "sparse-update-config"
+            ):
+                # pylint --py3k: W1636
+                fcounts = list(
+                    map(
+                        len,
+                        sparsemod._updateconfigandrefreshwdir(
+                            repo, [], [], [sparse_profile], force=True
+                        ),
+                    )
+                )
 
-                repo.ui.status(b'%d files added, %d files dropped, '
-                               b'%d files conflicting\n' % tuple(fcounts))
+                repo.ui.status(
+                    b"%d files added, %d files dropped, "
+                    b"%d files conflicting\n" % tuple(fcounts)
+                )
 
-            ui.write(b'(sparse refresh complete)\n')
+            ui.write(b"(sparse refresh complete)\n")
 
-    op = 'update_sparse' if sparse_profile else 'update'
-    behavior = 'update-sparse' if sparse_profile else 'update'
+    op = "update_sparse" if sparse_profile else "update"
+    behavior = "update-sparse" if sparse_profile else "update"
 
     with timeit(op, behavior):
         if commands.update(ui, repo, rev=checkoutrevision, clean=True):
-            raise error.Abort(b'error updating')
+            raise error.Abort(b"error updating")
 
-    ui.write(b'updated to %s\n' % checkoutrevision)
+    ui.write(b"updated to %s\n" % checkoutrevision)
 
     return None
 
 
 def extsetup(ui):
     # Ensure required extensions are loaded.
-    for ext in (b'purge', b'share'):
+    for ext in (b"purge", b"share"):
         try:
             extensions.find(ext)
         except KeyError:

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -17,7 +17,7 @@ import sys
 from typing import Optional
 
 if sys.version_info[0:2] < (3, 5):
-    print('run-task requires Python 3.5+')
+    print("run-task requires Python 3.5+")
     sys.exit(1)
 
 
@@ -41,7 +41,7 @@ import urllib.request
 
 from threading import Thread
 
-SECRET_BASEURL_TPL = 'http://taskcluster/secrets/v1/secret/{}'
+SECRET_BASEURL_TPL = "http://taskcluster/secrets/v1/secret/{}"
 
 GITHUB_SSH_FINGERPRINT = (
     b"github.com ssh-rsa "
@@ -53,7 +53,7 @@ GITHUB_SSH_FINGERPRINT = (
 )
 
 
-CACHE_UID_GID_MISMATCH = '''
+CACHE_UID_GID_MISMATCH = """
 There is a UID/GID mismatch on the cache. This likely means:
 
 a) different tasks are running as a different user/group
@@ -66,10 +66,10 @@ to file/directory user/group ownership.
 To make this error go away, ensure that all Docker images are use
 a consistent UID/GID and that all tasks using this cache are running as
 the same user/group.
-'''
+"""
 
 
-NON_EMPTY_VOLUME = '''
+NON_EMPTY_VOLUME = """
 error: volume %s is not empty
 
 Our Docker image policy requires volumes to be empty.
@@ -80,15 +80,15 @@ any VOLUME.
 
 A lesser possibility is that you stumbled upon a TaskCluster platform bug
 where it fails to use new volumes for tasks.
-'''
+"""
 
 
-FETCH_CONTENT_NOT_FOUND = '''
+FETCH_CONTENT_NOT_FOUND = """
 error: fetch-content script not found
 
 The script at `taskcluster/scripts/misc/fetch-content` could not be
 detected in the current environment.
-'''
+"""
 
 # The exit code to use when caches should be purged and the task retried.
 # This is EX_OSFILE (from sysexits.h):
@@ -97,9 +97,9 @@ detected in the current environment.
 EXIT_PURGE_CACHE = 72
 
 
-IS_MACOSX = sys.platform == 'darwin'
-IS_POSIX = os.name == 'posix'
-IS_WINDOWS = os.name == 'nt'
+IS_MACOSX = sys.platform == "darwin"
+IS_POSIX = os.name == "posix"
+IS_WINDOWS = os.name == "nt"
 
 # Both mercurial and git use sha1 as revision idenfiers. Luckily, both define
 # the same value as the null revision.
@@ -110,10 +110,10 @@ NULL_REVISION = "0000000000000000000000000000000000000000"
 
 
 def print_line(prefix, m):
-    now = datetime.datetime.utcnow().isoformat().encode('utf-8')
+    now = datetime.datetime.utcnow().isoformat().encode("utf-8")
     # slice microseconds to 3 decimals.
-    now = now[:-3] if now[-7:-6] == b'.' else now
-    sys.stdout.buffer.write(b'[%s %sZ] %s' % (prefix, now, m))
+    now = now[:-3] if now[-7:-6] == b"." else now
+    sys.stdout.buffer.write(b"[%s %sZ] %s" % (prefix, now, m))
     sys.stdout.buffer.flush()
 
 
@@ -188,7 +188,7 @@ def remove(path):
         _call_windows_retry(os.chmod, (path, mode))
 
     if not os.path.lexists(path):
-        print_line(b'remove', b'WARNING: %s does not exists!\n' % path.encode('utf-8'))
+        print_line(b"remove", b"WARNING: %s does not exists!\n" % path.encode("utf-8"))
         return
 
     """
@@ -202,7 +202,7 @@ def remove(path):
         and path[1] == ":"
         and path[2] == "\\"
     ):
-        path = u"\\\\?\\%s" % path
+        path = "\\\\?\\%s" % path
 
     if os.path.isfile(path) or os.path.islink(path):
         # Verify the file or link is read/write for the current user
@@ -244,7 +244,7 @@ def run_command(prefix, args, *, extra_env=None, cwd=None):
 
     Returns the process exit code.
     """
-    print_line(prefix, b'executing %r\n' % args)
+    print_line(prefix, b"executing %r\n" % args)
 
     env = dict(os.environ)
     env.update(extra_env or {})
@@ -260,23 +260,25 @@ def run_command(prefix, args, *, extra_env=None, cwd=None):
     # we manually install a latin1 stream wrapper. This allows us to readline()
     # and preserves bytes, without losing any data.
 
-    p = subprocess.Popen(args,
-                         # Disable buffering because we want to receive output
-                         # as it is generated so timestamps in logs are
-                         # accurate.
-                         bufsize=0,
-                         stdout=subprocess.PIPE,
-                         stderr=subprocess.STDOUT,
-                         stdin=sys.stdin.fileno(),
-                         cwd=cwd,
-                         env=env)
+    p = subprocess.Popen(
+        args,
+        # Disable buffering because we want to receive output
+        # as it is generated so timestamps in logs are
+        # accurate.
+        bufsize=0,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        stdin=sys.stdin.fileno(),
+        cwd=cwd,
+        env=env,
+    )
 
-    stdout = io.TextIOWrapper(p.stdout, encoding='latin1')
+    stdout = io.TextIOWrapper(p.stdout, encoding="latin1")
 
     while True:
-        data = stdout.readline().encode('latin1')
+        data = stdout.readline().encode("latin1")
 
-        if data == b'':
+        if data == b"":
             break
 
         print_line(prefix, data)
@@ -291,25 +293,24 @@ def get_posix_user_group(user, group):
     try:
         user_record = pwd.getpwnam(user)
     except KeyError:
-        print('could not find user %s; specify a valid user with --user' % user)
+        print("could not find user %s; specify a valid user with --user" % user)
         sys.exit(1)
 
     try:
         group_record = grp.getgrnam(group)
     except KeyError:
-        print('could not find group %s; specify a valid group with --group' %
-              group)
+        print("could not find group %s; specify a valid group with --group" % group)
         sys.exit(1)
 
     # Most tasks use worker:worker. We require they have a specific numeric ID
     # because otherwise it is too easy for files written to caches to have
     # mismatched numeric IDs, which results in permissions errors.
-    if user_record.pw_name == 'worker' and user_record.pw_uid != 1000:
-        print('user `worker` must have uid=1000; got %d' % user_record.pw_uid)
+    if user_record.pw_name == "worker" and user_record.pw_uid != 1000:
+        print("user `worker` must have uid=1000; got %d" % user_record.pw_uid)
         sys.exit(1)
 
-    if group_record.gr_name == 'worker' and group_record.gr_gid != 1000:
-        print('group `worker` must have gid=1000; got %d' % group_record.gr_gid)
+    if group_record.gr_name == "worker" and group_record.gr_gid != 1000:
+        print("group `worker` must have gid=1000; got %d" % group_record.gr_gid)
         sys.exit(1)
 
     # Find all groups to which this user is a member.
@@ -319,10 +320,9 @@ def get_posix_user_group(user, group):
 
 
 def write_audit_entry(path, msg):
-    now = datetime.datetime.utcnow().isoformat().encode('utf-8')
-    with open(path, 'ab') as fh:
-        fh.write(b'[%sZ %s] %s\n' % (
-                 now, os.environb.get(b'TASK_ID', b'UNKNOWN'), msg))
+    now = datetime.datetime.utcnow().isoformat().encode("utf-8")
+    with open(path, "ab") as fh:
+        fh.write(b"[%sZ %s] %s\n" % (now, os.environb.get(b"TASK_ID", b"UNKNOWN"), msg))
 
 
 WANTED_DIR_MODE = stat.S_IXUSR | stat.S_IRUSR | stat.S_IWUSR
@@ -341,10 +341,11 @@ def set_dir_permissions(path, uid, gid):
 
 
 def chown_recursive(path, user, group, uid, gid):
-    print_line(b'chown',
-               b'recursively changing ownership of %s to %s:%s\n' %
-               (path.encode('utf-8'), user.encode('utf-8'), group.encode(
-                   'utf-8')))
+    print_line(
+        b"chown",
+        b"recursively changing ownership of %s to %s:%s\n"
+        % (path.encode("utf-8"), user.encode("utf-8"), group.encode("utf-8")),
+    )
 
     set_dir_permissions(path, uid, gid)
 
@@ -361,8 +362,7 @@ def chown_recursive(path, user, group, uid, gid):
             os.lchown(os.path.join(root, f), uid, gid)
 
 
-def configure_cache_posix(cache, user, group,
-                          untrusted_caches, running_as_root):
+def configure_cache_posix(cache, user, group, untrusted_caches, running_as_root):
     """Configure a cache path on POSIX platforms.
 
     For each cache, we write out a special file denoting attributes and
@@ -387,33 +387,36 @@ def configure_cache_posix(cache, user, group,
         # to follow any explicit order. Since taskgraph bakes this file's
         # hash into cache names, any change to this file/version is sufficient
         # to force the use of a new cache.
-        b'version=1',
+        b"version=1",
         # Include the UID and GID the task will run as to ensure that tasks
         # with different UID and GID don't share the same cache.
-        b'uid=%d' % user.pw_uid,
-        b'gid=%d' % group.gr_gid,
+        b"uid=%d" % user.pw_uid,
+        b"gid=%d" % group.gr_gid,
     }
 
-    requires_path = os.path.join(cache, '.cacherequires')
-    audit_path = os.path.join(cache, '.cachelog')
+    requires_path = os.path.join(cache, ".cacherequires")
+    audit_path = os.path.join(cache, ".cachelog")
 
     # The cache is empty. Configure it.
     if not os.listdir(cache):
-        print_line(b'cache', b'cache %s is empty; writing requirements: '
-                             b'%s\n' % (
-                                 cache.encode('utf-8'), b' '.join(sorted(our_requirements))))
+        print_line(
+            b"cache",
+            b"cache %s is empty; writing requirements: "
+            b"%s\n" % (cache.encode("utf-8"), b" ".join(sorted(our_requirements))),
+        )
 
         # We write a requirements file so future invocations know what the
         # requirements are.
-        with open(requires_path, 'wb') as fh:
-            fh.write(b'\n'.join(sorted(our_requirements)))
+        with open(requires_path, "wb") as fh:
+            fh.write(b"\n".join(sorted(our_requirements)))
 
         # And make it read-only as a precaution against deletion.
         os.chmod(requires_path, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
 
-        write_audit_entry(audit_path,
-                          b'created; requirements: %s' %
-                          b', '.join(sorted(our_requirements)))
+        write_audit_entry(
+            audit_path,
+            b"created; requirements: %s" % b", ".join(sorted(our_requirements)),
+        )
 
         set_dir_permissions(cache, user.pw_uid, group.gr_gid)
         return
@@ -421,11 +424,14 @@ def configure_cache_posix(cache, user, group,
     # The cache has content and we have a requirements file. Validate
     # requirements alignment.
     if os.path.exists(requires_path):
-        with open(requires_path, 'rb') as fh:
+        with open(requires_path, "rb") as fh:
             wanted_requirements = set(fh.read().splitlines())
 
-        print_line(b'cache', b'cache %s exists; requirements: %s\n' % (
-            cache.encode('utf-8'), b' '.join(sorted(wanted_requirements))))
+        print_line(
+            b"cache",
+            b"cache %s exists; requirements: %s\n"
+            % (cache.encode("utf-8"), b" ".join(sorted(wanted_requirements))),
+        )
 
         missing = wanted_requirements - our_requirements
 
@@ -435,46 +441,61 @@ def configure_cache_posix(cache, user, group,
         # usability by introducing uid/gid mismatches. For untrusted
         # environments like Try, this is a perfectly reasonable thing to
         # allow.
-        if missing and untrusted_caches and running_as_root and \
-                all(s.startswith((b'uid=', b'gid=')) for s in missing):
-            print_line(b'cache',
-                       b'cache %s uid/gid mismatch; this is acceptable '
-                       b'because caches for this task are untrusted; '
-                       b'changing ownership to facilitate cache use\n' %
-                       cache.encode('utf-8'))
-            chown_recursive(cache, user.pw_name, group.gr_name, user.pw_uid,
-                            group.gr_gid)
+        if (
+            missing
+            and untrusted_caches
+            and running_as_root
+            and all(s.startswith((b"uid=", b"gid=")) for s in missing)
+        ):
+            print_line(
+                b"cache",
+                b"cache %s uid/gid mismatch; this is acceptable "
+                b"because caches for this task are untrusted; "
+                b"changing ownership to facilitate cache use\n" % cache.encode("utf-8"),
+            )
+            chown_recursive(
+                cache, user.pw_name, group.gr_name, user.pw_uid, group.gr_gid
+            )
 
             # And write out the updated reality.
-            with open(requires_path, 'wb') as fh:
-                fh.write(b'\n'.join(sorted(our_requirements)))
+            with open(requires_path, "wb") as fh:
+                fh.write(b"\n".join(sorted(our_requirements)))
 
-            write_audit_entry(audit_path,
-                              b'chown; requirements: %s' %
-                              b', '.join(sorted(our_requirements)))
+            write_audit_entry(
+                audit_path,
+                b"chown; requirements: %s" % b", ".join(sorted(our_requirements)),
+            )
 
         elif missing:
-            print('error: requirements for populated cache %s differ from '
-                  'this task' % cache)
-            print('cache requirements: %s' % ' '.join(sorted(
-                s.decode('utf-8') for s in wanted_requirements)))
-            print('our requirements:   %s' % ' '.join(sorted(
-                s.decode('utf-8') for s in our_requirements)))
-            if any(s.startswith((b'uid=', b'gid=')) for s in missing):
+            print(
+                "error: requirements for populated cache %s differ from "
+                "this task" % cache
+            )
+            print(
+                "cache requirements: %s"
+                % " ".join(sorted(s.decode("utf-8") for s in wanted_requirements))
+            )
+            print(
+                "our requirements:   %s"
+                % " ".join(sorted(s.decode("utf-8") for s in our_requirements))
+            )
+            if any(s.startswith((b"uid=", b"gid=")) for s in missing):
                 print(CACHE_UID_GID_MISMATCH)
 
-            write_audit_entry(audit_path,
-                              b'requirements mismatch; wanted: %s' %
-                              b', '.join(sorted(our_requirements)))
+            write_audit_entry(
+                audit_path,
+                b"requirements mismatch; wanted: %s"
+                % b", ".join(sorted(our_requirements)),
+            )
 
-            print('')
-            print('audit log:')
-            with open(audit_path, 'r') as fh:
+            print("")
+            print("audit log:")
+            with open(audit_path, "r") as fh:
                 print(fh.read())
 
             return True
         else:
-            write_audit_entry(audit_path, b'used')
+            write_audit_entry(audit_path, b"used")
 
         # We don't need to adjust permissions here because the cache is
         # associated with a uid/gid and the first task should have set
@@ -485,12 +506,14 @@ def configure_cache_posix(cache, user, group,
     # The cache has content and no requirements file. This shouldn't
     # happen because run-task should be the first thing that touches a
     # cache.
-    print('error: cache %s is not empty and is missing a '
-          '.cacherequires file; the cache names for this task are '
-          'likely mis-configured or TASKCLUSTER_CACHES is not set '
-          'properly' % cache)
+    print(
+        "error: cache %s is not empty and is missing a "
+        ".cacherequires file; the cache names for this task are "
+        "likely mis-configured or TASKCLUSTER_CACHES is not set "
+        "properly" % cache
+    )
 
-    write_audit_entry(audit_path, b'missing .cacherequires')
+    write_audit_entry(audit_path, b"missing .cacherequires")
     return True
 
 
@@ -506,53 +529,58 @@ def configure_volume_posix(volume, user, group, running_as_root):
     volume_files = os.listdir(volume)
     if volume_files:
         print(NON_EMPTY_VOLUME % volume)
-        print('entries in root directory: %s' %
-              ' '.join(sorted(volume_files)))
+        print("entries in root directory: %s" % " ".join(sorted(volume_files)))
         sys.exit(1)
 
     # The volume is almost certainly owned by root:root. Chown it so it
     # is writable.
 
     if running_as_root:
-        print_line(b'volume', b'changing ownership of volume %s '
-                              b'to %d:%d\n' % (volume.encode('utf-8'),
-                                               user.pw_uid,
-                                               group.gr_gid))
+        print_line(
+            b"volume",
+            b"changing ownership of volume %s "
+            b"to %d:%d\n" % (volume.encode("utf-8"), user.pw_uid, group.gr_gid),
+        )
         set_dir_permissions(volume, user.pw_uid, group.gr_gid)
 
 
 def _clean_git_checkout(destination_path):
     # Delete untracked files (i.e. build products)
-    print_line(b'vcs', b'cleaning git checkout...\n')
+    print_line(b"vcs", b"cleaning git checkout...\n")
     args = [
-        'git',
-        'clean',
+        "git",
+        "clean",
         # Two -f`s causes subdirectories with `.git`
         # directories to be cleaned as well.
-        '-nxdff',
+        "-nxdff",
     ]
-    print_line(b'vcs', b'executing %r\n' % args)
-    p = subprocess.Popen(args,
-                         # Disable buffering because we want to receive output
-                         # as it is generated so timestamps in logs are
-                         # accurate.
-                         bufsize=0,
-                         stdout=subprocess.PIPE,
-                         stderr=subprocess.STDOUT,
-                         stdin=sys.stdin.fileno(),
-                         cwd=destination_path,
-                         env=os.environ)
-    stdout = io.TextIOWrapper(p.stdout, encoding='latin1')
+    print_line(b"vcs", b"executing %r\n" % args)
+    p = subprocess.Popen(
+        args,
+        # Disable buffering because we want to receive output
+        # as it is generated so timestamps in logs are
+        # accurate.
+        bufsize=0,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        stdin=sys.stdin.fileno(),
+        cwd=destination_path,
+        env=os.environ,
+    )
+    stdout = io.TextIOWrapper(p.stdout, encoding="latin1")
     ret = p.wait()
     if ret:
         sys.exit(ret)
     data = stdout.read()
-    prefix = 'Would remove '
-    filenames = [os.path.join(destination_path, line[len(prefix):]) for line in data.splitlines()]
-    print_line(b'vcs', b'removing %r\n' % filenames)
+    prefix = "Would remove "
+    filenames = [
+        os.path.join(destination_path, line[len(prefix) :])
+        for line in data.splitlines()
+    ]
+    print_line(b"vcs", b"removing %r\n" % filenames)
     for filename in filenames:
         remove(filename)
-    print_line(b'vcs', b'successfully cleaned git checkout!\n')
+    print_line(b"vcs", b"successfully cleaned git checkout!\n")
 
 
 def git_checkout(
@@ -564,56 +592,49 @@ def git_checkout(
     ref: Optional[str],
     commit: Optional[str],
     ssh_key_file: Optional[Path],
-    ssh_known_hosts_file: Optional[Path]
+    ssh_known_hosts_file: Optional[Path],
 ):
-    env = {'PYTHONUNBUFFERED': '1'}
+    env = {"PYTHONUNBUFFERED": "1"}
 
     if ssh_key_file and ssh_known_hosts_file:
         if not ssh_key_file.exists():
             raise RuntimeError("Can't find specified ssh_key file.")
         if not ssh_known_hosts_file.exists():
             raise RuntimeError("Can't find specified known_hosts file.")
-        env['GIT_SSH_COMMAND'] = " ".join([
-            "ssh",
-            "-oIdentityFile={}".format(ssh_key_file.as_posix()),
-            "-oStrictHostKeyChecking=yes",
-            "-oUserKnownHostsFile={}".format(ssh_known_hosts_file.as_posix()),
-        ])
+        env["GIT_SSH_COMMAND"] = " ".join(
+            [
+                "ssh",
+                "-oIdentityFile={}".format(ssh_key_file.as_posix()),
+                "-oStrictHostKeyChecking=yes",
+                "-oUserKnownHostsFile={}".format(ssh_known_hosts_file.as_posix()),
+            ]
+        )
     elif ssh_key_file or ssh_known_hosts_file:
         raise RuntimeError(
-            'Must specify both ssh_key_file and ssh_known_hosts_file, if either are specified',
+            "Must specify both ssh_key_file and ssh_known_hosts_file, if either are specified",
         )
 
     if not os.path.exists(destination_path):
         # Repository doesn't already exist, needs to be cloned
         args = [
-            'git',
-            'clone',
+            "git",
+            "clone",
             base_repo if base_repo else head_repo,
             destination_path,
         ]
 
-        retry_required_command(b'vcs', args, extra_env=env)
+        retry_required_command(b"vcs", args, extra_env=env)
 
     if base_ref:
-        args = [
-            'git',
-            'fetch',
-            'origin',
-            base_ref
-        ]
+        args = ["git", "fetch", "origin", base_ref]
 
-        retry_required_command(b'vcs', args, cwd=destination_path, extra_env=env)
+        retry_required_command(b"vcs", args, cwd=destination_path, extra_env=env)
 
         # Create local branch so that taskgraph is able to compute differences
         # between the head branch and the base one, if needed
-        args = [
-            'git',
-            'checkout',
-            base_ref
-        ]
+        args = ["git", "checkout", base_ref]
 
-        retry_required_command(b'vcs', args, cwd=destination_path, extra_env=env)
+        retry_required_command(b"vcs", args, cwd=destination_path, extra_env=env)
 
     # When commits are force-pushed (like on a testing branch), base_rev doesn't
     # exist on base_ref. Fetching it allows taskgraph to compute differences
@@ -622,109 +643,103 @@ def git_checkout(
     # Unlike base_ref just above, there is no need to checkout the revision:
     # it's immediately avaiable after the fetch.
     if base_rev and base_rev != NULL_REVISION:
-        args = [
-            'git',
-            'fetch',
-            'origin',
-            base_rev
-        ]
+        args = ["git", "fetch", "origin", base_rev]
 
-        retry_required_command(b'vcs', args, cwd=destination_path, extra_env=env)
+        retry_required_command(b"vcs", args, cwd=destination_path, extra_env=env)
 
     # If a ref isn't provided, we fetch all refs from head_repo, which may be slow
     args = [
-        'git',
-        'fetch',
-        '--no-tags',
+        "git",
+        "fetch",
+        "--no-tags",
         head_repo,
-        ref if ref else '+refs/heads/*:refs/remotes/work/*'
+        ref if ref else "+refs/heads/*:refs/remotes/work/*",
     ]
 
-    retry_required_command(b'vcs', args, cwd=destination_path, extra_env=env)
+    retry_required_command(b"vcs", args, cwd=destination_path, extra_env=env)
 
     args = [
-        'git',
-        'checkout',
-        '-f',
+        "git",
+        "checkout",
+        "-f",
     ]
 
     if ref:
-        args.extend(['-B', ref])
+        args.extend(["-B", ref])
     args.append(commit if commit else ref)
 
-    run_required_command(b'vcs', args, cwd=destination_path)
+    run_required_command(b"vcs", args, cwd=destination_path)
 
-    if os.path.exists(os.path.join(destination_path, '.gitmodules')):
+    if os.path.exists(os.path.join(destination_path, ".gitmodules")):
         args = [
-            'git',
-            'submodule',
-            'init',
+            "git",
+            "submodule",
+            "init",
         ]
 
-        run_required_command(b'vcs', args, cwd=destination_path)
+        run_required_command(b"vcs", args, cwd=destination_path)
 
         args = [
-            'git',
-            'submodule',
-            'update',
+            "git",
+            "submodule",
+            "update",
         ]
 
-        run_required_command(b'vcs', args, cwd=destination_path)
+        run_required_command(b"vcs", args, cwd=destination_path)
 
     _clean_git_checkout(destination_path)
 
-    args = [
-        'git',
-        'rev-parse',
-        '--verify',
-        'HEAD'
-    ]
+    args = ["git", "rev-parse", "--verify", "HEAD"]
 
     commit_hash = subprocess.check_output(
         args, cwd=destination_path, universal_newlines=True
     ).strip()
-    assert re.match('^[a-f0-9]{40}$', commit_hash)
+    assert re.match("^[a-f0-9]{40}$", commit_hash)
 
-    if head_repo.startswith('https://github.com'):
-        if head_repo.endswith('/'):
+    if head_repo.startswith("https://github.com"):
+        if head_repo.endswith("/"):
             head_repo = head_repo[:-1]
 
-        tinderbox_link = '{}/commit/{}'.format(head_repo, commit_hash)
-        repo_name = head_repo.split('/')[-1]
+        tinderbox_link = "{}/commit/{}".format(head_repo, commit_hash)
+        repo_name = head_repo.split("/")[-1]
     else:
         tinderbox_link = head_repo
         repo_name = head_repo
 
-    msg = ("TinderboxPrint:<a href='{link}' "
-           "title='Built from {name} commit {commit_hash}'>"
-           "{commit_hash}</a>\n".format(commit_hash=commit_hash,
-                                        link=tinderbox_link,
-                                        name=repo_name))
+    msg = (
+        "TinderboxPrint:<a href='{link}' "
+        "title='Built from {name} commit {commit_hash}'>"
+        "{commit_hash}</a>\n".format(
+            commit_hash=commit_hash, link=tinderbox_link, name=repo_name
+        )
+    )
 
-    print_line(b'vcs', msg.encode('utf-8'))
+    print_line(b"vcs", msg.encode("utf-8"))
 
     return commit_hash
 
 
 def fetch_ssh_secret(secret_name):
-    """ Retrieves the private ssh key, and returns it as a StringIO object
-    """
+    """Retrieves the private ssh key, and returns it as a StringIO object"""
     secret_url = SECRET_BASEURL_TPL.format(secret_name)
     try:
-        print_line(b'vcs', b'fetching secret %s from %s\n' %
-                   (secret_name.encode('utf-8'), secret_url.encode('utf-8')))
+        print_line(
+            b"vcs",
+            b"fetching secret %s from %s\n"
+            % (secret_name.encode("utf-8"), secret_url.encode("utf-8")),
+        )
         res = urllib.request.urlopen(secret_url, timeout=10)
         secret = res.read()
         try:
-            secret = json.loads(secret.decode('utf-8'))
+            secret = json.loads(secret.decode("utf-8"))
         except ValueError:
-            print_line(b'vcs', b'invalid JSON in secret')
+            print_line(b"vcs", b"invalid JSON in secret")
             sys.exit(1)
     except (urllib.error.URLError, socket.timeout):
-        print_line(b'vcs', b'Unable to retrieve ssh secret. aborting...')
+        print_line(b"vcs", b"Unable to retrieve ssh secret. aborting...")
         sys.exit(1)
 
-    return secret['secret']['ssh_privkey']
+    return secret["secret"]["ssh_privkey"]
 
 
 def hg_checkout(
@@ -734,112 +749,119 @@ def hg_checkout(
     store_path: str,
     sparse_profile: Optional[str],
     branch: Optional[str],
-    revision: Optional[str]
+    revision: Optional[str],
 ):
     if IS_MACOSX:
-        hg_bin = '/tools/python27-mercurial/bin/hg'
+        hg_bin = "/tools/python27-mercurial/bin/hg"
     elif IS_POSIX:
-        hg_bin = 'hg'
+        hg_bin = "hg"
     elif IS_WINDOWS:
         # This is where OCC installs it in the AMIs.
-        hg_bin = r'C:\Program Files\Mercurial\hg.exe'
+        hg_bin = r"C:\Program Files\Mercurial\hg.exe"
         if not os.path.exists(hg_bin):
-            print('could not find Mercurial executable: %s' % hg_bin)
+            print("could not find Mercurial executable: %s" % hg_bin)
             sys.exit(1)
     else:
-        raise RuntimeError('Must be running on mac, posix or windows')
+        raise RuntimeError("Must be running on mac, posix or windows")
 
     args = [
         hg_bin,
-        'robustcheckout',
-        '--sharebase', store_path,
-        '--purge',
+        "robustcheckout",
+        "--sharebase",
+        store_path,
+        "--purge",
     ]
 
     if base_repo:
-        args.extend(['--upstream', base_repo])
+        args.extend(["--upstream", base_repo])
     if sparse_profile:
-        args.extend(['--sparseprofile', sparse_profile])
+        args.extend(["--sparseprofile", sparse_profile])
 
     # Specify method to checkout a revision. This defaults to revisions as
     # SHA-1 strings, but also supports symbolic revisions like `tip` via the
     # branch flag.
-    args.extend([
-        '--branch' if branch else '--revision',
-        branch or revision,
-        head_repo, destination_path,
-    ])
+    args.extend(
+        [
+            "--branch" if branch else "--revision",
+            branch or revision,
+            head_repo,
+            destination_path,
+        ]
+    )
 
-    run_required_command(b'vcs', args, extra_env={'PYTHONUNBUFFERED': '1'})
+    run_required_command(b"vcs", args, extra_env={"PYTHONUNBUFFERED": "1"})
 
     # Update the current revision hash and ensure that it is well formed.
     revision = subprocess.check_output(
-        [hg_bin, 'log',
-         '--rev', '.',
-         '--template', '{node}'],
+        [hg_bin, "log", "--rev", ".", "--template", "{node}"],
         cwd=destination_path,
         # Triggers text mode on Python 3.
-        universal_newlines=True)
+        universal_newlines=True,
+    )
 
-    assert re.match('^[a-f0-9]{40}$', revision)
+    assert re.match("^[a-f0-9]{40}$", revision)
 
-    msg = ("TinderboxPrint:<a href={head_repo}/rev/{revision} "
-           "title='Built from {repo_name} revision {revision}'>"
-           "{revision}</a>\n".format(revision=revision,
-                                     head_repo=head_repo,
-                                     repo_name=head_repo.split('/')[-1]))
+    msg = (
+        "TinderboxPrint:<a href={head_repo}/rev/{revision} "
+        "title='Built from {repo_name} revision {revision}'>"
+        "{revision}</a>\n".format(
+            revision=revision, head_repo=head_repo, repo_name=head_repo.split("/")[-1]
+        )
+    )
 
-    print_line(b'vcs', msg.encode('utf-8'))
+    print_line(b"vcs", msg.encode("utf-8"))
 
     return revision
 
 
 def fetch_artifacts():
-    print_line(b'fetches', b'fetching artifacts\n')
+    print_line(b"fetches", b"fetching artifacts\n")
 
-    fetch_content = shutil.which('fetch-content')
+    fetch_content = shutil.which("fetch-content")
 
     if not fetch_content or not os.path.isfile(fetch_content):
-        fetch_content = os.path.join(os.path.dirname(__file__),
-                                     'fetch-content')
+        fetch_content = os.path.join(os.path.dirname(__file__), "fetch-content")
 
     if not os.path.isfile(fetch_content):
         print(FETCH_CONTENT_NOT_FOUND)
         sys.exit(1)
 
-    cmd = [sys.executable, '-u', fetch_content, 'task-artifacts']
-    print_line(b'fetches', b'executing %r\n' % cmd)
+    cmd = [sys.executable, "-u", fetch_content, "task-artifacts"]
+    print_line(b"fetches", b"executing %r\n" % cmd)
     subprocess.run(cmd, check=True, env=os.environ)
-    print_line(b'fetches', b'finished fetching artifacts\n')
+    print_line(b"fetches", b"finished fetching artifacts\n")
 
 
 def add_vcs_arguments(parser, project, name):
     """Adds arguments to ArgumentParser to control VCS options for a project."""
 
-    parser.add_argument('--%s-checkout' % project,
-                        help='Directory where %s checkout should be created' %
-                             name)
-    parser.add_argument('--%s-sparse-profile' % project,
-                        help='Path to sparse profile for %s checkout' % name)
+    parser.add_argument(
+        "--%s-checkout" % project,
+        help="Directory where %s checkout should be created" % name,
+    )
+    parser.add_argument(
+        "--%s-sparse-profile" % project,
+        help="Path to sparse profile for %s checkout" % name,
+    )
 
 
 def collect_vcs_options(args, project, name):
-    checkout = getattr(args, '%s_checkout' % project)
-    sparse_profile = getattr(args, '%s_sparse_profile' % project)
+    checkout = getattr(args, "%s_checkout" % project)
+    sparse_profile = getattr(args, "%s_sparse_profile" % project)
 
     env_prefix = project.upper()
 
-    repo_type = os.environ.get('%s_REPOSITORY_TYPE' % env_prefix)
-    base_repo = os.environ.get('%s_BASE_REPOSITORY' % env_prefix)
-    base_ref = os.environ.get('%s_BASE_REF' % env_prefix)
-    base_rev = os.environ.get('%s_BASE_REV' % env_prefix)
-    head_repo = os.environ.get('%s_HEAD_REPOSITORY' % env_prefix)
-    revision = os.environ.get('%s_HEAD_REV' % env_prefix)
-    ref = os.environ.get('%s_HEAD_REF' % env_prefix)
-    pip_requirements = os.environ.get('%s_PIP_REQUIREMENTS' % env_prefix)
-    private_key_secret = os.environ.get('%s_SSH_SECRET_NAME' % env_prefix)
+    repo_type = os.environ.get("%s_REPOSITORY_TYPE" % env_prefix)
+    base_repo = os.environ.get("%s_BASE_REPOSITORY" % env_prefix)
+    base_ref = os.environ.get("%s_BASE_REF" % env_prefix)
+    base_rev = os.environ.get("%s_BASE_REV" % env_prefix)
+    head_repo = os.environ.get("%s_HEAD_REPOSITORY" % env_prefix)
+    revision = os.environ.get("%s_HEAD_REV" % env_prefix)
+    ref = os.environ.get("%s_HEAD_REF" % env_prefix)
+    pip_requirements = os.environ.get("%s_PIP_REQUIREMENTS" % env_prefix)
+    private_key_secret = os.environ.get("%s_SSH_SECRET_NAME" % env_prefix)
 
-    store_path = os.environ.get('HG_STORE_PATH')
+    store_path = os.environ.get("HG_STORE_PATH")
 
     # Expand ~ in some paths.
     if checkout:
@@ -853,48 +875,48 @@ def collect_vcs_options(args, project, name):
     # Some callers set the base repository to mozilla-central for historical
     # reasons. Switch to mozilla-unified because robustcheckout works best
     # with it.
-    if base_repo == 'https://hg.mozilla.org/mozilla-central':
-        base_repo = 'https://hg.mozilla.org/mozilla-unified'
+    if base_repo == "https://hg.mozilla.org/mozilla-central":
+        base_repo = "https://hg.mozilla.org/mozilla-unified"
 
     return {
-        'store-path': store_path,
-        'project': project,
-        'name': name,
-        'env-prefix': env_prefix,
-        'checkout': checkout,
-        'sparse-profile': sparse_profile,
-        'base-repo': base_repo,
-        'base-ref': base_ref,
-        'base-rev': base_rev,
-        'head-repo': head_repo,
-        'revision': revision,
-        'ref': ref,
-        'repo-type': repo_type,
-        'ssh-secret-name': private_key_secret,
-        'pip-requirements': pip_requirements,
+        "store-path": store_path,
+        "project": project,
+        "name": name,
+        "env-prefix": env_prefix,
+        "checkout": checkout,
+        "sparse-profile": sparse_profile,
+        "base-repo": base_repo,
+        "base-ref": base_ref,
+        "base-rev": base_rev,
+        "head-repo": head_repo,
+        "revision": revision,
+        "ref": ref,
+        "repo-type": repo_type,
+        "ssh-secret-name": private_key_secret,
+        "pip-requirements": pip_requirements,
     }
 
 
 def vcs_checkout_from_args(options):
 
-    if not options['checkout']:
-        if options['ref'] and not options['revision']:
-            print('task should be defined in terms of non-symbolic revision')
+    if not options["checkout"]:
+        if options["ref"] and not options["revision"]:
+            print("task should be defined in terms of non-symbolic revision")
             sys.exit(1)
         return
 
-    revision = options['revision']
-    ref = options['ref']
+    revision = options["revision"]
+    ref = options["ref"]
     ssh_key_file = None
     ssh_known_hosts_file = None
     ssh_dir = None
 
     try:
-        if options.get('ssh-secret-name'):
+        if options.get("ssh-secret-name"):
             ssh_dir = Path("~/.ssh-run-task").expanduser()
             os.makedirs(ssh_dir, 0o700)
-            ssh_key_file = ssh_dir.joinpath('private_ssh_key')
-            ssh_key = fetch_ssh_secret(options['ssh-secret-name'])
+            ssh_key_file = ssh_dir.joinpath("private_ssh_key")
+            ssh_key = fetch_ssh_secret(options["ssh-secret-name"])
             # We don't use write_text here, to avoid \n -> \r\n on windows
             ssh_key_file.write_bytes(ssh_key.encode("ascii"))
             ssh_key_file.chmod(0o600)
@@ -902,37 +924,40 @@ def vcs_checkout_from_args(options):
             ssh_known_hosts_file = ssh_dir.joinpath("known_hosts")
             ssh_known_hosts_file.write_bytes(GITHUB_SSH_FINGERPRINT)
 
-        if options['repo-type'] == 'git':
+        if options["repo-type"] == "git":
             if not revision and not ref:
-                raise RuntimeError('Git requires that either a ref, a revision, or both are provided')
+                raise RuntimeError(
+                    "Git requires that either a ref, a revision, or both are provided"
+                )
 
             if not ref:
-                print('Providing a ref will improve the performance of this checkout')
+                print("Providing a ref will improve the performance of this checkout")
 
             revision = git_checkout(
-                options['checkout'],
-                options['head-repo'],
-                options['base-repo'],
-                options['base-ref'],
-                options['base-rev'],
+                options["checkout"],
+                options["head-repo"],
+                options["base-repo"],
+                options["base-ref"],
+                options["base-rev"],
                 ref,
                 revision,
                 ssh_key_file,
                 ssh_known_hosts_file,
             )
-        elif options['repo-type'] == 'hg':
+        elif options["repo-type"] == "hg":
             if not revision and not ref:
-                raise RuntimeError('Hg requires that at least one of a ref or revision '
-                                   'is provided')
+                raise RuntimeError(
+                    "Hg requires that at least one of a ref or revision " "is provided"
+                )
 
             revision = hg_checkout(
-                options['checkout'],
-                options['head-repo'],
-                options['base-repo'],
-                options['store-path'],
-                options['sparse-profile'],
+                options["checkout"],
+                options["head-repo"],
+                options["base-repo"],
+                options["store-path"],
+                options["sparse-profile"],
                 ref,
-                revision
+                revision,
             )
         else:
             raise RuntimeError('Type of VCS must be either "git" or "hg"')
@@ -941,26 +966,25 @@ def vcs_checkout_from_args(options):
             shutil.rmtree(ssh_dir, ignore_errors=True)
             pass
 
-    os.environ['%s_HEAD_REV' % options['env-prefix']] = revision
+    os.environ["%s_HEAD_REV" % options["env-prefix"]] = revision
 
 
 def install_pip_requirements(repositories):
     """Install pip requirements files from specified repositories, if necessary."""
     requirements = [
-        r['pip-requirements'] for r in repositories
-        if r['pip-requirements']
+        r["pip-requirements"] for r in repositories if r["pip-requirements"]
     ]
     if not requirements:
         return
 
-    cmd = [sys.executable, '-mpip', 'install']
+    cmd = [sys.executable, "-mpip", "install"]
     if os.environ.get("PIP_DISABLE_REQUIRE_HASHES") != "1":
         cmd.append("--require-hashes")
 
     for path in requirements:
-        cmd.extend(['-r', path])
+        cmd.extend(["-r", path])
 
-    run_required_command(b'pip-install', cmd)
+    run_required_command(b"pip-install", cmd)
 
 
 def maybe_run_resource_monitoring():
@@ -970,46 +994,49 @@ def maybe_run_resource_monitoring():
     and https://bugzil.la/1648051
 
     """
-    if 'MOZ_FETCHES' not in os.environ:
+    if "MOZ_FETCHES" not in os.environ:
         return
-    if 'RESOURCE_MONITOR_OUTPUT' not in os.environ:
+    if "RESOURCE_MONITOR_OUTPUT" not in os.environ:
         return
 
-    prefix = b'resource_monitor'
+    prefix = b"resource_monitor"
 
-    executable = '{}/resource-monitor/resource-monitor{}'.format(
-        os.environ.get('MOZ_FETCHES_DIR'), '.exe' if IS_WINDOWS else '')
+    executable = "{}/resource-monitor/resource-monitor{}".format(
+        os.environ.get("MOZ_FETCHES_DIR"), ".exe" if IS_WINDOWS else ""
+    )
 
     if not os.path.exists(executable) or not os.access(executable, os.X_OK):
-        print_line(prefix, b"%s not executable\n" % executable.encode('utf-8'))
+        print_line(prefix, b"%s not executable\n" % executable.encode("utf-8"))
         return
     args = [
         executable,
-        '-process',
+        "-process",
         str(os.getpid()),
-        '-output',
+        "-output",
         os.environ["RESOURCE_MONITOR_OUTPUT"],
     ]
-    print_line(prefix, b"Resource monitor starting: %s\n" % str(args).encode('utf-8'))
+    print_line(prefix, b"Resource monitor starting: %s\n" % str(args).encode("utf-8"))
     # Avoid environment variables the payload doesn't need.
-    del os.environ['RESOURCE_MONITOR_OUTPUT']
+    del os.environ["RESOURCE_MONITOR_OUTPUT"]
 
     # Without CREATE_NEW_PROCESS_GROUP Windows signals will attempt to kill run-task, too.
-    process = subprocess.Popen(args,
-                               # Disable buffering because we want to receive output
-                               # as it is generated so timestamps in logs are
-                               # accurate.
-                               bufsize=0,
-                               stdout=subprocess.PIPE,
-                               stderr=subprocess.STDOUT,
-                               creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if IS_WINDOWS else 0,
-                               cwd=os.getcwd())
+    process = subprocess.Popen(
+        args,
+        # Disable buffering because we want to receive output
+        # as it is generated so timestamps in logs are
+        # accurate.
+        bufsize=0,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if IS_WINDOWS else 0,
+        cwd=os.getcwd(),
+    )
 
     def capture_output():
-        fh = io.TextIOWrapper(process.stdout, encoding='latin1')
+        fh = io.TextIOWrapper(process.stdout, encoding="latin1")
         while True:
-            data = fh.readline().encode('latin1')
-            if data == b'':
+            data = fh.readline().encode("latin1")
+            if data == b"":
                 break
             print_line(prefix, data)
 
@@ -1020,43 +1047,48 @@ def maybe_run_resource_monitoring():
 
 def main(args):
     os.environ["TASK_WORKDIR"] = os.getcwd()
-    print_line(b'setup', b'run-task started in %s\n' % os.environ["TASK_WORKDIR"].encode('utf-8'))
+    print_line(
+        b"setup",
+        b"run-task started in %s\n" % os.environ["TASK_WORKDIR"].encode("utf-8"),
+    )
     running_as_root = IS_POSIX and os.getuid() == 0
 
     # Arguments up to '--' are ours. After are for the main task
     # to be executed.
     try:
-        i = args.index('--')
+        i = args.index("--")
         our_args = args[0:i]
-        task_args = args[i + 1:]
+        task_args = args[i + 1 :]
     except ValueError:
         our_args = args
         task_args = []
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--user', default='worker', help='user to run as')
-    parser.add_argument('--group', default='worker', help='group to run as')
-    parser.add_argument('--task-cwd', help='directory to run the provided command in')
+    parser.add_argument("--user", default="worker", help="user to run as")
+    parser.add_argument("--group", default="worker", help="group to run as")
+    parser.add_argument("--task-cwd", help="directory to run the provided command in")
 
-    repositories = os.environ.get('REPOSITORIES')
+    repositories = os.environ.get("REPOSITORIES")
     if repositories:
         repositories = json.loads(repositories)
     else:
-        repositories = {'vcs': "repository"}
+        repositories = {"vcs": "repository"}
 
     for repository, name in repositories.items():
         add_vcs_arguments(parser, repository, name)
 
-    parser.add_argument('--fetch-hgfingerprint', action='store_true',
-                        help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--fetch-hgfingerprint", action="store_true", help=argparse.SUPPRESS
+    )
 
     args = parser.parse_args(our_args)
 
     repositories = [
-        collect_vcs_options(args, repository, name) for (repository, name) in repositories.items()
+        collect_vcs_options(args, repository, name)
+        for (repository, name) in repositories.items()
     ]
     # Sort repositories so that parent checkout paths come before children
-    repositories.sort(key=lambda repo: Path(repo['checkout'] or "/").parts)
+    repositories.sort(key=lambda repo: Path(repo["checkout"] or "/").parts)
 
     uid = gid = gids = None
     if IS_POSIX and running_as_root:
@@ -1075,46 +1107,48 @@ def main(args):
     # environment variable (which we don't want to pass down to child
     # processes).
 
-    if 'TASKCLUSTER_CACHES' in os.environ:
-        caches = os.environ['TASKCLUSTER_CACHES'].split(';')
-        del os.environ['TASKCLUSTER_CACHES']
+    if "TASKCLUSTER_CACHES" in os.environ:
+        caches = os.environ["TASKCLUSTER_CACHES"].split(";")
+        del os.environ["TASKCLUSTER_CACHES"]
     else:
         caches = []
 
-    if 'TASKCLUSTER_UNTRUSTED_CACHES' in os.environ:
+    if "TASKCLUSTER_UNTRUSTED_CACHES" in os.environ:
         untrusted_caches = True
-        del os.environ['TASKCLUSTER_UNTRUSTED_CACHES']
+        del os.environ["TASKCLUSTER_UNTRUSTED_CACHES"]
     else:
         untrusted_caches = False
 
     for cache in caches:
         if not os.path.isdir(cache):
-            print('error: cache %s is not a directory; this should never '
-                  'happen' % cache)
+            print(
+                "error: cache %s is not a directory; this should never "
+                "happen" % cache
+            )
             return 1
 
-        purge = configure_cache_posix(cache, user, group, untrusted_caches,
-                                      running_as_root)
+        purge = configure_cache_posix(
+            cache, user, group, untrusted_caches, running_as_root
+        )
 
         if purge:
             return EXIT_PURGE_CACHE
 
-    if 'TASKCLUSTER_VOLUMES' in os.environ:
-        volumes = os.environ['TASKCLUSTER_VOLUMES'].split(';')
-        del os.environ['TASKCLUSTER_VOLUMES']
+    if "TASKCLUSTER_VOLUMES" in os.environ:
+        volumes = os.environ["TASKCLUSTER_VOLUMES"].split(";")
+        del os.environ["TASKCLUSTER_VOLUMES"]
     else:
         volumes = []
 
     if volumes and not IS_POSIX:
-        print('assertion failed: volumes not expected on Windows')
+        print("assertion failed: volumes not expected on Windows")
         return 1
 
     # Sanitize volumes.
     for volume in volumes:
         # If a volume is a cache, it was dealt with above.
         if volume in caches:
-            print_line(b'volume', b'volume %s is a cache\n' %
-                       volume.encode('utf-8'))
+            print_line(b"volume", b"volume %s is a cache\n" % volume.encode("utf-8"))
             continue
 
         configure_volume_posix(volume, user, group, running_as_root)
@@ -1142,17 +1176,19 @@ def main(args):
         # The checkout path becomes the working directory. Since there are
         # special cache files in the cache's root directory and working
         # directory purging could blow them away, disallow this scenario.
-        if os.path.exists(os.path.join(checkout, '.cacherequires')):
-            print('error: cannot perform vcs checkout into cache root: %s' %
-                  checkout)
+        if os.path.exists(os.path.join(checkout, ".cacherequires")):
+            print("error: cannot perform vcs checkout into cache root: %s" % checkout)
             sys.exit(1)
 
         # TODO given the performance implications, consider making this a fatal
         # error.
         if not path_in_cache_or_volume(checkout):
-            print_line(b'vcs', b'WARNING: vcs checkout path (%s) not in cache '
-                               b'or volume; performance will likely suffer\n' %
-                               checkout.encode('utf-8'))
+            print_line(
+                b"vcs",
+                b"WARNING: vcs checkout path (%s) not in cache "
+                b"or volume; performance will likely suffer\n"
+                % checkout.encode("utf-8"),
+            )
 
         # Ensure the directory for the source checkout exists.
         try:
@@ -1167,16 +1203,19 @@ def main(args):
 
     def prepare_hg_store_path():
         # And ensure the shared store path exists and has proper permissions.
-        if 'HG_STORE_PATH' not in os.environ:
-            print('error: HG_STORE_PATH environment variable not set')
+        if "HG_STORE_PATH" not in os.environ:
+            print("error: HG_STORE_PATH environment variable not set")
             sys.exit(1)
 
-        store_path = os.environ['HG_STORE_PATH']
+        store_path = os.environ["HG_STORE_PATH"]
 
         if not path_in_cache_or_volume(store_path):
-            print_line(b'vcs', b'WARNING: HG_STORE_PATH (%s) not in cache or '
-                               b'volume; performance will likely suffer\n' %
-                               store_path.encode('utf-8'))
+            print_line(
+                b"vcs",
+                b"WARNING: HG_STORE_PATH (%s) not in cache or "
+                b"volume; performance will likely suffer\n"
+                % store_path.encode("utf-8"),
+            )
 
         try:
             os.makedirs(store_path)
@@ -1191,17 +1230,15 @@ def main(args):
         Path(repo["checkout"]) for repo in repositories if repo["checkout"]
     ]
     for repo in repositories:
-        if not repo['checkout']:
+        if not repo["checkout"]:
             continue
-        parents = Path(repo['checkout']).parents
+        parents = Path(repo["checkout"]).parents
         if any((path in repository_paths) for path in parents):
             # Skip creating any checkouts that are inside other checokuts
             continue
-        prepare_checkout_dir(repo['checkout'])
+        prepare_checkout_dir(repo["checkout"])
 
-    if any(
-        repo['checkout'] and repo['repo-type'] == 'hg' for repo in repositories
-    ):
+    if any(repo["checkout"] and repo["repo-type"] == "hg" for repo in repositories):
         prepare_hg_store_path()
 
     if IS_POSIX and running_as_root:
@@ -1209,8 +1246,11 @@ def main(args):
         # This code is modeled after what `sudo` was observed to do in a Docker
         # container. We do not bother calling setrlimit() because containers have
         # their own limits.
-        print_line(b'setup', b'running as %s:%s\n' % (
-            args.user.encode('utf-8'), args.group.encode('utf-8')))
+        print_line(
+            b"setup",
+            b"running as %s:%s\n"
+            % (args.user.encode("utf-8"), args.group.encode("utf-8")),
+        )
 
         os.setgroups(gids)
         os.umask(0o22)
@@ -1223,16 +1263,18 @@ def main(args):
     resource_process = None
 
     try:
-        for k in ['MOZ_FETCHES_DIR', 'UPLOAD_DIR'] + [
-            '{}_PATH'.format(repository['project'].upper()) for repository in repositories
+        for k in ["MOZ_FETCHES_DIR", "UPLOAD_DIR"] + [
+            "{}_PATH".format(repository["project"].upper())
+            for repository in repositories
         ]:
             if k in os.environ:
                 os.environ[k] = os.path.abspath(os.environ[k])
-                print_line(b'setup', b'%s is %s\n' % (
-                    k.encode('utf-8'),
-                    os.environ[k].encode('utf-8')))
+                print_line(
+                    b"setup",
+                    b"%s is %s\n" % (k.encode("utf-8"), os.environ[k].encode("utf-8")),
+                )
 
-        if 'MOZ_FETCHES' in os.environ:
+        if "MOZ_FETCHES" in os.environ:
             fetch_artifacts()
 
         # Install Python requirements after fetches in case tasks want to use
@@ -1241,10 +1283,10 @@ def main(args):
 
         resource_process = maybe_run_resource_monitoring()
 
-        return run_command(b'task', task_args, cwd=args.task_cwd)
+        return run_command(b"task", task_args, cwd=args.task_cwd)
     finally:
         if resource_process:
-            print_line(b'resource_monitor', b'terminating\n')
+            print_line(b"resource_monitor", b"terminating\n")
             if IS_WINDOWS:
                 # .terminate() on Windows is not a graceful shutdown, due to
                 # differences in signals. CTRL_BREAK_EVENT will work provided
@@ -1254,12 +1296,12 @@ def main(args):
             else:
                 resource_process.terminate()
             resource_process.wait()
-        fetches_dir = os.environ.get('MOZ_FETCHES_DIR')
+        fetches_dir = os.environ.get("MOZ_FETCHES_DIR")
         if fetches_dir and os.path.isdir(fetches_dir):
-            print_line(b'fetches', b'removing %s\n' % fetches_dir.encode('utf-8'))
+            print_line(b"fetches", b"removing %s\n" % fetches_dir.encode("utf-8"))
             remove(fetches_dir)
-            print_line(b'fetches', b'finished\n')
+            print_line(b"fetches", b"finished\n")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main(sys.argv[1:]))

--- a/src/taskgraph/transforms/fetch.py
+++ b/src/taskgraph/transforms/fetch.py
@@ -286,6 +286,7 @@ def create_fetch_url_task(config, name, fetch):
     schema={
         Required("repo"): str,
         Required("revision"): str,
+        Optional("include-dot-git"): bool,
         Optional("artifact-name"): str,
         Optional("path-prefix"): str,
         # ssh-key is a taskcluster secret path (e.g. project/civet/github-deploy-key)
@@ -321,9 +322,14 @@ def create_git_fetch_task(config, name, fetch):
         args.append("--ssh-key-secret")
         args.append(ssh_key)
 
+    digest_data = [fetch["revision"], path_prefix, artifact_name]
+    if fetch.get("include-dot-git", False):
+        args.append("--include-dot-git")
+        digest_data.append(".git")
+
     return {
         "command": args,
         "artifact_name": artifact_name,
-        "digest_data": [fetch["revision"], path_prefix, artifact_name],
+        "digest_data": digest_data,
         "secret": ssh_key,
     }

--- a/src/taskgraph/transforms/fetch.py
+++ b/src/taskgraph/transforms/fetch.py
@@ -157,6 +157,10 @@ def make_task(config, jobs):
                 "tier": 1,
             }
 
+        if job.get("secret", None):
+            task["scopes"] = ["secrets:get:" + job.get("secret")]
+            task["worker"]["taskcluster-proxy"] = True
+
         if not taskgraph.fast:
             cache_name = task["label"].replace(f"{config.kind}-", "", 1)
 
@@ -284,6 +288,11 @@ def create_fetch_url_task(config, name, fetch):
         Required("revision"): str,
         Optional("artifact-name"): str,
         Optional("path-prefix"): str,
+        # ssh-key is a taskcluster secret path (e.g. project/civet/github-deploy-key)
+        # In the secret dictionary, the key should be specified as
+        #  "ssh_privkey": "-----BEGIN OPENSSH PRIVATE KEY-----\nkfksnb3jc..."
+        # n.b. The OpenSSH private key file format requires a newline at the end of the file.
+        Optional("ssh-key"): str,
     },
 )
 def create_git_fetch_task(config, name, fetch):
@@ -307,8 +316,14 @@ def create_git_fetch_task(config, name, fetch):
         "/builds/worker/artifacts/%s" % artifact_name,
     ]
 
+    ssh_key = fetch.get("ssh-key")
+    if ssh_key:
+        args.append("--ssh-key-secret")
+        args.append(ssh_key)
+
     return {
         "command": args,
         "artifact_name": artifact_name,
         "digest_data": [fetch["revision"], path_prefix, artifact_name],
+        "secret": ssh_key,
     }

--- a/src/taskgraph/transforms/job/__init__.py
+++ b/src/taskgraph/transforms/job/__init__.py
@@ -79,6 +79,7 @@ job_description_schema = Schema(
                     Required("artifact"): str,
                     Optional("dest"): str,
                     Optional("extract"): bool,
+                    Optional("verify-hash"): bool,
                 },
             ],
         },
@@ -298,10 +299,12 @@ def use_fetches(config, jobs):
                         path = artifact
                         dest = None
                         extract = True
+                        verify_hash = False
                     else:
                         path = artifact["artifact"]
                         dest = artifact.get("dest")
                         extract = artifact.get("extract", True)
+                        verify_hash = artifact.get("verify-hash", False)
 
                     fetch = {
                         "artifact": f"{prefix}/{path}",
@@ -310,6 +313,8 @@ def use_fetches(config, jobs):
                     }
                     if dest is not None:
                         fetch["dest"] = dest
+                    if verify_hash:
+                        fetch["verify-hash"] = verify_hash
                     job_fetches.append(fetch)
 
         job_artifact_prefixes = {

--- a/test/test_scripts_fetch_content.py
+++ b/test/test_scripts_fetch_content.py
@@ -59,7 +59,7 @@ def fetch_content_mod():
 def test_stream_download(
     monkeypatch, fetch_content_mod, url, sha256, size, headers, raises
 ):
-    def mock_urlopen(req):
+    def mock_urlopen(req, *, cafile=None):
         assert req._full_url == url
         if headers:
             assert len(req.headers) == len(headers)


### PR DESCRIPTION
This brings all changes to gecko's version of fetch-content from the last couple of years to upstream taskgraph.

In addition this updates the robustcheckout hg extension to the latest version, and reformats the scripts in the `run-task` directory with black.

Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1796139