### PR TITLE
feat: allow setting the maximum number of workers to use for taskgraph operations

### DIFF
--- a/src/taskgraph/main.py
+++ b/src/taskgraph/main.py
@@ -193,7 +193,7 @@ def generate_taskgraph(options, parameters, logdir):
         return 0
 
     futures = {}
-    with ProcessPoolExecutor() as executor:
+    with ProcessPoolExecutor(max_workers=options["max_workers"]) as executor:
         for spec in parameters:
             f = executor.submit(format_taskgraph, options, spec, logfile(spec))
             futures[f] = spec
@@ -341,6 +341,15 @@ def generate_taskgraph(options, parameters, logdir):
     help="Generate and diff the current taskgraph against another revision. "
     "Without args the base revision will be used. A revision specifier such as "
     "the hash or `.~1` (hg) or `HEAD~1` (git) can be used as well.",
+)
+@argument(
+    "-j",
+    "--max-workers",
+    dest="max_workers",
+    default=None,
+    type=int,
+    help="The maximum number of workers to use for parallel operations such as"
+    "when multiple parameters files are passed.",
 )
 def show_taskgraph(options):
     from taskgraph.parameters import Parameters, parameters_loader


### PR DESCRIPTION
Although rare, in certain cases taskgraph can cause OOMs if generating too many graphs in parallel.