### PR TITLE
fix(init): don't rely on local clone name for configuration

### DIFF
--- a/src/taskgraph/main.py
+++ b/src/taskgraph/main.py
@@ -18,6 +18,7 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, List
+from urllib.parse import urlparse
 
 import appdirs
 import yaml
@@ -834,6 +835,8 @@ def init_taskgraph(options):
             file=sys.stderr,
         )
         return 1
+
+    context["repo_name"] = urlparse(repo_url).path.rsplit("/", 1)[-1]
 
     # Generate the project.
     cookiecutter(

--- a/template/cookiecutter.json
+++ b/template/cookiecutter.json
@@ -1,7 +1,8 @@
 {
     "project_name": "my-project",
-    "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
     "repo_host": ["github", "hgmo"],
+    "repo_name": "my-repo",
+    "project_slug": "{{ cookiecutter.repo_name.lower().replace(' ', '_').replace('-', '_') }}",
     "trust_domain": "mozilla",
     "level": 1
 }

--- a/template/{{cookiecutter.project_name}}/taskcluster/ci/config.yml
+++ b/template/{{cookiecutter.project_name}}/taskcluster/ci/config.yml
@@ -6,7 +6,7 @@ taskgraph:
   cached-task-prefix: "{{cookiecutter.trust_domain}}.v2.{{cookiecutter.project_slug.replace('_', '-')}}"
   repositories:
     {{cookiecutter.project_slug}}:
-      name: "{{cookiecutter.project_name}}"
+      name: "{{cookiecutter.repo_name}}"
 
 workers:
   aliases:

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -197,14 +197,15 @@ def test_get_filtered_taskgraph(regex, exclude, expected):
 
 
 def test_init_taskgraph(mocker, tmp_path, project_root, repo_with_upstream):
+    name = "bar"
     repo, _ = repo_with_upstream
 
     # Mock out upstream url to bypass the repo host check.
     if repo.tool == "hg":
-        fake_url = "https://hg.mozilla.org/foo"
+        fake_url = f"https://hg.mozilla.org/foo/{name}"
         mocker.patch.object(HgRepository, "get_url").return_value = fake_url
     else:
-        fake_url = "https://github.com/foo"
+        fake_url = f"https://github.com/foo/{name}"
         mocker.patch.object(GitRepository, "get_url").return_value = fake_url
 
     # Point cookiecutter at temporary directories.
@@ -231,7 +232,6 @@ def test_init_taskgraph(mocker, tmp_path, project_root, repo_with_upstream):
         os.chdir(oldcwd)
 
     # Make assertions about the repository state.
-    name = repo_root.name
     expected_files = [
         ".taskcluster.yml",
         "taskcluster/ci/config.yml",
@@ -240,7 +240,8 @@ def test_init_taskgraph(mocker, tmp_path, project_root, repo_with_upstream):
         f"taskcluster/{name}_taskgraph/transforms/hello.py",
     ]
     for f in expected_files:
-        assert (repo_root / f).is_file()
+        path = repo_root / f
+        assert path.is_file(), f"{str(path)} not found!"
 
     c = load_yaml(str(repo_root / "taskcluster" / "ci" / "config.yml"))
     assert c["trust-domain"] == "mozilla"


### PR DESCRIPTION
Issue: #347