### PR TITLE
fix: from-deps: don't override all existing dependencies; don't add fetch entry for kinds without fetches

### DIFF
--- a/src/taskgraph/transforms/from_deps.py
+++ b/src/taskgraph/transforms/from_deps.py
@@ -184,9 +184,9 @@ def from_deps(config, tasks):
 
             new_task = deepcopy(task)
             new_task.setdefault("dependencies", {})
-            new_task["dependencies"].update({
-                dep.kind if unique_kinds else dep.label: dep.label for dep in group
-            })
+            new_task["dependencies"].update(
+                {dep.kind if unique_kinds else dep.label: dep.label for dep in group}
+            )
 
             # Set name and copy attributes from the primary kind.
             for kind in kinds:

--- a/src/taskgraph/transforms/from_deps.py
+++ b/src/taskgraph/transforms/from_deps.py
@@ -183,9 +183,10 @@ def from_deps(config, tasks):
                 )
 
             new_task = deepcopy(task)
-            new_task["dependencies"] = {
+            new_task.setdefault("dependencies", {})
+            new_task["dependencies"].update({
                 dep.kind if unique_kinds else dep.label: dep.label for dep in group
-            }
+            })
 
             # Set name and copy attributes from the primary kind.
             for kind in kinds:
@@ -216,6 +217,10 @@ def from_deps(config, tasks):
                 task_fetches = new_task.setdefault("fetches", {})
 
                 for dep_task in get_dependencies(config, new_task):
+                    # Nothing to do if this kind has no fetches listed
+                    if dep_task.kind not in fetches:
+                        continue
+
                     fetches_from_dep = []
                     for kind, kind_fetches in fetches.items():
                         if kind != dep_task.kind:


### PR DESCRIPTION
The former is arguably more than a "fix" in that it changes `from-deps` in a way that it is no longer the sole thing that manages upstream dependencies. In my opinion, if we are considering `from-deps` the official way to collect results from chunked/parallelized tasks, this is a necessary change, as we cannot predict the other things that such tasks may also depend on.

The latter is a pure bug fix: we shouldn't add a `fetch` block for kinds that have no `fetches` listed in `from-deps`.

(I can separate these two if it's useful.)