### PR TITLE
ci: enable 'autoCancelPreviousChecks' policy

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -6,6 +6,7 @@
 ---
 version: 1
 reporting: checks-v1
+autoCancelPreviousChecks: true
 policy:
     pullRequests: public_restricted
 tasks:

--- a/template/{{cookiecutter.project_name}}/taskcluster.github.yml
+++ b/template/{{cookiecutter.project_name}}/taskcluster.github.yml
@@ -6,6 +6,7 @@
 ---
 version: 1
 reporting: checks-v1
+autoCancelPreviousChecks: true
 policy:
     pullRequests: public
 tasks:


### PR DESCRIPTION
This is a new feature of Taskcluster Github that will attempt to automatically cancel tasks associated with a pull request after force pushing.