### PR TITLE
fix: build-docker silent injection with `dontbuild` bug.

### DIFF
--- a/src/taskgraph/generator.py
+++ b/src/taskgraph/generator.py
@@ -352,12 +352,6 @@ class TaskGraphGenerator:
         yield self.verify("target_task_set", target_task_set, graph_config, parameters)
 
         logger.info("Generating target task graph")
-        # include all docker-image build tasks here, in case they are needed for a graph morph
-        docker_image_tasks = {
-            t.label
-            for t in full_task_graph.tasks.values()
-            if t.attributes["kind"] == "docker-image"
-        }
         # include all tasks with `always_target` set
         if parameters["enable_always_target"]:
             always_target_tasks = {
@@ -371,7 +365,7 @@ class TaskGraphGenerator:
             "Adding %d tasks with `always_target` attribute"
             % (len(always_target_tasks) - len(always_target_tasks & target_tasks))
         )
-        requested_tasks = target_tasks | docker_image_tasks | always_target_tasks
+        requested_tasks = target_tasks | always_target_tasks
         target_graph = full_task_graph.graph.transitive_closure(requested_tasks)
         target_task_graph = TaskGraph(
             {l: all_tasks[l] for l in target_graph.nodes}, target_graph

--- a/src/taskgraph/transforms/docker_image.py
+++ b/src/taskgraph/transforms/docker_image.py
@@ -141,6 +141,7 @@ def fill_template(config, tasks):
                 "image_name": image_name,
                 "artifact_prefix": "public",
             },
+            "always-target": True,
             "expires-after": "28 days" if config.params.is_try() else "1 year",
             "scopes": [],
             "run-on-projects": [],

--- a/test/test_transform_docker_image.py
+++ b/test/test_transform_docker_image.py
@@ -1,0 +1,69 @@
+"""
+Tests for the 'docker_image' transforms.
+"""
+
+import unittest
+from copy import deepcopy
+
+import pytest
+
+from taskgraph.transforms import docker_image
+
+TASK_DEFAULTS = {
+    "name": "fake-name",
+    "index": {
+        "product": "fake-prod",
+        "job-name": "fake-job-name",
+        "type": "fake-type",
+        "rank": 1,
+    },
+}
+
+
+@pytest.mark.parametrize(
+    "task_input, extra_params, expected_task_output",
+    (
+        pytest.param({}, {}, {"always-target": True}, id="null"),
+        pytest.param(
+            {"parent": "fake-parent"},
+            {},
+            {"dependencies": {"parent": "build-docker-image-fake-parent"}},
+            id="parent",
+        ),
+        pytest.param(
+            {"symbol": "fake-symbol"},
+            {},
+            {
+                "treeherder": {
+                    "symbol": "fake-symbol",
+                    "platform": "taskcluster-images/opt",
+                    "kind": "other",
+                    "tier": 1,
+                }
+            },
+            id="symbol",
+        ),
+    ),
+)
+@unittest.mock.patch(
+    "taskgraph.transforms.docker_image.generate_context_hash",
+    unittest.mock.MagicMock(),
+)
+def test_transforms(
+    make_transform_config, run_transform, task_input, extra_params, expected_task_output
+):
+    task = deepcopy(TASK_DEFAULTS)
+    task.update(task_input)
+
+    config = make_transform_config()
+    config.params.update(extra_params)
+
+    expected_task_output["label"] = "build-docker-image-" + task["name"]
+    expected_task_output["index"] = task["index"]
+    expected_task_output[
+        "description"
+    ] = "Build the docker image {} for use by dependent tasks".format(task["name"])
+    assert (
+        expected_task_output.items()
+        <= run_transform(docker_image.transforms, task, config)[0].items()
+    )


### PR DESCRIPTION
This PR addresses issue #190. Currently, when the `dontbuild` keyword is provided, no tasks are scheduled, but the build-docker tasks are still silently injected in between the target and optimized phases. This behavior is inconsistent with the intended use of the `dontbuild` keyword and can cause confusion.

This PR modifies the taskgraph to remove the silent injection of build-docker tasks by enabling `always-target` for them to explicitly state their generation.