### PR TITLE
Much more broad support for task substitution

### DIFF
--- a/docs/reference/transforms/index.rst
+++ b/docs/reference/transforms/index.rst
@@ -9,3 +9,4 @@ provides, read below to learn how to use them.
 .. toctree::
 
    from_deps
+   task_context

--- a/docs/reference/transforms/task_context.rst
+++ b/docs/reference/transforms/task_context.rst
@@ -1,0 +1,137 @@
+.. _task_context:
+
+Task Context
+============
+
+The :mod:`taskgraph.transforms.task_context` transform can be used to
+substitute values into any field in a task with data that is not known
+until ``taskgraph`` runs.
+
+This data can be provided in a few ways, as described below.
+
+Usage
+-----
+
+from-parameters
+~~~~~~~~~~~~~~~
+
+Context can be pulled from parameters that are provided to ``taskgraph``.
+
+First, add the transform to the ``transforms`` key in your ``kind.yml`` file:
+
+.. code-block:: yaml
+
+   transforms:
+     - taskgraph.transforms.task_context
+     # ...
+
+Then create a ``task-context`` section in your task definition, e.g:
+
+.. code-block:: yaml
+
+   tasks:
+     build:
+       description: my description {foo}
+       task-context:
+         from-parameters:
+           foo: foo
+         substitution-fields:
+           - description
+
+When ``taskgraph`` is run the value of ``foo`` in the parameters it is provided
+will be substituted into the description. For example, if the following parameters
+are used:
+
+.. code-block:: yaml
+
+   foo: with some extra
+
+...the description will end up with a value of "my description with some extra".
+
+When using ``from-parameters`` you may also provide an ordered list of keys to
+look for in the parameters, with the first one found being used. For example,
+with the this ``kind``:
+
+.. code-block:: yaml
+
+   tasks:
+     build:
+       description: my description {foo}
+       task-context:
+         from-parameters:
+           foo:
+             - foo
+             - default
+         substitution-fields:
+           - description
+
+...the description will bring in the value ``foo`` from the parameters if
+present, or ``default`` otherwise.
+
+from-file
+~~~~~~~~~
+
+Context may also be provided from a defined yaml file. The provided file
+should usually only contain top level keys and values (eg: nested objects
+will not be interpolated - they will be substituted as text representations
+of the object).
+
+For example, with this kind definition:
+
+.. code-block:: yaml
+
+   tasks:
+     build:
+       description: my description {foo}
+       task-context:
+         from-file: some_file.yaml
+         substitution-fields:
+           - description
+
+And this in ``some_file.yaml``:
+
+.. code-block:: yaml
+
+   foo: from a file
+
+...description will end up with "my description from a file".
+
+
+from-object
+~~~~~~~~~~~
+
+You may also specify context as direct keys and values in the ``task-context``
+configuration in ``from-object`` . This can be useful in ``kinds`` that define
+most of their contents in ``task-defaults``, but have some values that may
+differ for various concrete ``tasks`` in the ``kind``.
+
+For example:
+
+.. code-block:: yaml
+
+   task-defaults:
+     description: my description {extra_desc}
+     task-context:
+       substitution-fields:
+         - description
+
+   tasks:
+     build1:
+       task-context:
+         from-object:
+           extra_desc: build1
+     build2:
+       task-context:
+         from-object:
+           extra_desc: build2
+
+This will give build1 and build2 descriptions with their ``extra_desc``
+included while allowing them to share the rest of their task definition.
+
+Precedence
+----------
+
+If the same key is found in multiple places the order of precedence
+is as follows: ``from-parameters``, ``from-object`` keys, ``from-file``.
+
+That is to say: parameters will always override anything else.

--- a/src/taskgraph/transforms/job/run_task.py
+++ b/src/taskgraph/transforms/job/run_task.py
@@ -15,7 +15,6 @@ from taskgraph.transforms.job.common import support_vcs_checkout
 from taskgraph.transforms.task import taskref_or_string
 from taskgraph.util import path, taskcluster
 from taskgraph.util.schema import Schema
-from taskgraph.util.yaml import load_yaml
 
 EXEC_COMMANDS = {
     "bash": ["bash", "-cx"],
@@ -46,16 +45,6 @@ run_task_schema = Schema(
         # it will be included in a single argument to the command specified by
         # `exec-with`.
         Required("command"): Any([taskref_or_string], taskref_or_string),
-        # Context to substitute into the command using format string
-        # substitution (e.g {value}). This is useful if certain aspects of the
-        # command need to be generated in transforms.
-        Optional("command-context"): {
-            # If present, loads a set of context variables from an unnested yaml
-            # file. If a value is present in both the provided file and directly
-            # in command-context, the latter will take priority.
-            Optional("from-file"): str,
-            Extra: object,
-        },
         # What to execute the command with in the event command is a string.
         Optional("exec-with"): Any(*list(EXEC_COMMANDS)),
         # Command used to invoke the `run-task` script. Can be used if the script
@@ -137,25 +126,6 @@ def script_url(config, script):
     return f"{tc_url}/api/queue/v1/task/{task_id}/artifacts/public/{script}"
 
 
-def substitute_command_context(command_context, command):
-    from_file = command_context.pop("from-file", None)
-    full_context = {}
-    if from_file:
-        full_context = load_yaml(from_file)
-    else:
-        full_context = {}
-
-    full_context.update(command_context)
-
-    if isinstance(command, list):
-        for i in range(len(command)):
-            command[i] = command[i].format(**full_context)
-    else:
-        command = command.format(**full_context)
-
-    return command
-
-
 @run_job_using(
     "docker-worker", "run-task", schema=run_task_schema, defaults=worker_defaults
 )
@@ -176,13 +146,6 @@ def docker_worker_run_task(config, job, taskdesc):
         )
 
     run_command = run["command"]
-
-    if run.get("command-context"):
-        run_command = substitute_command_context(
-            run.get("command-context"), run["command"]
-        )
-    else:
-        run_command = run["command"]
 
     # dict is for the case of `{'task-reference': str}`.
     if isinstance(run_command, str) or isinstance(run_command, dict):
@@ -249,11 +212,6 @@ def generic_worker_run_task(config, job, taskdesc):
             run_command = f'"{run_command}"'
         exec_cmd = EXEC_COMMANDS[run.pop("exec-with", "bash")]
         run_command = exec_cmd + [run_command]
-
-    if run.get("command-context"):
-        run_command = substitute_command_context(
-            run.get("command-context"), run_command
-        )
 
     if run["run-as-root"]:
         command.extend(("--user", "root", "--group", "root"))

--- a/src/taskgraph/transforms/job/run_task.py
+++ b/src/taskgraph/transforms/job/run_task.py
@@ -8,7 +8,7 @@ Support for running jobs that are invoked via the `run-task` script.
 import dataclasses
 import os
 
-from voluptuous import Any, Extra, Optional, Required
+from voluptuous import Any, Optional, Required
 
 from taskgraph.transforms.job import run_job_using
 from taskgraph.transforms.job.common import support_vcs_checkout

--- a/src/taskgraph/transforms/task_context.py
+++ b/src/taskgraph/transforms/task_context.py
@@ -1,11 +1,11 @@
-import copy
 from textwrap import dedent
+
+from voluptuous import ALLOW_EXTRA, Any, Optional, Required
 
 from taskgraph.transforms.base import TransformSequence
 from taskgraph.util.schema import Schema
 from taskgraph.util.templates import deep_get, substitute
 from taskgraph.util.yaml import load_yaml
-from voluptuous import ALLOW_EXTRA, Any, Extra, Optional, Required
 
 SCHEMA = Schema(
     {

--- a/src/taskgraph/transforms/task_context.py
+++ b/src/taskgraph/transforms/task_context.py
@@ -1,0 +1,121 @@
+import copy
+from textwrap import dedent
+
+from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.schema import Schema
+from taskgraph.util.templates import deep_get, substitute
+from taskgraph.util.yaml import load_yaml
+from voluptuous import ALLOW_EXTRA, Any, Extra, Optional, Required
+
+SCHEMA = Schema(
+    {
+        Required(
+            "task-context",
+            description=dedent(
+                """
+            `task-context` can be used to substitute values into any field in a
+            task with data that is not known until `taskgraph` runs.
+
+            This data can be provided via `from-parameters` or `from-file`,
+            which can pull in values from parameters and a defined yml file
+            respectively.
+
+            Data may also be provided directly in the `from-object` section of
+            `task-context`. This can be useful in `kinds` that define most of
+            their contents in `task-defaults`, but have some values that may
+            differ for various concrete `tasks` in the `kind`.
+
+            If the same key is found in multiple places the order of precedence
+            is as follows:
+              - Parameters
+              - `from-object` keys
+              - File
+
+            That is to say: parameters will always override anything else.
+
+            """.lstrip(),
+            ),
+        ): {
+            Optional(
+                "from-parameters",
+                description=dedent(
+                    """
+                Retrieve task context values from parameters. A single
+                parameter may be provided or a list of parameters in
+                priority order. The latter can be useful in implementing a
+                "default" value if some other parameter is not provided.
+                """.lstrip()
+                ),
+            ): {str: Any([str], str)},
+            Optional(
+                "from-file",
+                description=dedent(
+                    """
+                Retrieve task context values from a yaml file. The provided
+                file should usually only contain top level keys and values
+                (eg: nested objects will not be interpolated - they will be
+                substituted as text representations of the object).
+                """.lstrip()
+                ),
+            ): str,
+            Optional(
+                "from-object",
+                description="Key/value pairs to be used as task context",
+            ): object,
+            Required(
+                "substitution-fields",
+                description=dedent(
+                    """
+                A list of fields in the task to substitute the provided values
+                into.
+                """.lstrip()
+                ),
+            ): [str],
+        },
+    },
+    extra=ALLOW_EXTRA,
+)
+
+transforms = TransformSequence()
+transforms.add_validate(SCHEMA)
+
+
+@transforms.add
+def render_task(config, jobs):
+    for job in jobs:
+        sub_config = job.pop("task-context")
+        params_context = {}
+        for var, path in sub_config.pop("from-parameters", {}).items():
+            if isinstance(path, str):
+                params_context[var] = deep_get(config.params, path)
+            else:
+                for choice in path:
+                    value = deep_get(config.params, choice)
+                    if value is not None:
+                        params_context[var] = value
+                        break
+
+        file_context = {}
+        from_file = sub_config.pop("from-file", None)
+        if from_file:
+            file_context = load_yaml(from_file)
+
+        fields = sub_config.pop("substitution-fields")
+
+        subs = {}
+        subs.update(file_context)
+        # We've popped away the configuration; everything left in `sub_config` is
+        # substitution key/value pairs.
+        subs.update(sub_config.pop("from-object", {}))
+        subs.update(params_context)
+
+        # Now that we have our combined context, we can substitute.
+        for field in fields:
+            container, subfield = job, field
+            while "." in subfield:
+                f, subfield = subfield.split(".", 1)
+                container = container[f]
+
+            container[subfield] = substitute(container[subfield], **subs)
+
+        yield job

--- a/src/taskgraph/util/templates.py
+++ b/src/taskgraph/util/templates.py
@@ -48,3 +48,33 @@ def merge(*objects):
     if len(objects) == 1:
         return copy.deepcopy(objects[0])
     return merge_to(objects[-1], merge(*objects[:-1]))
+
+
+def deep_get(dict_, field):
+    container, subfield = dict_, field
+    while "." in subfield:
+        f, subfield = subfield.split(".", 1)
+        if f not in container:
+            return None
+
+        container = container[f]
+
+    return container.get(subfield)
+
+
+def substitute(item, **subs):
+    if isinstance(item, list):
+        for i in range(len(item)):
+            item[i] = substitute(item[i], **subs)
+    elif isinstance(item, dict):
+        new_dict = {}
+        for k, v in item.items():
+            k = k.format(**subs)
+            new_dict[k] = substitute(v, **subs)
+        item = new_dict
+    elif isinstance(item, str):
+        item = item.format(**subs)
+    else:
+        item = item
+
+    return item

--- a/test/data/command_context.yaml
+++ b/test/data/command_context.yaml
@@ -1,1 +1,0 @@
-extra_string: "world"

--- a/test/data/task_context.yml
+++ b/test/data/task_context.yml
@@ -1,0 +1,4 @@
+file: file
+direct_and_file: shouldn't be used
+file_and_param: shouldn't be used
+direct_file_and_param: shouldn't be used

--- a/test/test_transform_task_context.py
+++ b/test/test_transform_task_context.py
@@ -1,0 +1,84 @@
+"""
+Tests for the 'fetch' transforms.
+"""
+
+import os.path
+from copy import deepcopy
+from pprint import pprint
+
+import pytest
+
+from taskgraph.transforms import task_context
+from taskgraph.transforms.base import TransformConfig
+
+from .conftest import FakeParameters
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+TASK_DEFAULTS = {
+    "description": "fake description {object} {file} {param} {object_and_file}"
+    "{object_and_param} {file_and_param} {object_file_and_param} {param_fallback}",
+    "name": "fake-task-name",
+    "task-context": {
+        "from-parameters": {
+            "param": "param",
+            "object_and_param": "object_and_param",
+            "file_and_param": "file_and_param",
+            "object_file_and_param": "object_file_and_param",
+            "param_fallback": ["missing-param", "default"],
+        },
+        "from-file": f"{here}/data/task_context.yml",
+        "from-object": {
+            "object": "object",
+            "object_and_param": "shouldn't be used",
+            "object_and_file": "object-overrides-file",
+            "object_file_and_param": "shouldn't be used",
+        },
+        "substitution-fields": [
+            "description",
+        ],
+    },
+}
+
+
+def test_transforms(request, run_transform, graph_config):
+    task = deepcopy(TASK_DEFAULTS)
+
+
+    params = FakeParameters(
+        {
+            "param": "param",
+            "object_and_param": "param-overrides-object",
+            "file_and_param": "param-overrides-file",
+            "object_file_and_param": "param-overrides-all",
+            "default": "default",
+            "base_repository": "http://hg.example.com",
+            "build_date": 0,
+            "build_number": 1,
+            "enable_always_target": True,
+            "head_repository": "http://hg.example.com",
+            "head_rev": "abcdef",
+            "head_ref": "default",
+            "level": "1",
+            "moz_build_date": 0,
+            "next_version": "1.0.1",
+            "owner": "some-owner",
+            "project": "some-project",
+            "pushlog_id": 1,
+            "repository_type": "hg",
+            "target_tasks_method": "test_method",
+            "tasks_for": "hg-push",
+            "try_mode": None,
+            "version": "1.0.0",
+        },
+    )
+    transform_config = TransformConfig(
+        "test", str(here), {}, params, {}, graph_config, write_artifacts=False
+    )
+
+    task = run_transform(task_context.transforms, task, config=transform_config)[0]
+    print("Dumping task:")
+    pprint(task, indent=2)
+
+    assert task["description"] == "fake description object file param object-overrides-file" \
+        "param-overrides-object param-overrides-file param-overrides-all default"

--- a/test/test_transform_task_context.py
+++ b/test/test_transform_task_context.py
@@ -6,8 +6,6 @@ import os.path
 from copy import deepcopy
 from pprint import pprint
 
-import pytest
-
 from taskgraph.transforms import task_context
 from taskgraph.transforms.base import TransformConfig
 
@@ -44,7 +42,6 @@ TASK_DEFAULTS = {
 def test_transforms(request, run_transform, graph_config):
     task = deepcopy(TASK_DEFAULTS)
 
-
     params = FakeParameters(
         {
             "param": "param",
@@ -80,5 +77,8 @@ def test_transforms(request, run_transform, graph_config):
     print("Dumping task:")
     pprint(task, indent=2)
 
-    assert task["description"] == "fake description object file param object-overrides-file" \
+    assert (
+        task["description"]
+        == "fake description object file param object-overrides-file"
         "param-overrides-object param-overrides-file param-overrides-all default"
+    )

--- a/test/test_transforms_job.py
+++ b/test/test_transforms_job.py
@@ -88,50 +88,6 @@ def test_worker_caches(task, transform):
     validate_schema(partial_schema, taskdesc["worker"][key], "validation error")
 
 
-@pytest.mark.parametrize(
-    "workerfn", [fn for fn, *_ in job.registry["run-task"].values()]
-)
-@pytest.mark.parametrize(
-    "task",
-    (
-        {
-            "worker-type": "t-linux",
-            "run": {
-                "checkout": True,
-                "comm-checkout": False,
-                "command": "echo '{output}'",
-                "command-context": {"output": "hello", "extra": None},
-                "run-as-root": False,
-                "sparse-profile": False,
-                "tooltool-downloads": False,
-            },
-        },
-    ),
-)
-def test_run_task_command_context(task, transform, workerfn, monkeypatch):
-    if "TASKCLUSTER_ROOT_URL" not in os.environ:
-        monkeypatch.setenv("TASKCLUSTER_ROOT_URL", _test_root_url())
-    # Clear memoized function
-    get_root_url.clear()
-
-    config, job_, taskdesc, _ = transform(task)
-    job_ = deepcopy(job_)
-
-    def assert_cmd(expected):
-        cmd = taskdesc["worker"]["command"]
-        while isinstance(cmd, list):
-            cmd = cmd[-1]
-        assert cmd == expected
-
-    workerfn(config, job_, taskdesc)
-    assert_cmd("echo 'hello'")
-
-    job_copy = job_.copy()
-    del job_copy["run"]["command-context"]
-    workerfn(config, job_copy, taskdesc)
-    assert_cmd("echo '{output}'")
-
-
 def assert_use_fetches_toolchain_env(task):
     assert task["worker"]["env"]["FOO"] == "1"
 

--- a/test/test_transforms_job.py
+++ b/test/test_transforms_job.py
@@ -14,15 +14,12 @@ from unittest.mock import patch
 import pytest
 
 # prevent pytest thinking this is a test
-from taskcluster_urls import test_root_url as _test_root_url
-
 from taskgraph.task import Task
 from taskgraph.transforms import job
 from taskgraph.transforms.job import run_task  # noqa: F401
 from taskgraph.transforms.job.common import add_cache
 from taskgraph.transforms.task import payload_builders
 from taskgraph.util.schema import Schema, validate_schema
-from taskgraph.util.taskcluster import get_root_url
 from taskgraph.util.templates import merge
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/test/test_transforms_job_run_task.py
+++ b/test/test_transforms_job_run_task.py
@@ -20,10 +20,7 @@ TASK_DEFAULTS = {
         "os": "linux",
         "env": {},
     },
-    "run": {
-        "using": "run-task",
-        "command": "echo hello world"
-    },
+    "run": {"using": "run-task", "command": "echo hello world"},
 }
 
 

--- a/test/test_transforms_job_run_task.py
+++ b/test/test_transforms_job_run_task.py
@@ -22,10 +22,7 @@ TASK_DEFAULTS = {
     },
     "run": {
         "using": "run-task",
-        "command": "echo hello {extra_string}",
-        "command-context": {
-            "from-file": f"{here}/data/command_context.yaml",
-        },
+        "command": "echo hello world"
     },
 }
 


### PR DESCRIPTION
While working on the Firefox Translations training pipeline I created a couple of very general transforms that had the effect of allowing substitution values into any part of a task definition. These values could be defined in the task templates themselves, or come from parameters. Both of these were inspired by the `command_context` support we already have in core Taskgraph, but take the idea much, much further.

My philosophy while working on this was to try to avoid kind-specific transforms at all costs, which meant having more generalized transforms that pushed some logic into the kinds via their configuration.

This pull request is a close-to-upstreamable version of those transforms. I'm not even sure we _want_ to support this here, so this is very much a draft at the moment, to be used to start a discussion.

Here are a couple of example from the Translations configuration that demonstrate the usage:
* In most kinds we substitute `src_locale` and `trg_locale` into a number of places (name, description, env or command, usually some dependencies and fetches). [This task](https://github.com/mozilla/firefox-translations-training/blob/a6748776bc81be973951c47df65796668631a105/taskcluster/ci/cefilter/kind.yml) is a good, simple example of that.
* In some cases, a context value may come from one of two places (think a specific value that can fallback to a default). [This kind shows that off](https://github.com/mozilla/firefox-translations-training/blob/a6748776bc81be973951c47df65796668631a105/taskcluster/ci/bicleaner/kind.yml#L57).
* Another good example is this kind where we have [tasks running a very similar command](https://github.com/mozilla/firefox-translations-training/blob/a6748776bc81be973951c47df65796668631a105/taskcluster/ci/merge-mono/kind.yml), with just [one argument being different between the two tasks](https://github.com/mozilla/firefox-translations-training/blob/a6748776bc81be973951c47df65796668631a105/taskcluster/ci/merge-mono/kind.yml#L97-L119).

It's worth calling out that task context is more or less just a generalized version of command context. The reason they're both here is because we don't have a good way to do multiple interpolations of the same field, so if, eg: you wanted to use `task-context` substitute something from parameters into `command`, but also use `command-context` to substitute something else - you'd end up getting a `KeyError` in the first `format()`.

If we decide we want to take this in full on in part there's definitely some clean-up that needs to happen - but this is a starting point.