### PR TITLE
Normalize Path Separator in util.hash.py

### DIFF
--- a/src/taskgraph/util/hash.py
+++ b/src/taskgraph/util/hash.py
@@ -55,4 +55,8 @@ def _find_matching_files(base_path, pattern):
 
 @memoize
 def _get_all_files(base_path):
-    return [mozpath.normsep(str(path)) for path in Path(base_path).rglob("*") if path.is_file()]
+    return [
+        mozpath.normsep(str(path))
+        for path in Path(base_path).rglob("*")
+        if path.is_file()
+    ]

--- a/src/taskgraph/util/hash.py
+++ b/src/taskgraph/util/hash.py
@@ -55,4 +55,4 @@ def _find_matching_files(base_path, pattern):
 
 @memoize
 def _get_all_files(base_path):
-    return [str(path) for path in Path(base_path).rglob("*") if path.is_file()]
+    return [mozpath.normsep(str(path)) for path in Path(base_path).rglob("*") if path.is_file()]


### PR DESCRIPTION
Hey! :) 

I just did setup taskgraph locally on a windows machine, and wanted to run the full moz-vpn taskgraph. That it was trying to match `taskcluster/scripts/toolchain/compile_openssl.ps1` vs the windows path `taskcluster\scripts\toolchain\compile_openssl.ps1` therefore failed :c 
