### PR TITLE
Fix load-image with an image name

### DIFF
--- a/src/taskgraph/docker.py
+++ b/src/taskgraph/docker.py
@@ -34,7 +34,7 @@ def get_image_digest(image_name):
 
 def load_image_by_name(image_name, tag=None):
     from taskgraph.generator import load_tasks_for_kind
-    from taskgraph.optimize import IndexSearch
+    from taskgraph.optimize.strategies import IndexSearch
     from taskgraph.parameters import Parameters
 
     params = Parameters(
@@ -43,8 +43,9 @@ def load_image_by_name(image_name, tag=None):
     )
     tasks = load_tasks_for_kind(params, "docker-image")
     task = tasks[f"build-docker-image-{image_name}"]
+    deadline = None
     task_id = IndexSearch().should_replace_task(
-        task, {}, task.optimization.get("index-search", [])
+        task, {}, deadline, task.optimization.get("index-search", [])
     )
 
     if task_id in (True, False):
@@ -52,8 +53,10 @@ def load_image_by_name(image_name, tag=None):
             "Could not find artifacts for a docker image "
             "named `{image_name}`. Local commits and other changes "
             "in your checkout may cause this error. Try "
-            "updating to a fresh checkout of mozilla-central "
-            "to download image.".format(image_name=image_name)
+            "updating to a fresh checkout of {project} "
+            "to download image.".format(
+                image_name=image_name, project=params["project"]
+            )
         )
         return False
 


### PR DESCRIPTION
- import `IndexSearch` from the right place
- pass missing deadline argument to `should_replace_task`
- fix error message to not refer to mozilla-central