### PR TITLE
Log the command used to invoke run-task #259

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [5.4.0] - 2023-06-13
 
+### Added
+- logging of the command used to envoke 'run-task'
+
 ### Fixed
 
 - Regression in add-new-jobs and retrigger actions, introduced in 5.1.0.

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -1081,6 +1081,11 @@ def main(args):
         b"setup",
         b"run-task started in %s\n" % os.environ["TASK_WORKDIR"].encode("utf-8"),
     )
+    #logging command which envoked the script
+    calling_script = sys.argv[0]
+    print_line(
+    b"script",
+    b"Invoked by module: %s\n" % calling_script.encode("utf-8"),)
     _display_python_version()
     running_as_root = IS_POSIX and os.getuid() == 0
 

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -1081,11 +1081,6 @@ def main(args):
         b"setup",
         b"run-task started in %s\n" % os.environ["TASK_WORKDIR"].encode("utf-8"),
     )
-    #logging command which envoked the script
-    calling_script = sys.argv[0]
-    print_line(
-    b"script",
-    b"Invoked by module: %s\n" % calling_script.encode("utf-8"),)
     _display_python_version()
     running_as_root = IS_POSIX and os.getuid() == 0
 


### PR DESCRIPTION
Added `print-line` call function to log the command envoking `run-task`. Used the sys.argv to capture the envoking cmd. 