### PR TITLE
fix: `dontbuild` on `github-push`.

### DIFF
--- a/src/taskgraph/decision.py
+++ b/src/taskgraph/decision.py
@@ -227,7 +227,9 @@ def get_decision_parameters(graph_config, options):
     # ..but can be overridden by the commit message: if it contains the special
     # string "DONTBUILD" and this is an on-push decision task, then use the
     # special 'nothing' target task method.
-    if "DONTBUILD" in commit_message and options["tasks_for"] == "hg-push":
+    if "DONTBUILD" in commit_message and (
+        options["tasks_for"] in ("hg-push", "github-push")
+    ):
         parameters["target_tasks_method"] = "nothing"
 
     if options.get("optimize_target_tasks") is not None:

--- a/test/test_decision.py
+++ b/test/test_decision.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from taskgraph import decision
+from taskgraph.util.vcs import GitRepository, HgRepository
 from taskgraph.util.yaml import load_yaml
 
 FAKE_GRAPH_CONFIG = {"product-dir": "browser", "taskgraph": {}}
@@ -90,6 +91,55 @@ class TestGetDecisionParameters(unittest.TestCase):
         self.options["owner"] = "ffxbld"
         params = decision.get_decision_parameters(FAKE_GRAPH_CONFIG, self.options)
         self.assertEqual(params["owner"], "ffxbld@noreply.mozilla.org")
+
+    @unittest.mock.patch.object(
+        GitRepository,
+        "get_commit_message",
+        unittest.mock.MagicMock(return_value="Add Foo"),
+    )
+    @unittest.mock.patch.object(
+        HgRepository,
+        "get_commit_message",
+        unittest.mock.MagicMock(return_value="Add Foo"),
+    )
+    def test_default(self):
+        """
+        Ensures `target_tasks_method` is `default` when the commit message does not contain
+        `DONTBUILD`.
+        """
+        self.options["tasks_for"] = "github-push"
+        params = decision.get_decision_parameters(FAKE_GRAPH_CONFIG, self.options)
+        self.assertEqual(params["target_tasks_method"], "default")
+
+        self.options["tasks_for"] = "hg-push"
+        params = decision.get_decision_parameters(FAKE_GRAPH_CONFIG, self.options)
+        self.assertEqual(params["target_tasks_method"], "default")
+
+    @unittest.mock.patch.object(
+        GitRepository,
+        "get_commit_message",
+        unittest.mock.MagicMock(return_value="DONTBUILD"),
+    )
+    @unittest.mock.patch.object(
+        HgRepository,
+        "get_commit_message",
+        unittest.mock.MagicMock(return_value="DONTBUILD"),
+    )
+    def test_dontbuild(self):
+        """
+        Ensures `target_tasks_method` is `nothing` when the commit message contains `DONTBUILD`.
+        """
+        self.options["tasks_for"] = "github-release"
+        params = decision.get_decision_parameters(FAKE_GRAPH_CONFIG, self.options)
+        self.assertNotEqual(params["target_tasks_method"], "nothing")
+
+        self.options["tasks_for"] = "github-push"
+        params = decision.get_decision_parameters(FAKE_GRAPH_CONFIG, self.options)
+        self.assertEqual(params["target_tasks_method"], "nothing")
+
+        self.options["tasks_for"] = "hg-push"
+        params = decision.get_decision_parameters(FAKE_GRAPH_CONFIG, self.options)
+        self.assertEqual(params["target_tasks_method"], "nothing")
 
 
 @pytest.mark.parametrize(

--- a/test/test_decision.py
+++ b/test/test_decision.py
@@ -102,7 +102,7 @@ class TestGetDecisionParameters(unittest.TestCase):
         "get_commit_message",
         unittest.mock.MagicMock(return_value="Add Foo"),
     )
-    def test_default(self):
+    def test_regular_commit_message_yields_default_target_tasks_method(self):
         """
         Ensures `target_tasks_method` is `default` when the commit message does not contain
         `DONTBUILD`.
@@ -125,7 +125,7 @@ class TestGetDecisionParameters(unittest.TestCase):
         "get_commit_message",
         unittest.mock.MagicMock(return_value="DONTBUILD"),
     )
-    def test_dontbuild(self):
+    def test_dontbuild_commit_message_yields_default_target_tasks_method(self):
         """
         Ensures `target_tasks_method` is `nothing` when the commit message contains `DONTBUILD`.
         """


### PR DESCRIPTION
If the commit message of a `github-push` or `hg-push` contains `dontbuild` (all caps), the build should be skipped. Previously, this was supported for only `hg-push`. This commit adds support for `github-push` and provides tests to make sure the behavior is as expected.

fixes: #189 #191 