### PR TITLE
Fetch tags during run-task's git checkout in some scenarios

### DIFF
--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -654,6 +654,24 @@ def git_checkout(
 
         retry_required_command(b"vcs", args, cwd=destination_path, extra_env=env)
 
+    # If a ref was provided, it might be tag, so we need to make sure we fetch
+    # those. This is explicitly only done when base and head repo match,
+    # because it is the only scenario where tags could be present. (PRs, for
+    # example, always include an explicit rev.) Failure to do this could result
+    # in not having a tag, or worse: having an outdated version of one.
+    # `--force` is needed to be able to update an existing tag.
+    if ref and base_repo == head_repo:
+        args = [
+            "git",
+            "fetch",
+            "--tags",
+            "--force",
+            base_repo,
+            ref,
+        ]
+
+        retry_required_command(b"vcs", args, cwd=destination_path, extra_env=env)
+
     # If a ref isn't provided, we fetch all refs from head_repo, which may be slow
     args = [
         "git",


### PR DESCRIPTION
This works around recent issues found when starting from an older cached checkout - more details in the comments.

@jcristau - I ended up making this pretty targeted to avoid pulling tags in unwanted scenarios. I think it covers the case we ran into today at the very least? (Which, for posterity, was a task starting from a worker that had cached a checkout before the tag existed, then run a `github-release` task that wanted to checkout the tag.)