### PR TITLE
Revert "Support docker-worker capability disableSeccomp"

### DIFF
--- a/src/taskgraph/transforms/task.py
+++ b/src/taskgraph/transforms/task.py
@@ -268,7 +268,6 @@ def verify_index(config, index):
         Required("loopback-audio"): bool,
         Required("docker-in-docker"): bool,  # (aka 'dind')
         Required("privileged"): bool,
-        Required("disable-seccomp"): bool,
         # Paths to Docker volumes.
         #
         # For in-tree Docker images, volumes can be parsed from Dockerfile.
@@ -406,10 +405,6 @@ def build_docker_worker_payload(config, task, task_def):
     if worker.get("privileged"):
         capabilities["privileged"] = True
         task_def["scopes"].append("docker-worker:capability:privileged")
-
-    if worker.get("disable-seccomp"):
-        capabilities["disableSeccomp"] = True
-        task_def["scopes"].append("docker-worker:capability:disableSeccomp")
 
     task_def["payload"] = payload = {
         "image": image,
@@ -836,7 +831,6 @@ def set_defaults(config, tasks):
             worker.setdefault("loopback-audio", False)
             worker.setdefault("docker-in-docker", False)
             worker.setdefault("privileged", False)
-            worker.setdefault("disable-seccomp", False)
             worker.setdefault("volumes", [])
             worker.setdefault("env", {})
             if "caches" in worker:


### PR DESCRIPTION
This reverts PR #140, since it is no longer needed. The underlying docker-worker feature was removed in taskcluster/taskcluster#5800 when it was [discovered to be superfluous](https://github.com/taskcluster/taskcluster/pull/5800#issuecomment-1330766821).