### PR TITLE
unzip files in `fetch-content` quietly

### DIFF
--- a/src/taskgraph/run-task/fetch-content
+++ b/src/taskgraph/run-task/fetch-content
@@ -374,7 +374,7 @@ def extract_archive(path, dest_dir, typ):
     elif typ == "zip":
         # unzip from stdin has wonky behavior. We don't use a pipe for it.
         ifh = open(os.devnull, "rb")
-        args = ["unzip", "-o", str(path)]
+        args = ["unzip", "-q", "-o", str(path)]
         pipe_stdin = False
     else:
         raise ValueError("unknown archive format: %s" % path)


### PR DESCRIPTION
We already unzip tar files quietly, we probably ought to do the same for zips. It's been noted that this is very spammy in logs.