### PR TITLE
docs: update python version for the decision image

### DIFF
--- a/docs/howto/bootstrap-taskgraph.rst
+++ b/docs/howto/bootstrap-taskgraph.rst
@@ -34,7 +34,7 @@ Next, create the ``requirements.in`` file:
    cd taskcluster
    echo "taskcluster-taskgraph" > requirements.in
    # This works best if you use the same Python as the one used in the Decision
-   # image (currently 3.6).
+   # image (currently 3.8).
    pip-compile --generate-hashes --output-file requirements.txt requirements.in
 
 .. note::


### PR DESCRIPTION
Since commit 58ab2b74e436aab766b8f1ae3c2c346a888ef30c "decision: update docker image to Ubuntu 20.04 and Mercurial 5.3.1", the decision and decision-mobile images use python 3.8.