### PR TITLE
Add abillity to build firefox with mach from source tarball

### DIFF
--- a/src/taskgraph/generator.py
+++ b/src/taskgraph/generator.py
@@ -272,7 +272,7 @@ class TaskGraphGenerator:
         # Always add legacy target tasks method until we deprecate that API.
         if "target_tasks_method" not in filters:
             filters.insert(0, "target_tasks_method")
-        filters = [filter_tasks.filter_task_functions[f] for f in filters]
+        filters = [filter_tasks.filter_task_functions[f] for f in filters if f]
 
         yield self.verify("parameters", parameters)
 

--- a/src/taskgraph/parameters.py
+++ b/src/taskgraph/parameters.py
@@ -121,15 +121,17 @@ def _get_defaults(repo_root=None):
             repo_url = ""
             project = ""
 
-        defaults.update({
-            "base_repository": repo_url,
-            "head_ref": repo.branch or repo.head_rev,
-            "head_repository": repo_url,
-            "head_rev": repo.head_rev,
-            "project": project,
-            "repository_type": repo.tool,
-            "version": get_version(repo_path),
-        })
+        defaults.update(
+            {
+                "base_repository": repo_url,
+                "head_ref": repo.branch or repo.head_rev,
+                "head_repository": repo_url,
+                "head_rev": repo.head_rev,
+                "project": project,
+                "repository_type": repo.tool,
+                "version": get_version(repo_path),
+            }
+        )
     return defaults
 
 

--- a/src/taskgraph/parameters.py
+++ b/src/taskgraph/parameters.py
@@ -80,20 +80,8 @@ def get_version(repo_path):
 def _get_defaults(repo_root=None):
     repo_path = repo_root or os.getcwd()
     repo = get_repository(repo_path)
-    try:
-        repo_url = repo.get_url()
-        parsed_url = mozilla_repo_urls.parse(repo_url)
-        project = parsed_url.repo_name
-    except (
-        CalledProcessError,
-        mozilla_repo_urls.errors.InvalidRepoUrlError,
-        mozilla_repo_urls.errors.UnsupportedPlatformError,
-    ):
-        repo_url = ""
-        project = ""
-
-    return {
-        "base_repository": repo_url,
+    defaults = {
+        "base_repository": "SOURCE",
         "base_ref": "",
         "base_rev": "",
         "build_date": int(time.time()),
@@ -102,9 +90,9 @@ def _get_defaults(repo_root=None):
         "enable_always_target": True,
         "existing_tasks": {},
         "filters": ["target_tasks_method"],
-        "head_ref": repo.branch or repo.head_rev,
-        "head_repository": repo_url,
-        "head_rev": repo.head_rev,
+        "head_ref": "",
+        "head_repository": "",
+        "head_rev": "",
         "head_tag": "",
         "level": "3",
         "moz_build_date": datetime.now().strftime("%Y%m%d%H%M%S"),
@@ -112,14 +100,37 @@ def _get_defaults(repo_root=None):
         "optimize_strategies": None,
         "optimize_target_tasks": True,
         "owner": "nobody@mozilla.com",
-        "project": project,
+        "project": "",
         "pushdate": int(time.time()),
         "pushlog_id": "0",
-        "repository_type": repo.tool,
+        "repository_type": "",
         "target_tasks_method": "default",
         "tasks_for": "",
-        "version": get_version(repo_path),
+        "version": "",
     }
+    if repo:
+        try:
+            repo_url = repo.get_url()
+            parsed_url = mozilla_repo_urls.parse(repo_url)
+            project = parsed_url.repo_name
+        except (
+            CalledProcessError,
+            mozilla_repo_urls.errors.InvalidRepoUrlError,
+            mozilla_repo_urls.errors.UnsupportedPlatformError,
+        ):
+            repo_url = ""
+            project = ""
+
+        defaults.update({
+            "base_repository": repo_url,
+            "head_ref": repo.branch or repo.head_rev,
+            "head_repository": repo_url,
+            "head_rev": repo.head_rev,
+            "project": project,
+            "repository_type": repo.tool,
+            "version": get_version(repo_path),
+        })
+    return defaults
 
 
 defaults_functions = [_get_defaults]
@@ -195,13 +206,14 @@ class Parameters(ReadOnlyDict):
     @staticmethod
     def _fill_defaults(repo_root=None, **kwargs):
         defaults = {}
-        for fn in defaults_functions:
-            defaults.update(fn(repo_root))
+        if repo_root != "SOURCE":
+            for fn in defaults_functions:
+                defaults.update(fn(repo_root))
 
-        for name, default in defaults.items():
-            if name not in kwargs:
-                kwargs[name] = default
-        return kwargs
+            for name, default in defaults.items():
+                if name not in kwargs:
+                    kwargs[name] = default
+            return kwargs
 
     def check(self):
         schema = (

--- a/src/taskgraph/util/vcs.py
+++ b/src/taskgraph/util/vcs.py
@@ -511,8 +511,9 @@ def get_repository(path):
             return HgRepository(path)
         elif os.path.exists(os.path.join(path, ".git")):
             return GitRepository(path)
-
-    raise RuntimeError("Current directory is neither a git or hg repository")
+        elif os.path.exists(os.path.join(path, "moz.configure")):
+            return None
+    raise RuntimeError("Current directory is neither a git or hg repository, nor a release source")
 
 
 def find_hg_revision_push_info(repository, revision):

--- a/src/taskgraph/util/vcs.py
+++ b/src/taskgraph/util/vcs.py
@@ -513,7 +513,9 @@ def get_repository(path):
             return GitRepository(path)
         elif os.path.exists(os.path.join(path, "moz.configure")):
             return None
-    raise RuntimeError("Current directory is neither a git or hg repository, nor a release source")
+    raise RuntimeError(
+        "Current directory is neither a git or hg repository, nor a release source"
+    )
 
 
 def find_hg_revision_push_info(repository, revision):


### PR DESCRIPTION
Hey,
I was notified that changes i had done in https://bugzilla.mozilla.org/show_bug.cgi?id=1798746
to the `mozilla-central/third_party/python/taskcluster_taskgraph` were overwritten, and that they should have been changed here in the taskgraph github instead.

The reason for the change is to be able to build firefox from release tarball using the `mach` command (which was not previously doable)