### PR TITLE
Add support for command-context.from-file in run-task

### DIFF
--- a/src/taskgraph/transforms/job/run_task.py
+++ b/src/taskgraph/transforms/job/run_task.py
@@ -9,12 +9,13 @@ Support for running jobs that are invoked via the `run-task` script.
 import os
 
 import attr
-from voluptuous import Any, Optional, Required
+from voluptuous import Any, Extra, Optional, Required
 
 from taskgraph.transforms.job import run_job_using
 from taskgraph.transforms.job.common import support_vcs_checkout
 from taskgraph.transforms.task import taskref_or_string
 from taskgraph.util import path, taskcluster
+from taskgraph.util.yaml import load_yaml
 from taskgraph.util.schema import Schema
 
 EXEC_COMMANDS = {
@@ -49,7 +50,13 @@ run_task_schema = Schema(
         # Context to substitute into the command using format string
         # substitution (e.g {value}). This is useful if certain aspects of the
         # command need to be generated in transforms.
-        Optional("command-context"): dict,
+        Optional("command-context"): {
+            # If present, loads a set of context variables from an unnested yaml
+            # file. If a value is present in both the provided file and directly
+            # in command-context, the latter will take priority.
+            Optional("from-file"): str,
+            Extra: object,
+        },
         # What to execute the command with in the event command is a string.
         Optional("exec-with"): Any(*list(EXEC_COMMANDS)),
         # Base work directory used to set up the task.
@@ -128,6 +135,25 @@ def script_url(config, script):
     return f"{tc_url}/api/queue/v1/task/{task_id}/artifacts/public/{script}"
 
 
+def substitute_command_context(command_context, command):
+    from_file = command_context.pop("from-file", None)
+    full_context = {}
+    if from_file:
+        full_context = load_yaml(from_file)
+    else:
+        full_context = {}
+
+    full_context.update(command_context)
+
+    if isinstance(command, list):
+        for i in range(len(command)):
+            command[i] = command[i].format(**full_context)
+    else:
+        command = command.format(**full_context)
+
+    return command
+
+
 @run_job_using(
     "docker-worker", "run-task", schema=run_task_schema, defaults=worker_defaults
 )
@@ -149,9 +175,12 @@ def docker_worker_run_task(config, job, taskdesc):
 
     run_command = run["command"]
 
-    command_context = run.get("command-context")
-    if command_context:
-        run_command = run_command.format(**command_context)
+    if run.get("command-context"):
+        run_command = substitute_command_context(
+            run.get("command-context"), run["command"]
+        )
+    else:
+        run_command = run["command"]
 
     # dict is for the case of `{'task-reference': str}`.
     if isinstance(run_command, str) or isinstance(run_command, dict):
@@ -217,10 +246,10 @@ def generic_worker_run_task(config, job, taskdesc):
         exec_cmd = EXEC_COMMANDS[run.pop("exec-with", "bash")]
         run_command = exec_cmd + [run_command]
 
-    command_context = run.get("command-context")
-    if command_context:
-        for i in range(len(run_command)):
-            run_command[i] = run_command[i].format(**command_context)
+    if run.get("command-context"):
+        run_command = substitute_command_context(
+            run.get("command-context"), run_command
+        )
 
     if run["run-as-root"]:
         command.extend(("--user", "root", "--group", "root"))

--- a/src/taskgraph/transforms/job/run_task.py
+++ b/src/taskgraph/transforms/job/run_task.py
@@ -15,8 +15,8 @@ from taskgraph.transforms.job import run_job_using
 from taskgraph.transforms.job.common import support_vcs_checkout
 from taskgraph.transforms.task import taskref_or_string
 from taskgraph.util import path, taskcluster
-from taskgraph.util.yaml import load_yaml
 from taskgraph.util.schema import Schema
+from taskgraph.util.yaml import load_yaml
 
 EXEC_COMMANDS = {
     "bash": ["bash", "-cx"],

--- a/test/data/command_context.yaml
+++ b/test/data/command_context.yaml
@@ -1,0 +1,1 @@
+extra_string: "world"

--- a/test/test_transforms_job_run_task.py
+++ b/test/test_transforms_job_run_task.py
@@ -1,9 +1,9 @@
 """
 Tests for the 'toolchain' transforms.
 """
+import os.path
 from pprint import pprint
 
-import os.path
 import pytest
 
 from taskgraph.transforms.job import make_task_description

--- a/test/test_transforms_job_run_task.py
+++ b/test/test_transforms_job_run_task.py
@@ -3,10 +3,13 @@ Tests for the 'toolchain' transforms.
 """
 from pprint import pprint
 
+import os.path
 import pytest
 
 from taskgraph.transforms.job import make_task_description
 from taskgraph.util.templates import merge
+
+here = os.path.abspath(os.path.dirname(__file__))
 
 TASK_DEFAULTS = {
     "description": "fake description",
@@ -19,7 +22,10 @@ TASK_DEFAULTS = {
     },
     "run": {
         "using": "run-task",
-        "command": "echo hello world",
+        "command": "echo hello {extra_string}",
+        "command-context": {
+            "from-file": f"{here}/data/command_context.yaml",
+        },
     },
 }
 


### PR DESCRIPTION
This can be useful in cases where context is shared across many tasks and/or kinds, so it can be centralized elsewhere.

This is largely same as the Gecko specific version I wrote in https://phabricator.services.mozilla.com/D170242, with the exception that there's no root or base directory assumed -- the file path will be treated as is (whether it's absolute or remote).