### PR TITLE
feat: add an action to rebuild cached tasks

### DIFF
--- a/src/taskgraph/actions/rebuild_cached_tasks.py
+++ b/src/taskgraph/actions/rebuild_cached_tasks.py
@@ -1,0 +1,36 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from .registry import register_callback_action
+from .util import create_tasks, fetch_graph_and_labels
+
+
+@register_callback_action(
+    name="rebuild-cached-tasks",
+    title="Rebuild Cached Tasks",
+    symbol="rebuild-cached",
+    description="Rebuild cached tasks.",
+    order=1000,
+    context=[],
+)
+def rebuild_cached_tasks_action(
+    parameters, graph_config, input, task_group_id, task_id
+):
+    decision_task_id, full_task_graph, label_to_taskid = fetch_graph_and_labels(
+        parameters, graph_config
+    )
+    cached_tasks = [
+        label
+        for label, task in full_task_graph.tasks.items()
+        if task.attributes.get("cached_task", False)
+    ]
+    if cached_tasks:
+        create_tasks(
+            graph_config,
+            cached_tasks,
+            full_task_graph,
+            label_to_taskid,
+            parameters,
+            decision_task_id,
+        )

--- a/test/data/taskcluster/ci/config.yml
+++ b/test/data/taskcluster/ci/config.yml
@@ -1,0 +1,9 @@
+---
+trust-domain: test
+task-priority: low
+taskgraph:
+    repositories:
+        ci:
+            name: Taskgraph
+workers:
+    aliases: {}

--- a/test/test_actions_rebuild_cached_tasks.py
+++ b/test/test_actions_rebuild_cached_tasks.py
@@ -1,0 +1,55 @@
+"""
+Tests for the 'rebuild_cached_tasks' action.
+"""
+import pytest
+
+from taskgraph import create
+from taskgraph.actions import trigger_action_callback
+from taskgraph.util import taskcluster as tc_util
+
+from .conftest import make_graph, make_task
+
+
+@pytest.fixture
+def run_action(capsys, mocker, monkeypatch, parameters, graph_config):
+    # Monkeypatch these here so they get restored to their original values.
+    # Otherwise, `trigger_action_callback` will leave them set to `True` and
+    # cause failures in other tests.
+    monkeypatch.setattr(create, "testing", True)
+    monkeypatch.setattr(tc_util, "testing", True)
+
+    def inner(name, graph):
+        tgid = "group-id"
+        m = mocker.patch(
+            "taskgraph.actions.rebuild_cached_tasks.fetch_graph_and_labels"
+        )
+        m.return_value = (
+            tgid,
+            graph,
+            {},
+        )
+        trigger_action_callback(
+            task_group_id=tgid,
+            task_id=None,
+            input=None,
+            callback=name,
+            parameters=parameters,
+            root=graph_config.root_dir,
+            test=True,
+        )
+        captured = capsys.readouterr()
+        return captured.out, captured.err
+
+    return inner
+
+
+def test_rebuild_cached_tasks(run_action):
+    graph = make_graph(
+        make_task(
+            label="foo", attributes={"cached_task": True}, task_def={"name": "foo"}
+        ),
+        make_task(label="bar", task_def={"name": "bar"}),
+    )
+    out, _ = run_action("rebuild-cached-tasks", graph)
+    assert "foo" in out
+    assert "bar" not in out


### PR DESCRIPTION
This copies the existing action in Gecko to standalone Taskgraph + adds a test.