### PR TITLE
Rework treeherder defaults to fix indexes that get dropped sometimes.

### DIFF
--- a/test/fixtures/gen.py
+++ b/test/fixtures/gen.py
@@ -89,6 +89,11 @@ def fake_load_graph_config(root_dir):
             },
             "task-priority": "low",
             "treeherder": {"group-names": {"T": "tests"}},
+            "index": {
+                "products": [
+                    "fake",
+                ],
+            },
         },
         root_dir,
     )

--- a/test/test_transforms_task.py
+++ b/test/test_transforms_task.py
@@ -27,6 +27,11 @@ TASK_DEFAULTS = {
         "platform": "some-th-platform/some-th-collection",
         "kind": "build",
     },
+    "index": {
+        "rank": "by-tier",
+        "product": "fake",
+        "job-name": "fake-job",
+    },
 }
 here = Path(__file__).parent
 
@@ -36,6 +41,23 @@ def assert_common(task_dict):
     assert "task" in task_dict
     assert "extra" in task_dict["task"]
     assert "payload" in task_dict["task"]
+    assert "routes" in task_dict["task"]
+    assert (
+        "index.test-domain.v2.some-project.latest.fake.fake-job"
+        in task_dict["task"]["routes"]
+    )
+    assert (
+        "index.test-domain.v2.some-project.pushdate.1970.01.01.19700101000000.fake.fake-job"
+        in task_dict["task"]["routes"]
+    )
+    assert (
+        "index.test-domain.v2.some-project.pushlog-id.1.fake.fake-job"
+        in task_dict["task"]["routes"]
+    )
+    assert (
+        "index.test-domain.v2.some-project.revision.abcdef.fake.fake-job"
+        in task_dict["task"]["routes"]
+    )
 
 
 def assert_hg_push(task_dict):

--- a/test/test_transforms_task.py
+++ b/test/test_transforms_task.py
@@ -177,9 +177,7 @@ def test_transforms(request, run_transform, graph_config, task_params):
             {
                 "symbol": "T",
                 "tier": 1,
-                "kind": "test",
                 "jobKind": "test",
-                "platform": "default/opt",
                 "collection": {
                     "opt": True,
                 },
@@ -204,9 +202,7 @@ def test_transforms(request, run_transform, graph_config, task_params):
             {
                 "symbol": "ST",
                 "tier": 1,
-                "kind": "test",
                 "jobKind": "test",
-                "platform": "default/opt",
                 "collection": {
                     "opt": True,
                 },
@@ -233,9 +229,7 @@ def test_transforms(request, run_transform, graph_config, task_params):
             {
                 "symbol": "Test",
                 "tier": 1,
-                "kind": "test",
                 "jobKind": "test",
-                "platform": "default/opt",
                 "collection": {
                     "opt": True,
                 },
@@ -264,9 +258,7 @@ def test_transforms(request, run_transform, graph_config, task_params):
                 "groupSymbol": "T",
                 "groupName": "tests",
                 "tier": 1,
-                "kind": "test",
                 "jobKind": "test",
-                "platform": "default/opt",
                 "collection": {
                     "opt": True,
                 },
@@ -291,9 +283,7 @@ def test_transforms(request, run_transform, graph_config, task_params):
             {
                 "symbol": "B",
                 "tier": 1,
-                "kind": "build",
                 "jobKind": "build",
-                "platform": "default/opt",
                 "collection": {
                     "opt": True,
                 },
@@ -318,9 +308,7 @@ def test_transforms(request, run_transform, graph_config, task_params):
             {
                 "symbol": "S",
                 "tier": 1,
-                "kind": "other",
                 "jobKind": "other",
-                "platform": "default/opt",
                 "collection": {
                     "opt": True,
                 },
@@ -347,9 +335,7 @@ def test_transforms(request, run_transform, graph_config, task_params):
             {
                 "symbol": "TB",
                 "tier": 1,
-                "kind": "build",
                 "jobKind": "build",
-                "platform": "default/opt",
                 "collection": {
                     "opt": True,
                 },
@@ -376,9 +362,7 @@ def test_transforms(request, run_transform, graph_config, task_params):
             {
                 "symbol": "T",
                 "tier": 1,
-                "kind": "test",
                 "jobKind": "test",
-                "platform": "default/opt",
                 "collection": {
                     "opt": True,
                 },
@@ -405,9 +389,7 @@ def test_transforms(request, run_transform, graph_config, task_params):
             {
                 "symbol": "T",
                 "tier": 3,
-                "kind": "test",
                 "jobKind": "test",
-                "platform": "default/opt",
                 "collection": {
                     "opt": True,
                 },
@@ -434,9 +416,7 @@ def test_transforms(request, run_transform, graph_config, task_params):
             {
                 "symbol": "T",
                 "tier": 1,
-                "kind": "test",
                 "jobKind": "test",
-                "platform": "linux/debug",
                 "collection": {
                     "debug": True,
                 },
@@ -461,9 +441,7 @@ def test_transforms(request, run_transform, graph_config, task_params):
             {
                 "symbol": "T",
                 "tier": 1,
-                "kind": "test",
                 "jobKind": "test",
-                "platform": "default/opt",
                 "collection": {
                     "opt": True,
                 },
@@ -488,9 +466,7 @@ def test_transforms(request, run_transform, graph_config, task_params):
             {
                 "symbol": "T",
                 "tier": 1,
-                "kind": "test",
                 "jobKind": "test",
-                "platform": "default/opt",
                 "collection": {
                     "opt": True,
                 },
@@ -515,9 +491,7 @@ def test_transforms(request, run_transform, graph_config, task_params):
             {
                 "symbol": "T",
                 "tier": 1,
-                "kind": "test",
                 "jobKind": "test",
-                "platform": "default/opt",
                 "collection": {
                     "opt": True,
                 },
@@ -542,9 +516,7 @@ def test_transforms(request, run_transform, graph_config, task_params):
             {
                 "symbol": "T",
                 "tier": 1,
-                "kind": "test",
                 "jobKind": "test",
-                "platform": "default/opt",
                 "collection": {
                     "opt": True,
                 },
@@ -569,9 +541,7 @@ def test_transforms(request, run_transform, graph_config, task_params):
             {
                 "symbol": "T",
                 "tier": 1,
-                "kind": "test",
                 "jobKind": "test",
-                "platform": "default/opt",
                 "collection": {
                     "opt": True,
                 },
@@ -596,9 +566,7 @@ def test_transforms(request, run_transform, graph_config, task_params):
             {
                 "symbol": "T",
                 "tier": 1,
-                "kind": "test",
                 "jobKind": "test",
-                "platform": "default/opt",
                 "collection": {
                     "opt": True,
                 },
@@ -623,9 +591,7 @@ def test_transforms(request, run_transform, graph_config, task_params):
             {
                 "symbol": "T",
                 "tier": 1,
-                "kind": "test",
                 "jobKind": "test",
-                "platform": "default/opt",
                 "collection": {
                     "opt": True,
                 },
@@ -650,9 +616,7 @@ def test_transforms(request, run_transform, graph_config, task_params):
             {
                 "symbol": "T",
                 "tier": 1,
-                "kind": "test",
                 "jobKind": "test",
-                "platform": "default/opt",
                 "collection": {
                     "opt": True,
                 },
@@ -677,9 +641,7 @@ def test_transforms(request, run_transform, graph_config, task_params):
             {
                 "symbol": "T",
                 "tier": 1,
-                "kind": "test",
                 "jobKind": "test",
-                "platform": "default/opt",
                 "collection": {
                     "opt": True,
                 },


### PR DESCRIPTION
It turns out that `build_task` needs to run after `add_index_routes` (big whoops on my part...).

Fixing this means extracting all the treeherder goop from `build_task` so we can run it before `add_index_routes`. In the process I noticed that my original patch ended up adding unnecessary `kind` and `platform` keys to the `extra.treeherder` object, which I'm also correcting here. (This was due to using the `treeherder` object as both an intermediary object to merge the defaults and task provided treeherder information and the final thing we set on the task - something we weren't doing before.)