### PR TITLE
feat: allow overriding default task deadline

### DIFF
--- a/src/taskgraph/config.py
+++ b/src/taskgraph/config.py
@@ -35,9 +35,10 @@ graph_config_schema = Schema(
                 "lowest",
             ),
         ),
-        Optional("task-deadline-after",
-                 description="Default 'deadline' for tasks, in relative date format. "
-                 "Eg: '1 week'"
+        Optional(
+            "task-deadline-after",
+            description="Default 'deadline' for tasks, in relative date format. "
+            "Eg: '1 week'",
         ): optionally_keyed_by("project", str),
         Required("workers"): {
             Required("aliases"): {

--- a/src/taskgraph/config.py
+++ b/src/taskgraph/config.py
@@ -35,6 +35,10 @@ graph_config_schema = Schema(
                 "lowest",
             ),
         ),
+        Optional("task-deadline-after",
+                 description="Default 'deadline' for tasks, in relative date format. "
+                 "Eg: '1 week'"
+        ): optionally_keyed_by("project", str),
         Required("workers"): {
             Required("aliases"): {
                 str: {

--- a/src/taskgraph/transforms/task.py
+++ b/src/taskgraph/transforms/task.py
@@ -220,6 +220,12 @@ def get_default_priority(graph_config, project):
         graph_config["task-priority"], "Graph Config", {"project": project}
     )
 
+@memoize
+def get_default_deadline(graph_config, project):
+    return evaluate_keyed_by(
+        graph_config["task-deadline-after"], "Graph Config", {"project": project}
+    )
+
 
 # define a collection of payload builders, depending on the worker implementation
 payload_builders = {}
@@ -1069,7 +1075,12 @@ def build_task(config, tasks):
             task["expires-after"] = "28 days" if config.params.is_try() else "1 year"
 
         if "deadline-after" not in task:
-            task["deadline-after"] = "1 day"
+            if "task-deadline-after" in config.graph_config:
+                task["deadline-after"] = get_default_deadline(
+                    config.graph_config, config.params["project"]
+                )
+            else:
+                task["deadline-after"] = "1 day"
 
         if "priority" not in task:
             task["priority"] = get_default_priority(

--- a/src/taskgraph/transforms/task.py
+++ b/src/taskgraph/transforms/task.py
@@ -220,6 +220,7 @@ def get_default_priority(graph_config, project):
         graph_config["task-priority"], "Graph Config", {"project": project}
     )
 
+
 @memoize
 def get_default_deadline(graph_config, project):
     return evaluate_keyed_by(

--- a/test/test_transforms_task.py
+++ b/test/test_transforms_task.py
@@ -795,6 +795,7 @@ def test_check_task_dependencies(graph_config, test_task, expectation):
             len(list(task.check_task_dependencies(transform_config, [test_task]))) == 1
         )
 
+
 @pytest.mark.parametrize(
     "deadline_after, test_task",
     (
@@ -822,7 +823,7 @@ def test_check_task_dependencies(graph_config, test_task, expectation):
                 },
             },
         ),
-    )
+    ),
 )
 def test_default_deadline_after(run_transform, graph_config, deadline_after, test_task):
     if deadline_after:

--- a/test/test_transforms_task.py
+++ b/test/test_transforms_task.py
@@ -794,3 +794,76 @@ def test_check_task_dependencies(graph_config, test_task, expectation):
         assert (
             len(list(task.check_task_dependencies(transform_config, [test_task]))) == 1
         )
+
+@pytest.mark.parametrize(
+    "deadline_after, test_task",
+    (
+        (
+            None,
+            {
+                "description": "fake description",
+                "name": "fake-task-name",
+                "worker-type": "t-linux",
+                "worker": {
+                    "docker-image": "fake-image-name",
+                    "max-run-time": 1800,
+                },
+            },
+        ),
+        (
+            "2 weeks",
+            {
+                "description": "fake description",
+                "name": "fake-task-name",
+                "worker-type": "t-linux",
+                "worker": {
+                    "docker-image": "fake-image-name",
+                    "max-run-time": 1800,
+                },
+            },
+        ),
+    )
+)
+def test_default_deadline_after(run_transform, graph_config, deadline_after, test_task):
+    if deadline_after:
+        graph_config._config["task-deadline-after"] = deadline_after
+
+    params = FakeParameters(
+        {
+            "base_repository": "git@github.com://github.com/mozilla/example.git",
+            "build_date": 0,
+            "build_number": 1,
+            "head_repository": "git@github.com://github.com/mozilla/example.git",
+            "head_rev": "abcdef",
+            "head_ref": "default",
+            "level": "1",
+            "moz_build_date": 0,
+            "next_version": "1.0.1",
+            "owner": "some-owner",
+            "project": "some-project",
+            "pushlog_id": 1,
+            "repository_type": "git",
+            "target_tasks_method": "test_method",
+            "tasks_for": "github-pull-request",
+            "try_mode": None,
+            "version": "1.0.0",
+        },
+    )
+
+    transform_config = TransformConfig(
+        "check_deadline",
+        str(here),
+        {},
+        params,
+        {},
+        graph_config,
+        write_artifacts=False,
+    )
+
+    task_dict = deepcopy(test_task)
+
+    task_dict = run_transform(task.transforms, task_dict, config=transform_config)[0]
+    if deadline_after:
+        assert task_dict["task"]["deadline"] == {"relative-datestamp": deadline_after}
+    else:
+        assert task_dict["task"]["deadline"] == {"relative-datestamp": "1 day"}


### PR DESCRIPTION
This has come up with the work on our Translations model training pipeline. Full training runs are expected to take weeks or even a month to complete. Easily allowing the entire graph to have a longer deadline is the easiest way to cope with this, and I imagine other things could benefit as well, eg: fuzzing.