### PR TITLE
feat: add optional local-run field to put "How to run job locally"

### DIFF
--- a/src/taskgraph/transforms/job/__init__.py
+++ b/src/taskgraph/transforms/job/__init__.py
@@ -104,6 +104,8 @@ job_description_schema = Schema(
         # This object will be passed through to the task description, with additions
         # provided by the job's run-using function
         Optional("worker"): dict,
+        # Description for how to run the job locally.
+        Optional("local-run"): str,
     }
 )
 

--- a/src/taskgraph/transforms/task.py
+++ b/src/taskgraph/transforms/task.py
@@ -186,6 +186,8 @@ task_description_schema = Schema(
             Required("implementation"): str,
             Extra: object,
         },
+        # Description for how to run the job locally.
+        Optional("local-run"): str,
     }
 )
 


### PR DESCRIPTION
This is for [bug 1863187](https://bugzilla.mozilla.org/show_bug.cgi?id=1863187) and [bug 1863347](https://bugzilla.mozilla.org/show_bug.cgi?id=1863347), where I want to show "How to run job locally" to TreeHerder UI, to each job's view, in case the job fails on automation and people need to investigate the issue locally.

The optional `local-run` field is supposed to contain a string with list of commands, instructions (create file, etc), or a link to documentation.

example data is in https://phabricator.services.mozilla.com/D192856
