### PR TITLE
run-task: update robustcheckout.py

### DIFF
--- a/src/taskgraph/run-task/robustcheckout.py
+++ b/src/taskgraph/run-task/robustcheckout.py
@@ -41,7 +41,9 @@ from mercurial import (
 # Causes worker to purge caches on process exit and for task to retry.
 EXIT_PURGE_CACHE = 72
 
-testedwith = b"4.5 4.6 4.7 4.8 4.9 5.0 5.1 5.2 5.3 5.4 5.5 5.6 5.7 5.8 5.9"
+testedwith = (
+    b"4.5 4.6 4.7 4.8 4.9 5.0 5.1 5.2 5.3 5.4 5.5 5.6 5.7 5.8 5.9 6.0 6.1 6.2 6.3 6.4"
+)
 minimumhgversion = b"4.5"
 
 cmdtable = {}
@@ -496,6 +498,10 @@ def _docheckout(
             ui.warn(b"ssl error: %s\n" % pycompat.bytestr(str(e)))
             handlenetworkfailure()
             return True
+        elif isinstance(e, urllibcompat.urlerr.httperror) and e.code >= 500:
+            ui.warn(b"http error: %s\n" % pycompat.bytestr(str(e.reason)))
+            handlenetworkfailure()
+            return True
         elif isinstance(e, urllibcompat.urlerr.urlerror):
             if isinstance(e.reason, socket.error):
                 ui.warn(b"socket error: %s\n" % pycompat.bytestr(str(e.reason)))
@@ -806,7 +812,14 @@ def _docheckout(
             # one to change the sparse profile and another to update to the new
             # revision. This is not desired. But there's not a good API in
             # Mercurial to do this as one operation.
-            with repo.wlock(), repo.dirstate.parentchange(), timeit(
+            # TRACKING hg64 - Mercurial 6.4 and later require call to
+            # dirstate.changing_parents(repo)
+            def parentchange(repo):
+                if util.safehasattr(repo.dirstate, "changing_parents"):
+                    return repo.dirstate.changing_parents(repo)
+                return repo.dirstate.parentchange()
+
+            with repo.wlock(), parentchange(repo), timeit(
                 "sparse_update_config", "sparse-update-config"
             ):
                 # pylint --py3k: W1636


### PR DESCRIPTION
Includes changes from
https://hg.mozilla.org/hgcustom/version-control-tools/rev/65ac4b5986df and https://hg.mozilla.org/hgcustom/version-control-tools/rev/d8ea98788e5f