### PR TITLE
fix: sort taskgraph label output

### DIFF
--- a/src/taskgraph/main.py
+++ b/src/taskgraph/main.py
@@ -47,7 +47,9 @@ def argument(*args, **kwargs):
 
 def format_taskgraph_labels(taskgraph):
     return "\n".join(
-        taskgraph.tasks[index].label for index in taskgraph.graph.visit_postorder()
+        sorted(
+            taskgraph.tasks[index].label for index in taskgraph.graph.visit_postorder()
+        )
     )
 
 


### PR DESCRIPTION
When using the formatter that just outputs the labels, tasks will appear all out of order due to how dependencies are added. When the graph is large, it's very difficult to find the task you're looking for. Sorting the output makes this much better.