### PR TITLE
Fix regression in add-new-jobs and retrigger actions

### DIFF
--- a/src/taskgraph/actions/add_new_jobs.py
+++ b/src/taskgraph/actions/add_new_jobs.py
@@ -59,6 +59,6 @@ def add_new_jobs_action(parameters, graph_config, input, task_group_id, task_id)
             label_to_taskid,
             parameters,
             decision_task_id,
-            i,
+            f"{i}",
         )
     combine_task_graph_files(list(range(times)))

--- a/src/taskgraph/actions/retrigger.py
+++ b/src/taskgraph/actions/retrigger.py
@@ -176,7 +176,7 @@ def retrigger_action(parameters, graph_config, input, task_group_id, task_id):
             label_to_taskid,
             parameters,
             decision_task_id,
-            i,
+            f"{i}",
         )
 
         logger.info(f"Scheduled {label}{with_downstream}(time {i + 1}/{times})")


### PR DESCRIPTION
Pass the suffix as a string to `create_tasks`.

Fixes #267