### PR TITLE
Revert "Bug 1788606 - mobile: add gradle cache as a mounted volume"

### DIFF
--- a/taskcluster/docker/decision-mobile/Dockerfile
+++ b/taskcluster/docker/decision-mobile/Dockerfile
@@ -1,8 +1,6 @@
 ARG DOCKER_IMAGE_PARENT
 FROM $DOCKER_IMAGE_PARENT
 
-VOLUME /builds/worker/.gradle
-
 RUN apt-get update && \
     apt-get install -y --force-yes --no-install-recommends \
     # We need java 8 for sdkmanager


### PR DESCRIPTION
Reverts taskcluster/taskgraph#160

See https://github.com/mozilla-mobile/firefox-android/pull/340. This approach didn't pay off after all.