### PR TITLE
Fix: dump python version number in run task

### DIFF
--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -28,6 +28,7 @@ import io
 import json
 import os
 from pathlib import Path
+import platform
 import re
 import shutil
 import signal
@@ -1054,7 +1055,9 @@ def maybe_run_resource_monitoring():
     return process
 
 def _display_pyhton_version():
-    print("Python version:")
+    print("Python versions: ")
+    print(platform.python_version())
+
 
 def main(args):
     os.environ["TASK_WORKDIR"] = os.getcwd()

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -1055,7 +1055,7 @@ def maybe_run_resource_monitoring():
     return process
 
 def _display_pyhton_version():
-    print("Python versions: ")
+    print("Python version: ")
     print(platform.python_version())
 
 

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -1055,10 +1055,9 @@ def maybe_run_resource_monitoring():
     return process
 
 def _display_pyhton_version():
-    pythonVersionOutput = "Python version: "+platform.python_version()
     print_line(
         b"setup",
-        bytes(pythonVersionOutput, encoding='utf8')
+        b"Python version: "+ bytes(platform.python_version(), 'utf-8')
     )
 
 

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -1055,17 +1055,20 @@ def maybe_run_resource_monitoring():
     return process
 
 def _display_pyhton_version():
-    print("Python version: ")
-    print(platform.python_version())
+    pythonVersionOutput = "Python version: "+platform.python_version()
+    print_line(
+        b"setup",
+        bytes(pythonVersionOutput, encoding='utf8')
+    )
 
 
 def main(args):
     os.environ["TASK_WORKDIR"] = os.getcwd()
-    _display_pyhton_version()
     print_line(
         b"setup",
         b"run-task started in %s\n" % os.environ["TASK_WORKDIR"].encode("utf-8"),
     )
+    _display_pyhton_version()
     running_as_root = IS_POSIX and os.getuid() == 0
 
     # Arguments up to '--' are ours. After are for the main task

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -1053,6 +1053,8 @@ def maybe_run_resource_monitoring():
     monitor_process.start()
     return process
 
+def _display_pyhton_version():
+    print("Python version:")
 
 def main(args):
     os.environ["TASK_WORKDIR"] = os.getcwd()

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -1054,7 +1054,7 @@ def maybe_run_resource_monitoring():
     monitor_process.start()
     return process
 
-def _display_pyhton_version():
+def _display_python_version():
     print_line(
         b"setup",
         b"Python version: "+ bytes(platform.python_version(), 'utf-8')
@@ -1067,7 +1067,7 @@ def main(args):
         b"setup",
         b"run-task started in %s\n" % os.environ["TASK_WORKDIR"].encode("utf-8"),
     )
-    _display_pyhton_version()
+    _display_python_version()
     running_as_root = IS_POSIX and os.getuid() == 0
 
     # Arguments up to '--' are ours. After are for the main task

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -1061,6 +1061,7 @@ def _display_pyhton_version():
 
 def main(args):
     os.environ["TASK_WORKDIR"] = os.getcwd()
+    _display_pyhton_version()
     print_line(
         b"setup",
         b"run-task started in %s\n" % os.environ["TASK_WORKDIR"].encode("utf-8"),

--- a/test/test_scripts_run_task.py
+++ b/test/test_scripts_run_task.py
@@ -388,4 +388,13 @@ def test_display_pyhton_version_should_output_python_versions_title(
 ):
     run_task_mod._display_pyhton_version()
 
-    assert ("Python version:" in capsys.readouterr().out) is True
+    assert ("Python versions:" in capsys.readouterr().out) is True
+
+
+def test_display_pyhton_version_should_output_python_versions(run_task_mod, capsys):
+    run_task_mod._display_pyhton_version()
+
+    output = capsys.readouterr().out
+    assert ("Python versions: \n3." in output) or (
+        "Python versions: \n2." in output
+    ) is True

--- a/test/test_scripts_run_task.py
+++ b/test/test_scripts_run_task.py
@@ -386,6 +386,4 @@ def test_git_checkout_with_commit(
 def test_display_pyhton_version_should_output_python_versions(run_task_mod, capsys):
     run_task_mod._display_pyhton_version()
 
-    print("test")
-    print(capsys.readouterr())
     assert ("Python " in capsys.readouterr().out) is True

--- a/test/test_scripts_run_task.py
+++ b/test/test_scripts_run_task.py
@@ -383,7 +383,7 @@ def test_git_checkout_with_commit(
         )
 
 
-def test_display_pyhton_version_should_output_python_versions_title(
+def test_display_python_version_should_output_python_versions_title(
     run_task_mod, capsys
 ):
     run_task_mod._display_pyhton_version()
@@ -391,7 +391,7 @@ def test_display_pyhton_version_should_output_python_versions_title(
     assert ("Python version:" in capsys.readouterr().out) is True
 
 
-def test_display_pyhton_version_should_output_python_versions(run_task_mod, capsys):
+def test_display_python_version_should_output_python_versions(run_task_mod, capsys):
     run_task_mod._display_pyhton_version()
 
     output = capsys.readouterr().out

--- a/test/test_scripts_run_task.py
+++ b/test/test_scripts_run_task.py
@@ -381,3 +381,11 @@ def test_git_checkout_with_commit(
             ssh_key_file=None,
             ssh_known_hosts_file=None,
         )
+
+
+def test_display_pyhton_version_should_output_python_versions(run_task_mod, capsys):
+    run_task_mod._display_pyhton_version()
+
+    print("test")
+    print(capsys.readouterr())
+    assert ("Python " in capsys.readouterr().out) is True

--- a/test/test_scripts_run_task.py
+++ b/test/test_scripts_run_task.py
@@ -388,13 +388,13 @@ def test_display_pyhton_version_should_output_python_versions_title(
 ):
     run_task_mod._display_pyhton_version()
 
-    assert ("Python versions:" in capsys.readouterr().out) is True
+    assert ("Python version:" in capsys.readouterr().out) is True
 
 
 def test_display_pyhton_version_should_output_python_versions(run_task_mod, capsys):
     run_task_mod._display_pyhton_version()
 
     output = capsys.readouterr().out
-    assert ("Python versions: \n3." in output) or (
-        "Python versions: \n2." in output
+    assert ("Python version: \n3." in output) or (
+        "Python version: \n2." in output
     ) is True

--- a/test/test_scripts_run_task.py
+++ b/test/test_scripts_run_task.py
@@ -395,6 +395,4 @@ def test_display_pyhton_version_should_output_python_versions(run_task_mod, caps
     run_task_mod._display_pyhton_version()
 
     output = capsys.readouterr().out
-    assert ("Python version: \n3." in output) or (
-        "Python version: \n2." in output
-    ) is True
+    assert ("Python version: 3." in output) or ("Python version: 2." in output) is True

--- a/test/test_scripts_run_task.py
+++ b/test/test_scripts_run_task.py
@@ -388,4 +388,4 @@ def test_display_pyhton_version_should_output_python_versions_title(
 ):
     run_task_mod._display_pyhton_version()
 
-    assert ("Python " in capsys.readouterr().out) is True
+    assert ("Python version:" in capsys.readouterr().out) is True

--- a/test/test_scripts_run_task.py
+++ b/test/test_scripts_run_task.py
@@ -383,7 +383,9 @@ def test_git_checkout_with_commit(
         )
 
 
-def test_display_pyhton_version_should_output_python_versions(run_task_mod, capsys):
+def test_display_pyhton_version_should_output_python_versions_title(
+    run_task_mod, capsys
+):
     run_task_mod._display_pyhton_version()
 
     assert ("Python " in capsys.readouterr().out) is True

--- a/test/test_scripts_run_task.py
+++ b/test/test_scripts_run_task.py
@@ -386,13 +386,13 @@ def test_git_checkout_with_commit(
 def test_display_python_version_should_output_python_versions_title(
     run_task_mod, capsys
 ):
-    run_task_mod._display_pyhton_version()
+    run_task_mod._display_python_version()
 
     assert ("Python version:" in capsys.readouterr().out) is True
 
 
 def test_display_python_version_should_output_python_versions(run_task_mod, capsys):
-    run_task_mod._display_pyhton_version()
+    run_task_mod._display_python_version()
 
     output = capsys.readouterr().out
     assert ("Python version: 3." in output) or ("Python version: 2." in output) is True


### PR DESCRIPTION
This pull request is there to fix the issue:
https://github.com/taskcluster/taskgraph/issues/7

@JohanLorenzo : thanks for your help and advices. Can you review my PR? :)
