### PR TITLE
ci: Add task for syntax checking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,10 @@ ignore = [
     "E741",
 ]
 target-version = "py37"
+exclude = [
+  "src/taskgraph/run-task/robustcheckout.py",
+  "taskcluster/scripts/external_tools/tooltool.py",
+]
 
 [tool.ruff.isort]
 known-first-party = ["taskgraph"]

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -926,7 +926,6 @@ def collect_vcs_options(args, project, name):
 
 
 def vcs_checkout_from_args(options):
-
     if not options["checkout"]:
         if options["ref"] and not options["revision"]:
             print("task should be defined in terms of non-symbolic revision")
@@ -1072,10 +1071,11 @@ def maybe_run_resource_monitoring():
     monitor_process.start()
     return process
 
+
 def _display_python_version():
     print_line(
         b"setup",
-        b"Python version: %s\n" % platform.python_version().encode('utf-8')
+        b"Python version: %s\n" % platform.python_version().encode("utf-8"),
     )
 
 

--- a/taskcluster/ci/tests/kind.yml
+++ b/taskcluster/ci/tests/kind.yml
@@ -32,6 +32,16 @@ task-defaults:
         cache-dotcache: true
 
 tasks:
+    syntax:
+        description: "Run `syntax check`"
+        treeherder:
+            symbol: syntax
+        attributes:
+            artifact_prefix: public
+        run:
+            command: >-
+                pip install --user tox &&
+                tox -e syntax
     unit:
         description: "Run `unit tests` to validate the latest changes"
         treeherder:

--- a/tox.ini
+++ b/tox.ini
@@ -25,3 +25,9 @@ commands =
 deps = -r{toxinidir}/requirements/test.txt
 skip_install = true
 commands = coverage erase
+
+[testenv:syntax]
+deps = ruff
+commands =
+    ruff --version
+    ruff --verbose {toxinidir}


### PR DESCRIPTION
We currently don't enforce developers to install pre-commit. Adding a syntax check task will help reviewing PRs.