### PR TITLE
feat: sort fetches by key and artifact to ensure a consistent ordering

### DIFF
--- a/src/taskgraph/transforms/job/__init__.py
+++ b/src/taskgraph/transforms/job/__init__.py
@@ -246,9 +246,10 @@ def use_fetches(config, jobs):
         worker = job.setdefault("worker", {})
         env = worker.setdefault("env", {})
         prefix = get_artifact_prefix(job)
-        for kind, artifacts in fetches.items():
+        for kind in sorted(fetches):
+            artifacts = fetches[kind]
             if kind in ("fetch", "toolchain"):
-                for fetch_name in artifacts:
+                for fetch_name in sorted(artifacts):
                     label = f"{kind}-{fetch_name}"
                     label = aliases.get(label, label)
                     if label not in artifact_names:
@@ -300,7 +301,13 @@ def use_fetches(config, jobs):
 
                     prefix = get_artifact_prefix(dep_tasks[0])
 
-                for artifact in artifacts:
+                def cmp_artifacts(a):
+                    if isinstance(a, str):
+                        return a
+                    else:
+                        return a["artifact"]
+
+                for artifact in sorted(artifacts, key=cmp_artifacts):
                     if isinstance(artifact, str):
                         path = artifact
                         dest = None


### PR DESCRIPTION
Fetches are not always processed in the same order across different runs of `taskgraph`. This change helps to make diffs of taskgraph output more readable. In cases where there are no changes to the fetches, it gets rid of the diffs altogether. In cases where there _are_ changes to the fetches, it helps to highlight the things that have actually changed.

In an ideal world we could pretty print these variables when doing diffs, but that's more effort than I'm willing to put in at the moment.