### PR TITLE
Mock out decision._determine_more_accurate_base_ref in decision tasks

### DIFF
--- a/test/test_decision.py
+++ b/test/test_decision.py
@@ -66,10 +66,17 @@ class TestGetDecisionParameters(unittest.TestCase):
             decision._determine_more_accurate_base_rev
         )
         decision._determine_more_accurate_base_rev = lambda *_, **__: "abcd"
+        self.old_determine_more_accurate_base_ref = (
+            decision._determine_more_accurate_base_ref
+        )
+        decision._determine_more_accurate_base_ref = lambda *_, **__: "abcd"
 
     def tearDown(self):
         decision._determine_more_accurate_base_rev = (
             self.old_determine_more_accurate_base_rev
+        )
+        decision._determine_more_accurate_base_ref = (
+            self.old_determine_more_accurate_base_ref
         )
 
     def test_simple_options(self):


### PR DESCRIPTION
We already mock out decision._determine_more_accurate_base_rev, so I'm guessing we want to do this as well. Without it, these tests end up running some `util/vcs.py` code against your local taskgraph repo. In my case, this [fails to guess the default branch](https://github.com/taskcluster/taskgraph/blob/936142a8c73510d0a0b530ac4a9a16d54cced6c9/src/taskgraph/util/vcs.py#L399-L412) because I have multiple remotes configured.