### PR TITLE
Bug 1844298 - assert payload/index builders names are unique

### DIFF
--- a/src/taskgraph/transforms/task.py
+++ b/src/taskgraph/transforms/task.py
@@ -244,6 +244,7 @@ def payload_builder(name, schema):
     )
 
     def wrap(func):
+        assert name not in payload_builders, f"duplicate payload builder name {name}"
         payload_builders[name] = PayloadBuilder(schema, func)
         return func
 
@@ -256,6 +257,7 @@ index_builders = {}
 
 def index_builder(name):
     def wrap(func):
+        assert name not in index_builders, f"duplicate index builder name {name}"
         index_builders[name] = func
         return func
 


### PR DESCRIPTION
The task transform module keeps registries of payload and index builders, identified by a "name" string; AFAICT nothing prevents registering different functions under the same name, which seems potentially confusing.