### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ CI`_.
 Installation
 ------------
 
-Taskgraph supports Python 3.7 and up, and can be installed from Pypi:
+Taskgraph supports Python 3.8 and up, and can be installed from Pypi:
 
 .. code-block::
 

--- a/docs/reference/migrations.rst
+++ b/docs/reference/migrations.rst
@@ -3,6 +3,11 @@ Migration Guide
 
 This page can help when migrating Taskgraph across major versions.
 
+6.x -> 7.x
+----------
+
+* Upgrade to Python 3.8 or higher
+
 5.x -> 6.x
 ----------
 

--- a/pin-helper.sh
+++ b/pin-helper.sh
@@ -10,7 +10,7 @@ pip-compile-multi -u \
     -g base -g test -g dev -g docs
 '
 
-PIN_PYTHON=3.7
+PIN_PYTHON=3.8
 docker run -t -v $PWD:/src -w /src python:$PIN_PYTHON bash -c "${PIN_COMMAND}"
 
 set +x
@@ -23,7 +23,7 @@ set -x
 # Don't quit if a version fails
 set +e
 failed=0
-for version in 3.7 3.8 3.9 3.10 3.11; do
+for version in 3.8 3.9 3.10 3.11; do
     docker run -t -v $PWD:/src -w /src python:$version bash -c "pip install -q -r requirements/dev.txt"
     rt=$?
     if [ $rt -gt 0 ]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ ignore = [
     "E501",  # let black handle line-length
     "E741",
 ]
-target-version = "py37"
+target-version = "py38"
 
 [tool.ruff.isort]
 known-first-party = ["taskgraph"]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -118,10 +118,6 @@ idna==3.4 \
     --hash=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4 \
     --hash=sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
     # via requests
-importlib-metadata==6.6.0 \
-    --hash=sha256:43dd286a2cd8995d5eaef7fee2066340423b818ed3fd70adf0bad5f1fac53fed \
-    --hash=sha256:92501cdf9cc66ebd3e612f1b4f0c0765dfa42f0fa38ffb319b6bd84dd675d705
-    # via click
 jinja2==3.1.2 \
     --hash=sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852 \
     --hash=sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61
@@ -271,12 +267,6 @@ text-unidecode==1.3 \
     --hash=sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8 \
     --hash=sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93
     # via python-slugify
-typing-extensions==4.6.3 \
-    --hash=sha256:88a4153d8505aabbb4e13aacb7c486c2b4a33ca3b3f807914a9b4c844c471c26 \
-    --hash=sha256:d91d5919357fe7f681a9f2b5b4cb2a5f1ef0a1e9f59c4d8ff0d3491e05c0ffd5
-    # via
-    #   arrow
-    #   importlib-metadata
 urllib3==2.0.3 \
     --hash=sha256:48e7fafa40319d358848e1bc6809b208340fafe2096f1725d05d67443d0483d1 \
     --hash=sha256:bee28b5e56addb8226c96f7f13ac28cb4c301dd5ea8a6ca179c0b9835e032825
@@ -285,7 +275,3 @@ voluptuous==0.13.1 \
     --hash=sha256:4b838b185f5951f2d6e8752b68fcf18bd7a9c26ded8f143f92d6d28f3921a3e6 \
     --hash=sha256:e8d31c20601d6773cb14d4c0f42aee29c6821bbd1018039aac7ac5605b489723
     # via -r requirements/base.in
-zipp==3.15.0 \
-    --hash=sha256:112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b \
-    --hash=sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556
-    # via importlib-metadata

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -38,6 +38,10 @@ imagesize==1.4.1 \
     --hash=sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b \
     --hash=sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a
     # via sphinx
+importlib-metadata==6.8.0 \
+    --hash=sha256:3ebb78df84a805d7698245025b975d9d67053cd94c79245ba4b3eb694abe68bb \
+    --hash=sha256:dbace7892d8c0c4ac1ad096662232f831d4e64f4c4545bd53016a3e9d4654743
+    # via sphinx
 livereload==2.6.3 \
     --hash=sha256:776f2f865e59fde56490a56bcc6773b6917366bce0c267c60ee8aaf1a0959869 \
     --hash=sha256:ad4ac6f53b2d62bb6ce1a5e6e96f1f00976a32348afedcb4b6d68df2a1d346e4
@@ -133,3 +137,11 @@ tornado==6.2 \
     --hash=sha256:d3a2f5999215a3a06a4fc218026cd84c61b8b2b40ac5296a6db1f1451ef04c1e \
     --hash=sha256:e5f923aa6a47e133d1cf87d60700889d7eae68988704e20c75fb2d65677a8e4b
     # via livereload
+typing-extensions==4.8.0 \
+    --hash=sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0 \
+    --hash=sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef
+    # via pydata-sphinx-theme
+zipp==3.17.0 \
+    --hash=sha256:0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31 \
+    --hash=sha256:84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0
+    # via importlib-metadata

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",
         "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/taskcluster/ci/docker-image/kind.yml
+++ b/taskcluster/ci/docker-image/kind.yml
@@ -25,4 +25,4 @@ tasks:
     python:
         symbol: I(py)
         args:
-            PYENV_VERSIONS: "3.11, 3.10, 3.9, 3.8, 3.7"
+            PYENV_VERSIONS: "3.11, 3.10, 3.9, 3.8"

--- a/taskcluster/ci/tests/kind.yml
+++ b/taskcluster/ci/tests/kind.yml
@@ -50,7 +50,7 @@ tasks:
             command: >-
                 pip install --user -r requirements/test.txt --require-hashes &&
                 pip install --user --no-deps . &&
-                pyenv local 3.11 3.10 3.9 3.8 3.7 &&
+                pyenv local 3.11 3.10 3.9 3.8 &&
                 tox --parallel
     type-check:
         description: "Run type checking against src with Pyright"

--- a/test/test_util_docker.py
+++ b/test/test_util_docker.py
@@ -268,7 +268,7 @@ class TestDocker(unittest.TestCase):
             # file objects are BufferedRandom instances
             out_file = BufferedRandom(BytesIO(b""))
             h = docker.stream_context_tar(
-                tmp, d, out_file, "my_image", args={"PYTHON_VERSION": "3.7"}
+                tmp, d, out_file, "my_image", args={"PYTHON_VERSION": "3.8"}
             )
 
             self.assertEqual(

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
-envlist = clean,py{37,38,39,310,311},report
+envlist = clean,py{38,39,310,311},report
 
 [testenv]
 deps = -r{toxinidir}/requirements/test.txt
 parallel_show_output = true
 usedevelop = true
 depends =
-    py{37,38,39,310,311}: clean
-    report: py{37,38,39,310,311}
+    py{38,39,310,311}: clean
+    report: py{38,39,310,311}
 commands =
     python --version
     coverage run --context={envname} -p -m pytest -vv {posargs}


### PR DESCRIPTION
Python 3.7 is EOL and we are on the verge of dropping support for it in Gecko.