### PR TITLE
Format chunks with zero padding

### DIFF
--- a/src/taskgraph/transforms/chunking.py
+++ b/src/taskgraph/transforms/chunking.py
@@ -62,9 +62,10 @@ def chunk_tasks(config, tasks):
         for this_chunk in range(1, total_chunks + 1):
             subtask = copy.deepcopy(task)
 
+            # Format the chunks with zero padding
             subs = {
-                "this_chunk": this_chunk,
-                "total_chunks": total_chunks,
+                "this_chunk": str(this_chunk).zfill(2),
+                "total_chunks": str(total_chunks).zfill(2),
             }
             subtask.setdefault("attributes", {})
             subtask["attributes"].update(subs)

--- a/test/test_transform_chunking.py
+++ b/test/test_transform_chunking.py
@@ -31,5 +31,5 @@ def test_transforms(request, run_transform):
     pprint(tasks, indent=2)
 
     assert len(tasks) == 2, "Chunking should've generated 2 tasks"
-    assert_chunked_task(tasks[0], 1)
-    assert_chunked_task(tasks[1], 2)
+    assert_chunked_task(tasks[0], "01")
+    assert_chunked_task(tasks[1], "02")


### PR DESCRIPTION
I think these changes would solve https://github.com/mozilla/firefox-translations-training/issues/220

Since task can't have more than 99 dependencies I don't think we need to worry about people sorting things that go above 100.