### PR TITLE
Delete unused docker_worker_add_workspace_cache function

### DIFF
--- a/src/taskgraph/transforms/job/common.py
+++ b/src/taskgraph/transforms/job/common.py
@@ -60,31 +60,6 @@ def add_cache(job, taskdesc, name, mount_point, skip_untrusted=False):
         pass
 
 
-def docker_worker_add_workspace_cache(config, job, taskdesc, extra=None):
-    """Add the workspace cache.
-
-    Args:
-        config (TransformConfig): Transform configuration object.
-        job (dict): Task's job description.
-        taskdesc (dict): Target task description to modify.
-        extra (str): Optional context passed in that supports extending the cache
-            key name to avoid undesired conflicts with other caches.
-    """
-    cache_name = "{}-build-{}-{}-workspace".format(
-        config.params["project"],
-        taskdesc["attributes"]["build_platform"],
-        taskdesc["attributes"]["build_type"],
-    )
-    if extra:
-        cache_name = f"{cache_name}-{extra}"
-
-    mount_point = "{workdir}/workspace".format(**job["run"])
-
-    # Don't enable the workspace cache when we can't guarantee its
-    # behavior, like on Try.
-    add_cache(job, taskdesc, cache_name, mount_point, skip_untrusted=True)
-
-
 def add_artifacts(config, job, taskdesc, path):
     taskdesc["worker"].setdefault("artifacts", []).append(
         {


### PR DESCRIPTION
It existed in gecko until bug 1527313
(https://hg.mozilla.org/mozilla-central/rev/fbe3fcbb31d84b3edeace2fd19250dd1d2711225) but has always been unused here, as far as I can tell.