### PR TITLE
Split docker-worker caches by docker image (bug 1866109)

### DIFF
--- a/src/taskgraph/transforms/job/common.py
+++ b/src/taskgraph/transforms/job/common.py
@@ -130,12 +130,6 @@ def support_vcs_checkout(config, job, taskdesc, repo_configs, sparse=False):
     if sparse:
         cache_name += "-sparse"
 
-    # Workers using Mercurial >= 5.8 will enable revlog-compression-zstd, which
-    # workers using older versions can't understand, so they can't share cache.
-    # At the moment, only docker workers use the newer version.
-    if is_docker:
-        cache_name += "-hg58"
-
     add_cache(job, taskdesc, cache_name, checkoutdir)
 
     env = taskdesc["worker"].setdefault("env", {})

--- a/src/taskgraph/util/parameterization.py
+++ b/src/taskgraph/util/parameterization.py
@@ -20,6 +20,12 @@ def _recurse(val, param_fns):
             if len(val) == 1:
                 for param_key, param_fn in param_fns.items():
                     if set(val.keys()) == {param_key}:
+                        if isinstance(val[param_key], dict):
+                            # handle `{"task-reference": {"<foo>": "bar"}}`
+                            return {
+                                param_fn(key): recurse(v)
+                                for key, v in val[param_key].items()
+                            }
                         return param_fn(val[param_key])
             return {k: recurse(v) for k, v in val.items()}
         else:

--- a/test/test_transforms_job_run_task.py
+++ b/test/test_transforms_job_run_task.py
@@ -53,7 +53,7 @@ def assert_docker_worker(task):
             "caches": [
                 {
                     "mount-point": "/builds/worker/checkouts",
-                    "name": "checkouts-hg58",
+                    "name": "checkouts",
                     "skip-untrusted": False,
                     "type": "persistent",
                 }

--- a/test/test_util_parameterization.py
+++ b/test/test_util_parameterization.py
@@ -90,7 +90,7 @@ def test_task_refs_multiple(assert_task_refs):
 
 
 def test_task_refs_embedded(assert_task_refs):
-    "resolve_task_references resolves ebmedded references"
+    "resolve_task_references resolves embedded references"
     assert_task_refs(
         {"embedded": {"task-reference": "stuff before <edge3> stuff after"}},
         {"embedded": "stuff before tid3 stuff after"},
@@ -121,6 +121,14 @@ def test_task_refs_decision(assert_task_refs):
     "resolve_task_references resolves `decision` to the provided decision task id"
     assert_task_refs(
         {"escape": {"task-reference": "<decision>"}}, {"escape": "tid-decision"}
+    )
+
+
+def test_task_refs_key(assert_task_refs):
+    "resolve_task_references resolves task references in a dict's keys"
+    assert_task_refs(
+        {"dict": {"task-reference": {"<edge3>": "<ignored>"}}},
+        {"dict": {"tid3": "<ignored>"}},
     )
 
 


### PR DESCRIPTION
Sharing the same vcs checkout/storage dirs across different tasks running on different docker images runs the risk of incompatilibities, as shown e.g. when cloning a hg repo with one version of mercurial then trying to re-use it later using an older version.

Splitting by docker image means we lose some of the benefits of shared storage, but is safer in the face of tasks with (from taskgraph's point of view) unknown/arbitrary tool versions.  In practice this is hopefully good enough because there are few enough different docker images compared to the number of downstream tasks.

This requires a way to parametrize the cache name in the full task graph (at which stage in-tree docker images aren't resolved yet); we make it so that `{"task-reference": {"<foo>": "bar"}}` works and resolves `<foo>` to its task id at morph time.