### PR TITLE
Revert "fix: `DONTBUILD` on `github-push`."

### DIFF
--- a/src/taskgraph/decision.py
+++ b/src/taskgraph/decision.py
@@ -227,9 +227,7 @@ def get_decision_parameters(graph_config, options):
     # ..but can be overridden by the commit message: if it contains the special
     # string "DONTBUILD" and this is an on-push decision task, then use the
     # special 'nothing' target task method.
-    if "DONTBUILD" in commit_message and (
-        options["tasks_for"] in ("hg-push", "github-push")
-    ):
+    if "DONTBUILD" in commit_message and options["tasks_for"] == "hg-push":
         parameters["target_tasks_method"] = "nothing"
 
     if options.get("optimize_target_tasks") is not None:

--- a/test/test_decision.py
+++ b/test/test_decision.py
@@ -91,22 +91,6 @@ class TestGetDecisionParameters(unittest.TestCase):
         params = decision.get_decision_parameters(FAKE_GRAPH_CONFIG, self.options)
         self.assertEqual(params["owner"], "ffxbld@noreply.mozilla.org")
 
-    def test_dontbuild(self):
-        repo_mock = unittest.mock.MagicMock()
-        repo_mock.commit_message = "Add FOO DONTBUILD"
-
-        self.options["tasks_for"] = "github-release"
-        params = decision.get_decision_parameters(FAKE_GRAPH_CONFIG, self.options)
-        self.assertNotEqual(params["target_tasks_method"], "nothing")
-
-        self.options["tasks_for"] = "github-push"
-        params = decision.get_decision_parameters(FAKE_GRAPH_CONFIG, self.options)
-        self.assertEqual(params["target_tasks_method"], "nothing")
-
-        self.options["tasks_for"] = "hg-push"
-        params = decision.get_decision_parameters(FAKE_GRAPH_CONFIG, self.options)
-        self.assertEqual(params["target_tasks_method"], "nothing")
-
 
 @pytest.mark.parametrize(
     "candidate_base_ref, base_rev, expected_base_ref",


### PR DESCRIPTION
Reverts taskcluster/taskgraph#191 for breaking unit tests[1]: 

```
[task 2023-02-24T13:41:13.181Z] =================================== FAILURES ===================================
[task 2023-02-24T13:41:13.181Z] ___________________ TestGetDecisionParameters.test_dontbuild ___________________
[task 2023-02-24T13:41:13.181Z] 
[task 2023-02-24T13:41:13.181Z] self = <test.test_decision.TestGetDecisionParameters testMethod=test_dontbuild>
[task 2023-02-24T13:41:13.181Z] 
[task 2023-02-24T13:41:13.181Z]     def test_dontbuild(self):
[task 2023-02-24T13:41:13.181Z]         repo_mock = unittest.mock.MagicMock()
[task 2023-02-24T13:41:13.181Z]         repo_mock.commit_message = "Add FOO DONTBUILD"
[task 2023-02-24T13:41:13.181Z]     
[task 2023-02-24T13:41:13.181Z]         self.options["tasks_for"] = "github-release"
[task 2023-02-24T13:41:13.181Z]         params = decision.get_decision_parameters(FAKE_GRAPH_CONFIG, self.options)
[task 2023-02-24T13:41:13.181Z]         self.assertNotEqual(params["target_tasks_method"], "nothing")
[task 2023-02-24T13:41:13.181Z]     
[task 2023-02-24T13:41:13.181Z]         self.options["tasks_for"] = "github-push"
[task 2023-02-24T13:41:13.181Z]         params = decision.get_decision_parameters(FAKE_GRAPH_CONFIG, self.options)
[task 2023-02-24T13:41:13.181Z] >       self.assertEqual(params["target_tasks_method"], "nothing")
[task 2023-02-24T13:41:13.181Z] E       AssertionError: 'default' != 'nothing'
[task 2023-02-24T13:41:13.181Z] E       - default
[task 2023-02-24T13:41:13.181Z] E       + nothing
[task 2023-02-24T13:41:13.181Z] 
[task 2023-02-24T13:41:13.181Z] test/test_decision.py:104: AssertionError
```

The reason why #191 showed no failures was because the commit message does contain `DONTBUILD`. I'm sorry. I should have caught that in the review. 

[1] https://github.com/taskcluster/taskgraph/runs/11577302196