### PR TITLE
Log the body of taskcluster errors

### DIFF
--- a/src/taskgraph/util/taskcluster.py
+++ b/src/taskgraph/util/taskcluster.py
@@ -120,7 +120,7 @@ def _do_request(url, method=None, **kwargs):
     if response.status_code >= 400:
         # Consume content before raise_for_status, so that the connection can be
         # reused.
-        response.content
+        logger.warning("response body: %s", response.text)
     response.raise_for_status()
     return response
 


### PR DESCRIPTION
This means we log the entire error message instead of just the http status code.