### PR TITLE
docs: add a new tutorial that uses 'taskgraph init'

### DIFF
--- a/docs/concepts/transforms.rst
+++ b/docs/concepts/transforms.rst
@@ -1,9 +1,10 @@
 Transforms
 ==========
 
-Many task kinds generate tasks by a process of transforming job descriptions
-into task definitions. The basic operation is simple, although the sequence of
-transforms applied for a particular kind may not be!
+Often tasks grow in complexity such that it is annoying or even impossible to
+specify as a YAML object. Taskgraph has the concept of :term:`transforms
+<Transform>` to help deal with this. Transforms allow you to layer programmatic
+logic on top of your task definitions.
 
 Overview
 --------
@@ -57,28 +58,28 @@ to the previous one:
      - project_taskgraph.transforms
      - taskgraph.transforms.task
 
-
-
 Transform Functions
 ...................
 
-Each transformation looks like this:
+Each transform function looks like:
 
 .. code-block:: python
 
-    from taskgraph.transforms.base import TransformSequence
+    from typing import Dict, Iterator
+
+    from taskgraph.transforms.base import TransformConfig, TransformSequence
 
     transforms = TransformSequence()
 
     @transforms.add
-    def transform_a_task(config, tasks):
+    def transform_a_task(config: TransformConfig, tasks: Iterator[Dict]) -> Iterator[Dict]:
         """This transform ..."""  # always include a docstring!
         for task in tasks:
             # do stuff to the task..
             yield task
 
 The ``config`` argument is a Python object containing useful configuration for
-the kind, and is a subclass of
+the kind, and is an instance of
 :class:`taskgraph.transforms.base.TransformConfig`, which specifies a few of
 its attributes. Kinds may subclass and add additional attributes if necessary.
 

--- a/docs/howto/create-tasks.rst
+++ b/docs/howto/create-tasks.rst
@@ -1,0 +1,153 @@
+Create Tasks
+============
+
+If you've followed the tutorials, you may have a working Taskcluster +
+Taskgraph setup, but could be left wondering how to add a new task. This guide
+will teach you the basics of creating tasks!
+
+Create a Kind
+-------------
+
+Before we can define tasks, we need to define a :term:`Kind`. Kinds are groups
+of tasks that share some commonality with one another (how common they are
+depends on how you choose to organize them). So the first step is to define a
+kind for your task.
+
+If we're creating a build task, you might define a ``build`` kind by creating
+``taskcluster/ci/build/kind.yml``. Simply creating this file is enough to
+define a kind, though in practice you'll likely add extra configuration such
+as a :term:`loader <Loader>` or :term:`transforms <Transform>`.
+
+Add Tasks to your Kind
+----------------------
+
+Tasks are defined in the ``kind.yml`` under a ``tasks`` key. For example, our
+``build-linux`` task might look like:
+
+.. code-block:: yaml
+   :caption: taskcluster/ci/build/kind.yml
+
+   tasks:
+     build-linux:
+       description: "Build the app on Linux"
+       worker-type: b-linux
+       worker:
+         docker-image: {in-tree: build}
+       run:
+         using: run-task
+         cwd: '{checkout}'
+         command: ./scripts/build.sh
+
+If we want to add another task, say ``build-windows``, we can just append it
+to the ``tasks`` object:
+
+.. code-block:: yaml
+   :caption: taskcluster/ci/build/kind.yml
+
+   tasks:
+     build-linux:
+       description: "Build the app"
+       worker-type: b-linux
+       worker:
+         docker-image: {in-tree: build}
+       run:
+         using: run-task
+         cwd: '{checkout}'
+         command: ./scripts/build.sh
+
+     build-windows:
+       description: "Build the app"
+       worker-type: b-windows
+       run:
+         using: run-task
+         cwd: '{checkout}'
+         command: ./scripts/build.ps1
+
+.. note::
+
+   The format of the tasks depends heavily on which :term:`transforms
+   <Transform>` the kind uses. In this example, Taskgraph is implicitly adding
+   the :mod:`~taskgraph.transforms.job` and :mod:`~taskgraph.transforms.task`
+   transforms. See :doc:`/concepts/transforms` for more information.
+
+Task Defaults
+-------------
+
+You may find that as you add more tasks, a certain amount of boilerplate gets
+copied from one task to the next. A ``task-defaults`` key can be used to
+reduce this overhead. The previous example can be re-written as:
+
+.. code-block:: yaml
+   :caption: taskcluster/ci/build/kind.yml
+
+   task-defaults:
+     description: "Build the app"
+     run:
+       using: run-task
+       cwd: '{checkout}'
+
+   tasks:
+     build-linux:
+       worker-type: b-linux
+       worker:
+         docker-image: {in-tree: build}
+       run:
+         command: ./scripts/build.sh
+
+     build-windows:
+       worker-type: b-windows
+       run:
+         command: ./scripts/build.ps1
+
+Using ``task-defaults`` recursively merges task configuration into the defaults
+for each task.
+
+Tasks From
+----------
+
+If you have a kind with a lot of tasks, the ``kind.yml`` file may grow to
+unmanageable sizes. To help mitigate this, you can use the ``tasks-from`` key.
+This allows you to define your tasks in any number of Yaml files outside of
+``kind.yml``. For example, the following example is equivalent to the previous two:
+
+.. code-block:: yaml
+   :caption: taskcluster/ci/build/kind.yml
+
+   task-defaults:
+     description: "Build the app"
+     run:
+       using: run-task
+       cwd: '{checkout}'
+
+   tasks-from:
+     - linux.yml
+     - windows.yml
+
+.. code-block:: yaml
+   :caption: taskcluster/ci/build/linux.yml
+
+   tasks:
+     build-linux:
+       worker-type: b-linux
+       worker:
+         docker-image: {in-tree: build}
+       run:
+         command: ./scripts/build.sh
+
+
+.. code-block:: yaml
+   :caption: taskcluster/ci/build/windows.yml
+
+   tasks:
+     build-windows:
+       worker-type: b-windows
+       run:
+         command: ./scripts/build.ps1
+
+All three of the previous examples should result in identical task definitions.
+
+Further Reading
+---------------
+
+Next you may want to learn about using :doc:`/concepts/transforms` or how to
+:doc:`/howto/run-locally`.

--- a/docs/howto/index.rst
+++ b/docs/howto/index.rst
@@ -6,6 +6,7 @@ A collection of how-to guides.
 .. toctree::
    :maxdepth: 1
 
+   create-tasks
    run-locally
    debugging
    bootstrap-taskgraph

--- a/docs/tutorials/getting-started.rst
+++ b/docs/tutorials/getting-started.rst
@@ -1,0 +1,124 @@
+Getting Started
+===============
+
+This tutorial will guide you towards a working Taskcluster + Taskgraph setup
+with your repo in as few steps as possible.
+
+.. note::
+
+   This tutorial has a heavy focus on the end result. If you prefer to build
+   understanding as you go, you may wish to follow the
+   :doc:`creating-a-task-graph` and :doc:`connecting-taskcluster` tutorials
+   instead.
+
+There are three steps to getting running tasks:
+
+1. Install Taskcluster Github
+2. Request Permissions
+3. Define Tasks
+
+Let's dive into each!
+
+Install Taskcluster Github
+--------------------------
+
+.. note::
+
+   If you are not using Github, skip to the next section.
+
+Each Taskcluster deployment has an associated Github app that needs to be added
+to your repo. Some apps for known Taskcluster deployments are as follows:
+
+.. list-table:: Taskcluster Github Apps
+   :widths: 20 60
+   :header-rows: 1
+
+   * - Instance
+     - Github App
+   * - `Firefox-CI <https://firefox-ci-tc.services.mozilla.com>`_
+     - https://github.com/apps/firefoxci-taskcluster
+   * - `Community <https://community-tc.services.mozilla.com>`_
+     - https://github.com/apps/community-tc-integration
+
+Follow the link to the Github app for your deployment and click ``Configure``
+near the top right. Then select the repository you'd like to enable. If you are
+not an admin of the organization you are enabling the repo for, this will send
+a request to your Github administrators.
+
+.. note::
+
+   If you do not see a ``Configure`` button, contact your Github administrators
+   for assistance.
+
+Request Permissions
+-------------------
+
+Your repository is now connected to Taskcluster, but it won't have permission
+to run anything. In the Taskcluster world, permissions are also known as
+:term:`scopes <Scope>`. So the next step is to contact your Taskcluster
+administrators and request scopes for your project so that it has access to the
+resources it needs to run tasks.
+
+Each Taskcluster instance can be managed differently, but here are the processes
+to request scopes for some known Taskcluster deployments:
+
+.. list-table:: Taskcluster Github Apps
+   :widths: 20 60
+   :header-rows: 1
+
+   * - Instance
+     - Process
+   * - `Firefox-CI <https://firefox-ci-tc.services.mozilla.com>`_
+     - `File a Bug <https://bugzilla.mozilla.org/enter_bug.cgi?product=Release%20Engineering&component=Firefox-CI%20Administration>`_
+   * - `Community <https://community-tc.services.mozilla.com>`_
+     - `File an Issue <https://github.com/mozilla/community-tc-config/issues/new>`_
+
+Use a title such as: *Please setup `org/my-repo` with Taskcluster*.
+
+Create Tasks
+------------
+
+The last step is to define your tasks. You'll need:
+
+1. A :term:`Decision Task` defined in ``.taskcluster.yml``
+2. A Taskgraph setup in the ``taskcluster`` directory
+
+Luckily Taskgraph provides an ``init`` command that can generate both of these
+things automatically! Run:
+
+.. code-block:: shell
+
+   $ pip install taskcluster-taskgraph
+   $ taskgraph init
+
+This will automatically generate all the necessary files. Commit what was
+generated:
+
+.. code-block:: shell
+
+   $ git add .
+   $ git commit -m "Add Taskcluster files"
+
+Now when you push, you should have a working Decision task that generates a
+``hello-world`` task as well as a ``docker-image`` task that it depends on!
+
+Further Reading
+---------------
+
+Now that you have a working Taskcluster setup, explore these docs to learn more
+about using Taskgraph!
+
+If you'd like to understand more about the files that the ``taskgraph init``
+command generated, you can follow the :doc:`creating-a-task-graph` and
+:doc:`connecting-taskcluster` tutorials
+
+Check out the :doc:`/concepts/index` page if you'd like to learn more about how
+Taskgraph works.
+
+Or if you are ready to dive into creating more tasks, you may wish to learn how
+to:
+
+* :doc:`/howto/run-locally`
+* :doc:`/howto/debugging`
+* :doc:`/howto/use-fetches`
+* :doc:`/howto/docker`

--- a/docs/tutorials/getting-started.rst
+++ b/docs/tutorials/getting-started.rst
@@ -118,6 +118,7 @@ Taskgraph works.
 Or if you are ready to dive into creating more tasks, you may wish to learn how
 to:
 
+* :doc:`/howto/create-tasks`
 * :doc:`/howto/run-locally`
 * :doc:`/howto/debugging`
 * :doc:`/howto/use-fetches`

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -7,5 +7,6 @@ connecting your repository with Taskcluster to running tasks.
 .. toctree::
    :maxdepth: 1
 
+   getting-started
    creating-a-task-graph
    connecting-taskcluster


### PR DESCRIPTION
We already have tutorials that cover building a `.taskcluster.yml` and `taskcluster` dir, however they do so from scratch and were created prior to the existence of `taskgraph init`.

This adds a tutorial for all the impatient people who just want to see tasks running and don't care about how things work.