### PR TITLE
fix(init): use project specific checkout cache by default

### DIFF
--- a/template/{{cookiecutter.project_name}}/taskcluster.github.yml
+++ b/template/{{cookiecutter.project_name}}/taskcluster.github.yml
@@ -198,7 +198,7 @@ tasks:
                                     ACTION_CALLBACK: '${action.cb_name}'
 
                       cache:
-                          "${trustDomain}-level-${level}-checkouts-sparse-v2": /builds/worker/checkouts
+                          "${trustDomain}-project-${project}-level-${level}-checkouts-sparse-v2": /builds/worker/checkouts
 
                       features:
                           taskclusterProxy: true


### PR DESCRIPTION
While some trust domains (like Gecko) might want to share checkout caches across projects, typically projects are not related code bases to one another. So we probably don't want to share checkout caches by default.