### PR TITLE
feat: support extra 'run-task' features in toolchains

### DIFF
--- a/src/taskgraph/transforms/job/toolchain.py
+++ b/src/taskgraph/transforms/job/toolchain.py
@@ -5,7 +5,7 @@
 Support for running toolchain-building jobs via dedicated scripts
 """
 
-from voluptuous import Any, Optional, Required
+from voluptuous import ALLOW_EXTRA, Any, Optional, Required
 
 import taskgraph
 from taskgraph.transforms.job import configure_taskdesc_for_run, run_job_using
@@ -49,7 +49,8 @@ toolchain_run_schema = Schema(
         ): {str: object},
         # Base work directory used to set up the task.
         Required("workdir"): str,
-    }
+    },
+    extra=ALLOW_EXTRA,
 )
 
 

--- a/test/test_transforms_job_toolchain.py
+++ b/test/test_transforms_job_toolchain.py
@@ -184,6 +184,11 @@ def assert_powershell(job, _):
     }
 
 
+def assert_forward(job, _):
+    """Assert unknown schema args are forwarded to run_task"""
+    assert job["run"]["foo"] == "bar"
+
+
 @pytest.mark.parametrize(
     "task",
     (
@@ -221,6 +226,10 @@ def assert_powershell(job, _):
                 },
             },
             id="powershell",
+        ),
+        pytest.param(
+            {"run": {"foo": "bar"}},
+            id="forward",
         ),
     ),
 )


### PR DESCRIPTION
This ensures we forward unrecognized schema arguments to the `run_task.py` transforms. Validation of these arguments will then happen over there.