### PR TITLE
Bug 1854152 - switch mobile decision image to Java 17

### DIFF
--- a/taskcluster/docker/decision-mobile/Dockerfile
+++ b/taskcluster/docker/decision-mobile/Dockerfile
@@ -3,9 +3,7 @@ FROM $DOCKER_IMAGE_PARENT
 
 RUN apt-get update && \
     apt-get install -y --force-yes --no-install-recommends \
-    # We need java 8 for sdkmanager
-    openjdk-8-jdk-headless \
-    openjdk-11-jdk-headless \
+    openjdk-17-jdk-headless \
     && \
     apt-get clean && \
     apt-get autoclean


### PR DESCRIPTION
reference-browser is hitting bustage trying to update to Gradle 8 because it depends on Java 17 and the decision images are still running 11.