### PR TITLE
Bug 1798930 - Support .tgz extension in fetch-content

### DIFF
--- a/src/taskgraph/run-task/fetch-content
+++ b/src/taskgraph/run-task/fetch-content
@@ -321,7 +321,7 @@ def open_tar_stream(path: pathlib.Path):
     """"""
     if path.suffix == ".bz2":
         return bz2.open(str(path), "rb")
-    elif path.suffix == ".gz":
+    elif path.suffix in (".gz", ".tgz") :
         return gzip.open(str(path), "rb")
     elif path.suffix == ".xz":
         return lzma.open(str(path), "rb")
@@ -336,7 +336,7 @@ def open_tar_stream(path: pathlib.Path):
 
 def archive_type(path: pathlib.Path):
     """Attempt to identify a path as an extractable archive."""
-    if path.suffixes[-2:-1] == [".tar"]:
+    if path.suffixes[-2:-1] == [".tar"] or path.suffixes[-1:] == [".tgz"]:
         return "tar"
     elif path.suffix == ".zip":
         return "zip"


### PR DESCRIPTION
Many projects use .tgz as a shortcut to .tar.gz. Support that pattern.