### PR TITLE
feat: allow 'enable_always_target' parameter to accept a list of kinds

### DIFF
--- a/docs/reference/parameters.rst
+++ b/docs/reference/parameters.rst
@@ -104,11 +104,17 @@ These parameters are used at the ``target_task`` phase of :ref:`graph generation
 
 enable_always_target
 ~~~~~~~~~~~~~~~~~~~~
-    When ``True``, any task with the ``always_target`` attribute will be
-    included in the ``target_task_graph`` regardless of whether they were
-    filtered out by the ``target_tasks_method`` or not. Because they are not
-    part of the ``target_set``, they will still be eligible for optimization
-    when the ``optimize_target_tasks`` parameter is ``False``.
+
+   Can either be a boolean or a list of kinds.
+
+   When ``True``, any task with the ``always_target`` attribute will be included
+   in the ``target_task_graph`` regardless of whether they were filtered out by
+   the ``target_tasks_method`` or not. Because they are not part of the
+   ``target_set``, they will still be eligible for optimization when the
+   ``optimize_target_tasks`` parameter is ``False``.
+
+   When specified as a list of kinds, only tasks with a matching kind will be
+   eligible for addition to the graph.
 
 filters
 ~~~~~~~

--- a/src/taskgraph/generator.py
+++ b/src/taskgraph/generator.py
@@ -364,6 +364,8 @@ class TaskGraphGenerator:
                 t.label
                 for t in full_task_graph.tasks.values()
                 if t.attributes.get("always_target")
+                if parameters["enable_always_target"] is True
+                or t.kind in parameters["enable_always_target"]
             }
         else:
             always_target_tasks = set()

--- a/src/taskgraph/parameters.py
+++ b/src/taskgraph/parameters.py
@@ -37,7 +37,7 @@ base_schema = Schema(
         Required("build_date"): int,
         Required("build_number"): int,
         Required("do_not_optimize"): [str],
-        Required("enable_always_target"): bool,
+        Required("enable_always_target"): Any(bool, [str]),
         Required("existing_tasks"): {str: str},
         Required("filters"): [str],
         Required("head_ref"): str,

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -111,6 +111,42 @@ def test_always_target_tasks(maketgg):
         ["_fake-t-0", "_fake-t-1", "_ignore-t-0", "_ignore-t-1"]
     )
 
+    # Test `enable_always_target: ["_fake"]`
+    tgg_args = {
+        "target_tasks": ["_fake-t-0", "_fake-t-1", "_ignore-t-0", "_ignore-t-1"],
+        "kinds": [
+            (
+                "_fake",
+                {
+                    "task-defaults": {
+                        "attributes": {"always_target": True},
+                        "optimization": {"odd": None},
+                    }
+                },
+            ),
+            (
+                "_ignore",
+                {
+                    "task-defaults": {
+                        "attributes": {"always_target": True},
+                        "optimization": {"even": None},
+                    }
+                },
+            ),
+        ],
+        "params": {"enable_always_target": ["_fake"], "optimize_target_tasks": False},
+    }
+    tgg = maketgg(**tgg_args)
+    assert sorted(tgg.target_task_set.tasks.keys()) == sorted(
+        ["_fake-t-0", "_fake-t-1", "_ignore-t-0", "_ignore-t-1"]
+    )
+    assert sorted(tgg.target_task_graph.tasks.keys()) == sorted(
+        ["_fake-t-0", "_fake-t-1", "_fake-t-2", "_ignore-t-0", "_ignore-t-1"]
+    )
+    assert sorted(t.label for t in tgg.optimized_task_graph.tasks.values()) == sorted(
+        ["_fake-t-0", "_fake-t-1", "_fake-t-2", "_ignore-t-0", "_ignore-t-1"]
+    )
+
 
 def test_optimized_task_graph(maketgg):
     "The optimized task graph contains task ids"


### PR DESCRIPTION
The driver behind this change is that in Gecko we want to always add 'docker-image' tasks even when `enable_always_target` would otherwise be False for all other kinds.

This will allow us to default to `enable_always_target: ["docker-image"]`, and then upgrade to `enable_always_target: True` on autoland or try.