### PR TITLE
Add smarter defaults for loaders, transforms, and treeherders

### DIFF
--- a/docs/concepts/kind.rst
+++ b/docs/concepts/kind.rst
@@ -30,7 +30,10 @@ look at a simple build kind example, you'll notice at the top the `loader` and
 `transforms` are defined. These point to standard taskgraph, but if you wanted
 to use a custom loader or transform it would be defined here pointing to
 `your_project_name_taskgraph` directory, eg
-`my_project_name_taskgraph.transforms.job`.
+`my_project_name_taskgraph.transforms.job`. If no loader is specified,
+`taskgraph.loader.default:loader` will be used, which will bring with it
+`taskgraph.transforms.job` and `taskgraph.transforms.task` as default
+transforms.
 
 This can also be a clue of where to look if you are trying to understand what a
 specific yaml attribute does in an existing kind file (keeping in mind that

--- a/docs/concepts/loading.rst
+++ b/docs/concepts/loading.rst
@@ -40,6 +40,14 @@ transform - whatever it expects.
 Available Loaders
 -----------------
 
-Taskgraph provides only a single loader, the :mod:`Transform Loader
-<taskgraph.loader.transform>`. Projects may optionally provide their own loaders
-that support different behavior.
+Taskgraph provides two loaders, although in truth they are virtually identical:
+
+The :mod:`Transform Loader<taskgraph.loader.transform>` is a barebones loader.
+
+The :mod:`Default Loader<taskgraph.loader.default>` does everything that the
+Transform Loader does, and additionally ensures that the
+:mod:`Job<taskgraph.transforms.job>` and :mod:`Task<taskgraph.transforms.task>`
+transforms are used on every task it loads.
+
+Projects may optionally provide their own loaders that support different
+behavior.

--- a/docs/tutorials/creating-a-task-graph.rst
+++ b/docs/tutorials/creating-a-task-graph.rst
@@ -83,26 +83,17 @@ starting definitions of the tasks themselves. If you followed the layout above,
 you have a ``hello`` kind. For this next section we'll be editing
 ``taskcluster/ci/hello/kind.yml``.
 
-#. First declare a loader. Loaders determine how the task definitions get read.
-   The most common is the :func:`transform loader
-   <taskgraph.loader.transform.loader>`:
-
-   .. code-block:: yaml
-
-    loader: taskgraph.loader.transform:loader
-
-#. Next declare the set of :term:`transforms <transform>` that will be applied
-   to tasks. Usually there is at least a kind specific set of transforms, as
-   well as the general purpose :mod:`-taskgraph.transforms.task` transforms.
-   Practically every task should use the latter, as they perform the final
-   steps to modify the tasks into the `format Taskcluster expects`_. In our
-   example:
+#. Declare the set of :term:`transforms <transform>` that will be applied
+   to tasks. By default, taskgraph will include the
+   :mod:`-taskgraph.transforms.job` and :mod:`-taskgraph.transforms.tasks`
+   transforms, which are used by the vast majority of simple tasks. It is also
+   quite common for kind-specific transforms to be used, which we will do here
+   for the purpose of demonstration. In our example:
 
    .. code-block:: yaml
 
     transforms:
         - myrepo_taskgraph.transforms.hello:transforms
-        - taskgraph.transforms.task:transforms
 
 #. Finally we define the task under the ``tasks`` key. The format for the
    initial definition here can vary wildly from one kind to another, it all
@@ -123,10 +114,8 @@ Here is the combined ``kind.yml`` file:
 
 .. code-block:: yaml
 
- loader: taskgraph.loader.transform:loader
  transforms:
      - myrepo_taskgraph.transforms.hello:transforms
-     - taskgraph.transforms.task:transforms
  tasks:
      taskcluster:
          description: "Says hello to Taskcluster"

--- a/src/taskgraph/generator.py
+++ b/src/taskgraph/generator.py
@@ -42,7 +42,7 @@ class Kind:
         try:
             loader = self.config["loader"]
         except KeyError:
-            raise KeyError(f"{self.path!r} does not define `loader`")
+            loader = "taskgraph.loader.default:loader"
         return find_object(loader)
 
     def load_tasks(self, parameters, loaded_tasks, write_artifacts):

--- a/src/taskgraph/loader/default.py
+++ b/src/taskgraph/loader/default.py
@@ -1,0 +1,33 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+import logging
+
+from .transform import loader as transform_loader
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_TRANSFORMS = [
+    "taskgraph.transforms.job:transforms",
+    "taskgraph.transforms.task:transforms",
+]
+
+
+def loader(kind, path, config, params, loaded_tasks):
+    """
+    This default loader builds on the `transform` loader by providing sensible
+    default transforms that the majority of simple tasks will need.
+    Specifically, `job` and `task` transforms will be appended to the end of the
+    list of transforms in the kind being loaded.
+    """
+    transform_refs = config.setdefault("transforms", [])
+    for t in DEFAULT_TRANSFORMS:
+        if t in config.get("transforms", ()):
+            raise KeyError(
+                f"Transform {t} is already present in the loader's default transforms; it must not be defined in the kind"
+            )
+    transform_refs.extend(DEFAULT_TRANSFORMS)
+    return transform_loader(kind, path, config, params, loaded_tasks)

--- a/src/taskgraph/util/treeherder.py
+++ b/src/taskgraph/util/treeherder.py
@@ -62,3 +62,23 @@ def inherit_treeherder_from_dep(job, dep_job):
     # Does not set symbol
     treeherder.setdefault("kind", "build")
     return treeherder
+
+
+def treeherder_defaults(kind, label):
+    defaults = {
+        # Despite its name, this is expected to be a platform+collection
+        "platform": "default/opt",
+        "tier": 1,
+    }
+    if "build" in kind:
+        defaults["kind"] = "build"
+    elif "test" in kind:
+        defaults["kind"] = "test"
+    else:
+        defaults["kind"] = "other"
+
+    # Takes the uppercased first letter of each part of the kind name, eg:
+    # apple-banana -> AB
+    defaults["symbol"] = "".join([c[0] for c in kind.split("-")]).upper()
+
+    return defaults

--- a/template/{{cookiecutter.project_name}}/taskcluster/ci/hello/kind.yml
+++ b/template/{{cookiecutter.project_name}}/taskcluster/ci/hello/kind.yml
@@ -1,10 +1,6 @@
 ---
-loader: taskgraph.loader.transform:loader
-
 transforms:
   - {{cookiecutter.project_slug}}_taskgraph.transforms.hello:transforms
-  - taskgraph.transforms.job:transforms
-  - taskgraph.transforms.task:transforms
 
 task-defaults:
   worker-type: t-linux-large

--- a/test/fixtures/gen.py
+++ b/test/fixtures/gen.py
@@ -73,16 +73,22 @@ def fake_load_graph_config(root_dir):
             },
             "workers": {
                 "aliases": {
+                    "b-linux": {
+                        "provisioner": "taskgraph-b",
+                        "implementation": "docker-worker",
+                        "os": "linux",
+                        "worker-type": "linux",
+                    },
                     "t-linux": {
                         "provisioner": "taskgraph-t",
                         "implementation": "docker-worker",
                         "os": "linux",
                         "worker-type": "linux",
-                    }
+                    },
                 }
             },
             "task-priority": "low",
-            "treeherder": {"group-names": []},
+            "treeherder": {"group-names": {"T": "tests"}},
         },
         root_dir,
     )

--- a/test/fixtures/gen.py
+++ b/test/fixtures/gen.py
@@ -41,6 +41,8 @@ def fake_loader(kind, path, config, parameters, loaded_tasks):
 
 
 class FakeKind(Kind):
+    loaded_kinds = []
+
     def _get_loader(self):
         return fake_loader
 

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -2,8 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+
+import pytest
+
 from taskgraph import generator, graph
-from taskgraph.generator import load_tasks_for_kind
+from taskgraph.generator import Kind, load_tasks_for_kind
+from taskgraph.loader.default import loader as default_loader
 
 from .conftest import FakeKind, WithFakeKind, fake_load_graph_config
 
@@ -134,3 +138,67 @@ def test_load_tasks_for_kind(monkeypatch):
         "/root",
     )
     assert "t-1" in tasks and tasks["t-1"].label == "_example-kind-t-1"
+
+
+@pytest.mark.parametrize(
+    "config,expected_transforms",
+    (
+        pytest.param(
+            {},
+            [
+                "taskgraph.transforms.job:transforms",
+                "taskgraph.transforms.task:transforms",
+            ],
+            id="no_transforms",
+        ),
+        pytest.param(
+            {"transforms": ["taskgraph.transforms.notify:transforms"]},
+            [
+                "taskgraph.transforms.notify:transforms",
+                "taskgraph.transforms.job:transforms",
+                "taskgraph.transforms.task:transforms",
+            ],
+            id="additional_transform_specified",
+        ),
+    ),
+)
+def test_default_loader(config, expected_transforms):
+    loader = Kind("", "", config, {})._get_loader()
+    assert (
+        loader is default_loader
+    ), "Default Kind loader should be taskgraph.loader.default.loader"
+    loader("", "", config, {}, [])
+
+    assert config["transforms"] == expected_transforms
+
+
+@pytest.mark.parametrize(
+    "config",
+    (
+        pytest.param(
+            {
+                "transforms": [
+                    "taskgraph.transforms.job:transforms",
+                    "taskgraph.transforms.task:transforms",
+                ]
+            },
+            id="job_and_task_transforms_specified",
+        ),
+        pytest.param(
+            {"transforms": ["taskgraph.transforms.job:transforms"]},
+            id="only_job_transform_specified",
+        ),
+        pytest.param(
+            {"transforms": ["taskgraph.transforms.task:transforms"]},
+            id="only_task_transform_specified",
+        ),
+    ),
+)
+def test_default_loader_errors(config):
+    loader = Kind("", "", config, {})._get_loader()
+    try:
+        loader("", "", config, {}, [])
+    except KeyError:
+        return
+
+    assert False, "Should've raised a KeyError"

--- a/test/test_transforms_task.py
+++ b/test/test_transforms_task.py
@@ -143,3 +143,589 @@ def test_transforms(request, run_transform, graph_config, task_params):
     param_id = request.node.callspec.id
     assertion_func = globals()[f"assert_{param_id.replace('-', '_')}"]
     assertion_func(task_dict)
+
+
+@pytest.mark.parametrize(
+    "kind,task_def,expected_th",
+    (
+        pytest.param(
+            "test",
+            {
+                "description": "fake description",
+                "name": "fake-task-name",
+                "worker-type": "t-linux",
+                "worker": {
+                    "docker-image": "fake-image-name",
+                    "max-run-time": 1800,
+                },
+            },
+            {},
+            id="no treeherder info",
+        ),
+        pytest.param(
+            "test",
+            {
+                "description": "fake description",
+                "name": "linux64/opt",
+                "worker-type": "t-linux",
+                "worker": {
+                    "docker-image": "fake-image-name",
+                    "max-run-time": 1800,
+                },
+                "treeherder": True,
+            },
+            {
+                "symbol": "T",
+                "tier": 1,
+                "kind": "test",
+                "jobKind": "test",
+                "platform": "default/opt",
+                "collection": {
+                    "opt": True,
+                },
+                "machine": {
+                    "platform": "default",
+                },
+            },
+            id="fully generated treeherder info",
+        ),
+        pytest.param(
+            "special-test",
+            {
+                "description": "fake description",
+                "name": "linux64/opt",
+                "worker-type": "t-linux",
+                "worker": {
+                    "docker-image": "fake-image-name",
+                    "max-run-time": 1800,
+                },
+                "treeherder": True,
+            },
+            {
+                "symbol": "ST",
+                "tier": 1,
+                "kind": "test",
+                "jobKind": "test",
+                "platform": "default/opt",
+                "collection": {
+                    "opt": True,
+                },
+                "machine": {
+                    "platform": "default",
+                },
+            },
+            id="multi character symbol",
+        ),
+        pytest.param(
+            "test",
+            {
+                "description": "fake description",
+                "name": "linux64/opt",
+                "worker-type": "t-linux",
+                "worker": {
+                    "docker-image": "fake-image-name",
+                    "max-run-time": 1800,
+                },
+                "treeherder": {
+                    "symbol": "Test",
+                },
+            },
+            {
+                "symbol": "Test",
+                "tier": 1,
+                "kind": "test",
+                "jobKind": "test",
+                "platform": "default/opt",
+                "collection": {
+                    "opt": True,
+                },
+                "machine": {
+                    "platform": "default",
+                },
+            },
+            id="explicit symbol",
+        ),
+        pytest.param(
+            "test",
+            {
+                "description": "fake description",
+                "name": "linux64/opt",
+                "worker-type": "t-linux",
+                "worker": {
+                    "docker-image": "fake-image-name",
+                    "max-run-time": 1800,
+                },
+                "treeherder": {
+                    "symbol": "T(1)",
+                },
+            },
+            {
+                "symbol": "1",
+                "groupSymbol": "T",
+                "groupName": "tests",
+                "tier": 1,
+                "kind": "test",
+                "jobKind": "test",
+                "platform": "default/opt",
+                "collection": {
+                    "opt": True,
+                },
+                "machine": {
+                    "platform": "default",
+                },
+            },
+            id="explicit group symbol",
+        ),
+        pytest.param(
+            "build",
+            {
+                "description": "fake description",
+                "name": "linux64/opt",
+                "worker-type": "b-linux",
+                "worker": {
+                    "docker-image": "fake-image-name",
+                    "max-run-time": 1800,
+                },
+                "treeherder": True,
+            },
+            {
+                "symbol": "B",
+                "tier": 1,
+                "kind": "build",
+                "jobKind": "build",
+                "platform": "default/opt",
+                "collection": {
+                    "opt": True,
+                },
+                "machine": {
+                    "platform": "default",
+                },
+            },
+            id="build kind",
+        ),
+        pytest.param(
+            "signing",
+            {
+                "description": "fake description",
+                "name": "linux64/opt",
+                "worker-type": "t-linux",
+                "worker": {
+                    "docker-image": "fake-image-name",
+                    "max-run-time": 1800,
+                },
+                "treeherder": True,
+            },
+            {
+                "symbol": "S",
+                "tier": 1,
+                "kind": "other",
+                "jobKind": "other",
+                "platform": "default/opt",
+                "collection": {
+                    "opt": True,
+                },
+                "machine": {
+                    "platform": "default",
+                },
+            },
+            id="non-build and non-test kind",
+        ),
+        pytest.param(
+            "test-build",
+            {
+                "description": "fake description",
+                "name": "linux64/opt",
+                "worker-type": "t-linux",
+                "worker": {
+                    "docker-image": "fake-image-name",
+                    "max-run-time": 1800,
+                },
+                "treeherder": {
+                    "kind": "build",
+                },
+            },
+            {
+                "symbol": "TB",
+                "tier": 1,
+                "kind": "build",
+                "jobKind": "build",
+                "platform": "default/opt",
+                "collection": {
+                    "opt": True,
+                },
+                "machine": {
+                    "platform": "default",
+                },
+            },
+            id="explicit kind",
+        ),
+        pytest.param(
+            "test",
+            {
+                "description": "fake description",
+                "name": "linux64/opt",
+                "worker-type": "t-linux",
+                "worker": {
+                    "docker-image": "fake-image-name",
+                    "max-run-time": 1800,
+                },
+                "treeherder": {
+                    "tier": 1,
+                },
+            },
+            {
+                "symbol": "T",
+                "tier": 1,
+                "kind": "test",
+                "jobKind": "test",
+                "platform": "default/opt",
+                "collection": {
+                    "opt": True,
+                },
+                "machine": {
+                    "platform": "default",
+                },
+            },
+            id="explicit tier 1",
+        ),
+        pytest.param(
+            "test",
+            {
+                "description": "fake description",
+                "name": "linux64/opt",
+                "worker-type": "t-linux",
+                "worker": {
+                    "docker-image": "fake-image-name",
+                    "max-run-time": 1800,
+                },
+                "treeherder": {
+                    "tier": 3,
+                },
+            },
+            {
+                "symbol": "T",
+                "tier": 3,
+                "kind": "test",
+                "jobKind": "test",
+                "platform": "default/opt",
+                "collection": {
+                    "opt": True,
+                },
+                "machine": {
+                    "platform": "default",
+                },
+            },
+            id="explicit tier 3",
+        ),
+        pytest.param(
+            "test",
+            {
+                "description": "fake description",
+                "name": "linux64/opt",
+                "worker-type": "t-linux",
+                "worker": {
+                    "docker-image": "fake-image-name",
+                    "max-run-time": 1800,
+                },
+                "treeherder": {
+                    "platform": "linux/debug",
+                },
+            },
+            {
+                "symbol": "T",
+                "tier": 1,
+                "kind": "test",
+                "jobKind": "test",
+                "platform": "linux/debug",
+                "collection": {
+                    "debug": True,
+                },
+                "machine": {
+                    "platform": "linux",
+                },
+            },
+            id="explicit platform",
+        ),
+        pytest.param(
+            "test",
+            {
+                "description": "fake description",
+                "name": "linux64/opt",
+                "worker-type": "t-linux",
+                "worker": {
+                    "docker-image": "fake-image-name",
+                    "max-run-time": 1800,
+                },
+                "treeherder": True,
+            },
+            {
+                "symbol": "T",
+                "tier": 1,
+                "kind": "test",
+                "jobKind": "test",
+                "platform": "default/opt",
+                "collection": {
+                    "opt": True,
+                },
+                "machine": {
+                    "platform": "default",
+                },
+            },
+            id="fully generated treeherder info",
+        ),
+        pytest.param(
+            "test",
+            {
+                "description": "fake description",
+                "name": "linux64/opt",
+                "worker-type": "t-linux",
+                "worker": {
+                    "docker-image": "fake-image-name",
+                    "max-run-time": 1800,
+                },
+                "treeherder": True,
+            },
+            {
+                "symbol": "T",
+                "tier": 1,
+                "kind": "test",
+                "jobKind": "test",
+                "platform": "default/opt",
+                "collection": {
+                    "opt": True,
+                },
+                "machine": {
+                    "platform": "default",
+                },
+            },
+            id="fully generated treeherder info",
+        ),
+        pytest.param(
+            "test",
+            {
+                "description": "fake description",
+                "name": "linux64/opt",
+                "worker-type": "t-linux",
+                "worker": {
+                    "docker-image": "fake-image-name",
+                    "max-run-time": 1800,
+                },
+                "treeherder": True,
+            },
+            {
+                "symbol": "T",
+                "tier": 1,
+                "kind": "test",
+                "jobKind": "test",
+                "platform": "default/opt",
+                "collection": {
+                    "opt": True,
+                },
+                "machine": {
+                    "platform": "default",
+                },
+            },
+            id="fully generated treeherder info",
+        ),
+        pytest.param(
+            "test",
+            {
+                "description": "fake description",
+                "name": "linux64/opt",
+                "worker-type": "t-linux",
+                "worker": {
+                    "docker-image": "fake-image-name",
+                    "max-run-time": 1800,
+                },
+                "treeherder": True,
+            },
+            {
+                "symbol": "T",
+                "tier": 1,
+                "kind": "test",
+                "jobKind": "test",
+                "platform": "default/opt",
+                "collection": {
+                    "opt": True,
+                },
+                "machine": {
+                    "platform": "default",
+                },
+            },
+            id="fully generated treeherder info",
+        ),
+        pytest.param(
+            "test",
+            {
+                "description": "fake description",
+                "name": "linux64/opt",
+                "worker-type": "t-linux",
+                "worker": {
+                    "docker-image": "fake-image-name",
+                    "max-run-time": 1800,
+                },
+                "treeherder": True,
+            },
+            {
+                "symbol": "T",
+                "tier": 1,
+                "kind": "test",
+                "jobKind": "test",
+                "platform": "default/opt",
+                "collection": {
+                    "opt": True,
+                },
+                "machine": {
+                    "platform": "default",
+                },
+            },
+            id="fully generated treeherder info",
+        ),
+        pytest.param(
+            "test",
+            {
+                "description": "fake description",
+                "name": "linux64/opt",
+                "worker-type": "t-linux",
+                "worker": {
+                    "docker-image": "fake-image-name",
+                    "max-run-time": 1800,
+                },
+                "treeherder": True,
+            },
+            {
+                "symbol": "T",
+                "tier": 1,
+                "kind": "test",
+                "jobKind": "test",
+                "platform": "default/opt",
+                "collection": {
+                    "opt": True,
+                },
+                "machine": {
+                    "platform": "default",
+                },
+            },
+            id="fully generated treeherder info",
+        ),
+        pytest.param(
+            "test",
+            {
+                "description": "fake description",
+                "name": "linux64/opt",
+                "worker-type": "t-linux",
+                "worker": {
+                    "docker-image": "fake-image-name",
+                    "max-run-time": 1800,
+                },
+                "treeherder": True,
+            },
+            {
+                "symbol": "T",
+                "tier": 1,
+                "kind": "test",
+                "jobKind": "test",
+                "platform": "default/opt",
+                "collection": {
+                    "opt": True,
+                },
+                "machine": {
+                    "platform": "default",
+                },
+            },
+            id="fully generated treeherder info",
+        ),
+        pytest.param(
+            "test",
+            {
+                "description": "fake description",
+                "name": "linux64/opt",
+                "worker-type": "t-linux",
+                "worker": {
+                    "docker-image": "fake-image-name",
+                    "max-run-time": 1800,
+                },
+                "treeherder": True,
+            },
+            {
+                "symbol": "T",
+                "tier": 1,
+                "kind": "test",
+                "jobKind": "test",
+                "platform": "default/opt",
+                "collection": {
+                    "opt": True,
+                },
+                "machine": {
+                    "platform": "default",
+                },
+            },
+            id="fully generated treeherder info",
+        ),
+        pytest.param(
+            "test",
+            {
+                "description": "fake description",
+                "name": "linux64/opt",
+                "worker-type": "t-linux",
+                "worker": {
+                    "docker-image": "fake-image-name",
+                    "max-run-time": 1800,
+                },
+                "treeherder": True,
+            },
+            {
+                "symbol": "T",
+                "tier": 1,
+                "kind": "test",
+                "jobKind": "test",
+                "platform": "default/opt",
+                "collection": {
+                    "opt": True,
+                },
+                "machine": {
+                    "platform": "default",
+                },
+            },
+            id="fully generated treeherder info",
+        ),
+    ),
+)
+def test_treeherder_defaults(run_transform, graph_config, kind, task_def, expected_th):
+    params = FakeParameters(
+        {
+            "base_repository": "git@github.com://github.com/mozilla/example.git",
+            "build_date": 0,
+            "build_number": 1,
+            "head_repository": "git@github.com://github.com/mozilla/example.git",
+            "head_rev": "abcdef",
+            "head_ref": "default",
+            "level": "1",
+            "moz_build_date": 0,
+            "next_version": "1.0.1",
+            "owner": "some-owner",
+            "project": "some-project",
+            "pushlog_id": 1,
+            "repository_type": "git",
+            "target_tasks_method": "test_method",
+            "tasks_for": "github-pull-request",
+            "try_mode": None,
+            "version": "1.0.0",
+        },
+    )
+    transform_config = TransformConfig(
+        kind,
+        str(here),
+        {},
+        params,
+        {},
+        graph_config,
+        write_artifacts=False,
+    )
+    task_dict = deepcopy(task_def)
+
+    task_dict = run_transform(task.transforms, task_dict, config=transform_config)[0]
+    print("Dumping task:")
+    pprint(task_dict, indent=2)
+
+    assert task_dict["task"].get("extra", {}).get("treeherder", {}) == expected_th


### PR DESCRIPTION
This is a partial fix #184, dealing with the idea of a default loader, transforms, and autogenerated treeherder symbols. The individual commits have commentary on each of these - but it's largely in line with what's described in the issue.