### PR TITLE
fix: bypass Git's safe directory feature in 'run-task'

### DIFF
--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -624,6 +624,11 @@ def git_checkout(
             "Must specify both ssh_key_file and ssh_known_hosts_file, if either are specified",
         )
 
+    # Bypass Git's "safe directory" feature as the destination could be
+    # coming from a cache and therefore cloned by a different user.
+    args = ["git", "config", "--global", "--add", "safe.directory", Path(destination_path).as_posix()]
+    retry_required_command(b"vcs", args, extra_env=env)
+
     if not os.path.exists(destination_path):
         # Repository doesn't already exist, needs to be cloned
         args = [


### PR DESCRIPTION
As of Git 2.35.2, a security feature to mitigate a CVE on multi-user setups:
https://github.blog/2022-04-12-git-security-vulnerability-announced/#cve-2022-24765

Basically Git will error out if the checkout dir isn't owned by the current user. This impacts `run-task` because checkouts can come from caches meaning they were cloned by a different task user.

As long as we aren't sharing caches across levels or pools (which we aren't), that other user is just as trusted as the current one. So it's safe to disable this check.

Issue: #345