### PR TITLE
feat: implement a 'run-task-command' key in run_task.py transforms

### DIFF
--- a/test/test_transforms_job_run_task.py
+++ b/test/test_transforms_job_run_task.py
@@ -146,6 +146,33 @@ def assert_exec_with(task):
     ]
 
 
+def assert_run_task_command_docker_worker(task):
+    assert task["worker"]["command"] == [
+        "/foo/bar/python3",
+        "run-task",
+        "--ci-checkout=/builds/worker/checkouts/vcs/",
+        "--",
+        "bash",
+        "-cx",
+        "echo hello world",
+    ]
+
+
+def assert_run_task_command_generic_worker(task):
+    assert task["worker"]["command"] == [
+        ["chmod", "+x", "run-task"],
+        [
+            "/foo/bar/python3",
+            "run-task",
+            "--ci-checkout=./checkouts/vcs/",
+            "--",
+            "bash",
+            "-cx",
+            "echo hello world",
+        ],
+    ]
+
+
 @pytest.mark.parametrize(
     "task",
     (
@@ -170,6 +197,21 @@ def assert_exec_with(task):
                 },
             },
             id="exec_with",
+        ),
+        pytest.param(
+            {
+                "run": {"run-task-command": ["/foo/bar/python3", "run-task"]},
+            },
+            id="run_task_command_docker_worker",
+        ),
+        pytest.param(
+            {
+                "run": {"run-task-command": ["/foo/bar/python3", "run-task"]},
+                "worker": {
+                    "implementation": "generic-worker",
+                },
+            },
+            id="run_task_command_generic_worker",
         ),
     ),
 )


### PR DESCRIPTION
The current Python path to Mac hardcodes Python 3.6 into the name, and on Windows it assumes `mozilla-build` is being used!

While we can (and should) update this to a better location (I see Gecko moved to `/usr/local/bin/python3`), forcing hardcoded Python path at all is somewhat problematic as it makes assumptions about the workers that are not necessarily going to be valid.

I think ideally we would just run `./run-task` all the time and it should just work, maybe the shebang could be changed to `/usr/bin/env python3`? However I'm a bit afraid that doing this is going to break certain workers.

So this implements a method to override the command used to invoke `run-task` from a task definition. This way if we break things, there will be a viable workaround ready to go.

I'm not super happy with this approach, so maybe it should be removed again once we have a more standard story around invoking `run-task`.