### PR TITLE
fix: move group-by logic to utility file

### DIFF
--- a/src/taskgraph/transforms/from_deps.py
+++ b/src/taskgraph/transforms/from_deps.py
@@ -17,38 +17,8 @@ from voluptuous import ALLOW_EXTRA, Any, Optional, Required
 
 from taskgraph.transforms.base import TransformSequence
 from taskgraph.util.attributes import attrmatch
+from taskgraph.util.dependencies import GROUP_BY_MAP
 from taskgraph.util.schema import Schema
-
-# Define a collection of group_by functions
-GROUP_BY_MAP = {}
-
-
-def group_by(name, schema=None):
-    def wrapper(func):
-        GROUP_BY_MAP[name] = func
-        func.schema = schema
-        return func
-
-    return wrapper
-
-
-@group_by("single")
-def group_by_single(config, tasks):
-    for task in tasks:
-        yield [task]
-
-
-@group_by("attribute", schema=Schema(str))
-def group_by_attribute(config, tasks, attr):
-    groups = {}
-    for task in tasks:
-        val = task.attributes.get(attr)
-        if not val:
-            continue
-        groups.setdefault(val, []).append(task)
-
-    return groups.values()
-
 
 FROM_DEPS_SCHEMA = Schema(
     {

--- a/src/taskgraph/util/dependencies.py
+++ b/src/taskgraph/util/dependencies.py
@@ -1,0 +1,35 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from taskgraph.util.schema import Schema
+
+# Define a collection of group_by functions
+GROUP_BY_MAP = {}
+
+
+def group_by(name, schema=None):
+    def wrapper(func):
+        GROUP_BY_MAP[name] = func
+        func.schema = schema
+        return func
+
+    return wrapper
+
+
+@group_by("single")
+def group_by_single(config, tasks):
+    for task in tasks:
+        yield [task]
+
+
+@group_by("attribute", schema=Schema(str))
+def group_by_attribute(config, tasks, attr):
+    groups = {}
+    for task in tasks:
+        val = task.attributes.get(attr)
+        if not val:
+            continue
+        groups.setdefault(val, []).append(task)
+
+    return groups.values()


### PR DESCRIPTION
This fixes a bug that results in a schema validation error anytime a custom group-by function is used. Essentially, the schema was using a snapshot of the GROUP_BY_MAP from the time it was imported. So third party taskgraph code that attempted to then add additional functions, would fail validation as the schema has already been built.

By moving this logic to an external utility module, it allows external consumers to register their custom functions prior to the schema being built.