### PR TITLE
Add support for `all` grouping in `from_deps`

### DIFF
--- a/docs/reference/transforms/from_deps.rst
+++ b/docs/reference/transforms/from_deps.rst
@@ -111,11 +111,34 @@ groups:
 Then the ``notify`` task will be duplicated into three, one for each group. The
 notify tasks will depend on each task in its associated group.
 
+You may also provide a special value of ``all`` to the ``group-by`` function.
+Using ``all`` will *always* result in one task being generated, with all tasks
+from the included kinds to be set as dependencies. It is usually useful to also
+set ``unique-kinds`` to ``False`` when using ``all``.
+
+If we alter the ``kind`` definition from above as follows:
+
+.. code-block:: yaml
+
+   kind-dependencies:
+     - build
+     - signing
+     - publish
+
+   tasks:
+     notify:
+       from-deps:
+         group-by: all
+
+We would end up with a single ``notify`` task that depends on all tasks from
+the ``build``, ``signing``, and ``publish`` kinds.
+
+
 Custom Grouping
 ~~~~~~~~~~~~~~~
 
-Only the default ``single`` and the ``attribute`` group-by functions are
-built-in. But if more complex grouping is needed, custom functions can be
+Only the default ``single``, ``all`` and the ``attribute`` group-by functions
+are built-in. But if more complex grouping is needed, custom functions can be
 implemented as well:
 
 .. code-block:: python
@@ -123,8 +146,8 @@ implemented as well:
    from typing import List
 
    from taskgraph.task import Task
-   from taskgraph.transforms.from_deps import group_by
    from taskgraph.transforms.base import TransformConfig
+   from taskgraph.util.dependencies import group_by
 
    @group_by("custom-name")
    def group_by(config: TransformConfig, tasks: List[Task]) -> List[List[Task]]:
@@ -146,8 +169,8 @@ allows tasks to pass down additional context (such as with the built-in
    from typing import List
 
    from taskgraph.task import Task
-   from taskgraph.transforms.from_deps import group_by
    from taskgraph.transforms.base import TransformConfig
+   from taskgraph.util.dependencies import group_by
    from taskgraph.util.schema import Schema
 
    @group_by("custom-name", schema=Schema(str))

--- a/src/taskgraph/util/dependencies.py
+++ b/src/taskgraph/util/dependencies.py
@@ -27,6 +27,11 @@ def group_by_single(config, tasks):
         yield [task]
 
 
+@group_by("all")
+def group_by_all(config, tasks):
+    return [[task for task in tasks]]
+
+
 @group_by("attribute", schema=Schema(str))
 def group_by_attribute(config, tasks, attr):
     groups = {}

--- a/test/test_transforms_from_deps.py
+++ b/test/test_transforms_from_deps.py
@@ -74,6 +74,18 @@ def assert_copy_attributes(tasks):
     }
 
 
+def assert_group_by_all(tasks):
+    handle_exception(tasks)
+    assert len(tasks) == 1
+    assert tasks[0]["dependencies"] == {"foo": "a", "bar": "bar-b"}
+
+
+def assert_group_by_all_dupe_allowed(tasks):
+    handle_exception(tasks)
+    assert len(tasks) == 1
+    assert tasks[0]["dependencies"] == {"a": "a", "b": "b", "c": "c"}
+
+
 @pytest.mark.parametrize(
     "task, kind_config, deps",
     (
@@ -177,6 +189,37 @@ def assert_copy_attributes(tasks):
                 ),
             },
             id="copy_attributes",
+        ),
+        pytest.param(
+            # task
+            {
+                "from-deps": {
+                    "group-by": "all",
+                }
+            },
+            # kind config
+            None,
+            # deps
+            None,
+            id="group_by_all",
+        ),
+        pytest.param(
+            # task
+            {
+                "from-deps": {
+                    "unique-kinds": False,
+                    "group-by": "all",
+                }
+            },
+            # kind config
+            None,
+            # deps
+            {
+                "a": make_task("a", kind="foo"),
+                "b": make_task("b", kind="foo"),
+                "c": make_task("c", kind="foo"),
+            },
+            id="group_by_all_dupe_allowed",
         ),
     ),
 )


### PR DESCRIPTION
I found a need for this while working on Translations, where there are multiple leaf nodes at the end of the graph - and having a single task that includes them all makes it easy to target everything.