### PR TITLE
Memoize taskgraph.util.load_yaml 

### DIFF
--- a/src/taskgraph/actions/registry.py
+++ b/src/taskgraph/actions/registry.py
@@ -31,7 +31,6 @@ def is_json(data):
     return True
 
 
-@memoize
 def read_taskcluster_yml(filename):
     """Load and parse .taskcluster.yml, memoized to save some time"""
     return yaml.load_yaml(filename)

--- a/src/taskgraph/util/docker.py
+++ b/src/taskgraph/util/docker.py
@@ -299,7 +299,6 @@ def stream_context_tar(topsrcdir, context_dir, out_file, image_name=None, args=N
     return writer.hexdigest()
 
 
-@memoize
 def image_paths():
     """Return a map of image name to paths containing their Dockerfile."""
     config = load_yaml("taskcluster", "ci", "docker-image", "kind.yml")

--- a/src/taskgraph/util/yaml.py
+++ b/src/taskgraph/util/yaml.py
@@ -5,6 +5,7 @@
 
 import os
 
+from .memoize import memoize
 from yaml.loader import SafeLoader
 
 
@@ -28,6 +29,7 @@ def load_stream(stream):
         loader.dispose()
 
 
+@memoize
 def load_yaml(*parts):
     """Convenience function to load a YAML file in the given path.  This is
     useful for loading kind configuration files from the kind path."""

--- a/src/taskgraph/util/yaml.py
+++ b/src/taskgraph/util/yaml.py
@@ -5,8 +5,9 @@
 
 import os
 
-from .memoize import memoize
 from yaml.loader import SafeLoader
+
+from .memoize import memoize
 
 
 class UnicodeLoader(SafeLoader):

--- a/test/test_util_yaml.py
+++ b/test/test_util_yaml.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from textwrap import dedent
+from unittest import mock
 
 from taskgraph.util import yaml
 
@@ -10,6 +11,7 @@ from .mockedopen import MockedOpen
 
 
 def test_load():
+    yaml.load_yaml.clear()
     with MockedOpen(
         {
             "/dir1/dir2/foo.yml": dedent(
@@ -23,7 +25,27 @@ def test_load():
         assert yaml.load_yaml("/dir1/dir2", "foo.yml") == {"prop": ["val1"]}
 
 
+@mock.patch("taskgraph.util.yaml.load_stream")
+def test_is_memoized(mocked_load_stream):
+    yaml.load_yaml.clear()
+    with MockedOpen(
+        {
+            "/dir1/dir2/foo.yml": dedent(
+                """\
+                prop:
+                    - val1
+                """
+            )
+        }
+    ):
+        yaml.load_yaml("/dir1/dir2", "foo.yml")
+        yaml.load_yaml("/dir1/dir2", "foo.yml")
+        yaml.load_yaml("/dir1/dir2", "foo.yml")
+        assert mocked_load_stream.call_count == 1
+
+
 def test_key_order():
+    yaml.load_yaml.clear()
     with MockedOpen(
         {
             "/dir1/dir2/foo.yml": dedent(


### PR DESCRIPTION
It _feels_ like this ought to be safe to do everywhere, but it's difficult to shake the feeling that there may be some edge cases lurking out there where a file would _want_ to be reloaded. The only plausible way this seems like it _should_ happen is in a scenario where a yaml file is being written and loaded during taskgraph generation...which is pretty far fetched, and possibly even something we would explicitly not support. Any such scenario would reduce the determinism of taskgraph, which seems like something that should be avoided.

I did test in Gecko with a number of different parameter sets, and the taskgraphs came out identical with and without this memoized - so that's _some_ level of assurance that this is not totally out there.