### PR TITLE
feat: Support `fetches` and `set-name` in `from_deps`

### DIFF
--- a/src/taskgraph/transforms/from_deps.py
+++ b/src/taskgraph/transforms/from_deps.py
@@ -16,8 +16,9 @@ from textwrap import dedent
 from voluptuous import Any, Extra, Optional, Required
 
 from taskgraph.transforms.base import TransformSequence
+from taskgraph.transforms.job import fetches_schema
 from taskgraph.util.attributes import attrmatch
-from taskgraph.util.dependencies import GROUP_BY_MAP
+from taskgraph.util.dependencies import GROUP_BY_MAP, get_dependencies
 from taskgraph.util.schema import Schema, validate_schema
 
 FROM_DEPS_SCHEMA = Schema(
@@ -36,6 +37,16 @@ FROM_DEPS_SCHEMA = Schema(
                 """.lstrip()
                 ),
             ): list,
+            Optional(
+                "set-name",
+                description=dedent(
+                    """
+                When True, `from_deps` will derive a name for the generated
+                tasks from the name of the primary dependency. Defaults to
+                True.
+                """.lstrip()
+                ),
+            ): bool,
             Optional(
                 "with-attributes",
                 description=dedent(
@@ -80,6 +91,17 @@ FROM_DEPS_SCHEMA = Schema(
                 """.lstrip()
                 ),
             ): bool,
+            Optional(
+                "fetches",
+                description=dedent(
+                    """
+                If present, a `fetches` entry will be added for each task
+                dependency. Attributes of the upstream task may be used as
+                substitution values in the `artifact` or `dest` values of the
+                `fetches` entry.
+                """.lstrip()
+                ),
+            ): {str: [fetches_schema]},
         },
         Extra: object,
     },
@@ -148,8 +170,10 @@ def from_deps(config, tasks):
             groups = func(config, deps)
 
         # Split the task, one per group.
+        set_name = from_deps.get("set-name", True)
         copy_attributes = from_deps.get("copy-attributes", False)
         unique_kinds = from_deps.get("unique-kinds", True)
+        fetches = from_deps.get("fetches", [])
         for group in groups:
             # Verify there is only one task per kind in each group.
             group_kinds = {t.kind for t in group}
@@ -177,14 +201,33 @@ def from_deps(config, tasks):
 
             primary_dep = [dep for dep in group if dep.kind == primary_kind][0]
 
-            if primary_dep.label.startswith(primary_kind):
-                new_task["name"] = primary_dep.label[len(primary_kind) + 1 :]
-            else:
-                new_task["name"] = primary_dep.label
+            if set_name:
+                if primary_dep.label.startswith(primary_kind):
+                    new_task["name"] = primary_dep.label[len(primary_kind) + 1 :]
+                else:
+                    new_task["name"] = primary_dep.label
 
             if copy_attributes:
-                attrs = new_task.get("attributes", {})
+                attrs = new_task.setdefault("attributes", {})
                 new_task["attributes"] = primary_dep.attributes.copy()
                 new_task["attributes"].update(attrs)
+
+            if fetches:
+                task_fetches = new_task.setdefault("fetches", {})
+
+                for dep_task in get_dependencies(config, new_task):
+                    fetches_from_dep = []
+                    for kind, kind_fetches in fetches.items():
+                        if kind != dep_task.kind:
+                            continue
+
+                        for fetch in kind_fetches:
+                            entry = fetch.copy()
+                            entry["artifact"] = entry["artifact"].format(**dep_task.attributes)
+                            if "dest" in entry:
+                                entry["dest"] = entry["dest"].format(**dep_task.attributes)
+                            fetches_from_dep.append(entry)
+
+                    task_fetches[dep_task.label] = fetches_from_dep
 
             yield new_task

--- a/src/taskgraph/transforms/from_deps.py
+++ b/src/taskgraph/transforms/from_deps.py
@@ -223,9 +223,13 @@ def from_deps(config, tasks):
 
                         for fetch in kind_fetches:
                             entry = fetch.copy()
-                            entry["artifact"] = entry["artifact"].format(**dep_task.attributes)
+                            entry["artifact"] = entry["artifact"].format(
+                                **dep_task.attributes
+                            )
                             if "dest" in entry:
-                                entry["dest"] = entry["dest"].format(**dep_task.attributes)
+                                entry["dest"] = entry["dest"].format(
+                                    **dep_task.attributes
+                                )
                             fetches_from_dep.append(entry)
 
                     task_fetches[dep_task.label] = fetches_from_dep

--- a/src/taskgraph/transforms/job/__init__.py
+++ b/src/taskgraph/transforms/job/__init__.py
@@ -27,6 +27,16 @@ from taskgraph.util.workertypes import worker_type_implementation
 
 logger = logging.getLogger(__name__)
 
+# Fetches may be accepted in other transforms and eventually passed along
+# to a `job` (eg: from_deps). Defining this here allows them to re-use
+# the schema and avoid duplication.
+fetches_schema = {
+    Required("artifact"): str,
+    Optional("dest"): str,
+    Optional("extract"): bool,
+    Optional("verify-hash"): bool,
+}
+
 # Schema for a build description
 job_description_schema = Schema(
     {
@@ -76,12 +86,7 @@ job_description_schema = Schema(
             Any("toolchain", "fetch"): [str],
             str: [
                 str,
-                {
-                    Required("artifact"): str,
-                    Optional("dest"): str,
-                    Optional("extract"): bool,
-                    Optional("verify-hash"): bool,
-                },
+                fetches_schema,
             ],
         },
         # A description of how to run this job.

--- a/test/test_transforms_from_deps.py
+++ b/test/test_transforms_from_deps.py
@@ -95,7 +95,12 @@ def assert_dont_set_name(tasks):
 def assert_group_by_all_with_fetch(tasks):
     handle_exception(tasks)
     assert len(tasks) == 1
-    assert tasks[0]["dependencies"] == {"foo1": "foo1", "foo2": "foo2", "foo3": "foo3", "foo4": "foo4"}
+    assert tasks[0]["dependencies"] == {
+        "foo1": "foo1",
+        "foo2": "foo2",
+        "foo3": "foo3",
+        "foo4": "foo4",
+    }
     assert tasks[0]["fetches"] == {
         "foo1": [
             {
@@ -161,7 +166,7 @@ def assert_group_by_all_with_fetch(tasks):
                 "from-deps": {
                     "group-by": "all",
                     "set-name": False,
-                }
+                },
             },
             # kind config
             None,
@@ -295,10 +300,26 @@ def assert_group_by_all_with_fetch(tasks):
             None,
             # deps
             {
-                "foo1": make_task("foo1", kind="foo", attributes={"this_chunk": "1", "total_chunks": "4", "kind": "foo"}),
-                "foo2": make_task("foo2", kind="foo", attributes={"this_chunk": "2", "total_chunks": "4", "kind": "foo"}),
-                "foo3": make_task("foo3", kind="foo", attributes={"this_chunk": "3", "total_chunks": "4", "kind": "foo"}),
-                "foo4": make_task("foo4", kind="foo", attributes={"this_chunk": "4", "total_chunks": "4", "kind": "foo"}),
+                "foo1": make_task(
+                    "foo1",
+                    kind="foo",
+                    attributes={"this_chunk": "1", "total_chunks": "4", "kind": "foo"},
+                ),
+                "foo2": make_task(
+                    "foo2",
+                    kind="foo",
+                    attributes={"this_chunk": "2", "total_chunks": "4", "kind": "foo"},
+                ),
+                "foo3": make_task(
+                    "foo3",
+                    kind="foo",
+                    attributes={"this_chunk": "3", "total_chunks": "4", "kind": "foo"},
+                ),
+                "foo4": make_task(
+                    "foo4",
+                    kind="foo",
+                    attributes={"this_chunk": "4", "total_chunks": "4", "kind": "foo"},
+                ),
                 "bar": make_task("bar", kind="bar", attributes={"kind": "bar"}),
             },
             id="group_by_all_with_fetch",


### PR DESCRIPTION
This came out of a long discussion that @ahal and I had about #294, where [we concluded that it would be better](https://github.com/taskcluster/taskgraph/pull/294#discussion_r1283529826) to have `from-deps` handle `fetches` than have a specialized transform that only deals with setting dependencies & fetches when an upstream task is chunked. 