### PR TITLE
refactor!: rename 'job' transforms to 'run'

### DIFF
--- a/docs/concepts/kind.rst
+++ b/docs/concepts/kind.rst
@@ -30,9 +30,9 @@ look at a simple build kind example, you'll notice at the top the `loader` and
 `transforms` are defined. These point to standard taskgraph, but if you wanted
 to use a custom loader or transform it would be defined here pointing to
 `your_project_name_taskgraph` directory, eg
-`my_project_name_taskgraph.transforms.job`. If no loader is specified,
+`my_project_name_taskgraph.transforms.run`. If no loader is specified,
 `taskgraph.loader.default:loader` will be used, which will bring with it
-`taskgraph.transforms.job` and `taskgraph.transforms.task` as default
+`taskgraph.transforms.run` and `taskgraph.transforms.task` as default
 transforms.
 
 This can also be a clue of where to look if you are trying to understand what a

--- a/docs/concepts/loading.rst
+++ b/docs/concepts/loading.rst
@@ -46,7 +46,7 @@ The :mod:`Transform Loader<taskgraph.loader.transform>` is a barebones loader.
 
 The :mod:`Default Loader<taskgraph.loader.default>` does everything that the
 Transform Loader does, and additionally ensures that the
-:mod:`Job<taskgraph.transforms.job>` and :mod:`Task<taskgraph.transforms.task>`
+:mod:`Run <taskgraph.transforms.run>` and :mod:`Task<taskgraph.transforms.task>`
 transforms are used on every task it loads.
 
 Projects may optionally provide their own loaders that support different

--- a/docs/concepts/task-graphs.rst
+++ b/docs/concepts/task-graphs.rst
@@ -100,8 +100,8 @@ Transitive closure is a fancy name for this sort of operation:
  * add all tasks on which any of those tasks depend
  * repeat until nothing changes
 
-The effect is this: imagine you start with a linux32 test job and a linux64
-test job. In the first round, each test task depends on the test docker image
+The effect is this: imagine you start with a linux32 test task and a linux64
+test task. In the first round, each test task depends on the test docker image
 task, so add that image task. Each test also depends on a build, so add the
 linux32 and linux64 build tasks.
 
@@ -112,7 +112,7 @@ the set depend on a task not in the set, so nothing changes and the process is
 complete.
 
 And as you can see, the graph we've built now includes everything we wanted
-(the test jobs) plus everything required to do that (docker images, builds).
+(the test tasks) plus everything required to do that (docker images, builds).
 
 Dependencies
 ------------

--- a/docs/concepts/transforms.rst
+++ b/docs/concepts/transforms.rst
@@ -166,29 +166,29 @@ stages defined by schemas. The process begins with the raw data structures
 parsed from the YAML files in the kind configuration. This data can processed
 by kind-specific transforms resulting in a "kind specific description".
 
-From there, it's common for tasks to use the :mod:`job transforms
-<taskgraph.transforms.job>` which provide convenient utilities for things such
+From there, it's common for tasks to use the :mod:`run transforms
+<taskgraph.transforms.run>` which provide convenient utilities for things such
 as cloning repositories, downloading artifacts, caching and much more! After
-these transforms tasks will conform to the "job description".
+these transforms tasks will conform to the "run description".
 
 Finally almost all kinds should use the :mod:`task transforms
 <taskgraph.transforms.task>`. These transforms massage the task into the
 `Taskcluster task schema`_
 
-Job Descriptions
+Run Descriptions
 ................
 
-A job description defines what to run in the task. It is a combination of a
+A *run description* defines what to run in the task. It is a combination of a
 ``run`` section and all of the fields from a task description. The run section
 has a ``using`` property that defines how this task should be run; for example,
 ``run-task`` to run arbitrary commands, or ``toolchain-script`` to invoke a
 well defined script. The remainder of the run section is specific to the
 run-using implementation.
 
-The effect of a job description is to say "run this thing on this worker". The
-job description must contain enough information about the worker to identify
+The effect of a run description is to say "run this thing on this worker". The
+run description must contain enough information about the worker to identify
 the workerType and the implementation (docker-worker, generic-worker, etc.).
-Alternatively, job descriptions can specify the ``platforms`` field in
+Alternatively, run descriptions can specify the ``platforms`` field in
 conjunction with the ``by-platform`` key to specify multiple workerTypes and
 implementations. Any other task-description information is passed along
 verbatim, although it is augmented by the run-using implementation.

--- a/docs/howto/create-tasks.rst
+++ b/docs/howto/create-tasks.rst
@@ -67,7 +67,7 @@ to the ``tasks`` object:
 
    The format of the tasks depends heavily on which :term:`transforms
    <Transform>` the kind uses. In this example, Taskgraph is implicitly adding
-   the :mod:`~taskgraph.transforms.job` and :mod:`~taskgraph.transforms.task`
+   the :mod:`~taskgraph.transforms.run` and :mod:`~taskgraph.transforms.task`
    transforms. See :doc:`/concepts/transforms` for more information.
 
 Task Defaults

--- a/docs/howto/use-fetches.rst
+++ b/docs/howto/use-fetches.rst
@@ -15,7 +15,7 @@ in its payload.
 Using Fetches
 -------------
 
-Fetches are implemented as part of the :mod:`~taskgraph.transforms.job`
+Fetches are implemented as part of the :mod:`~taskgraph.transforms.run`
 transforms. So first make sure your task's ``kind.yml`` file is using those
 transforms:
 
@@ -24,7 +24,7 @@ transforms:
    loader: taskgraph.loader.transform:loader
 
    transforms:
-     - taskgraph.transforms.job:transforms
+     - taskgraph.transforms.run:transforms
 
 
 Now let's say we're creating a test task. We'll need to download and

--- a/docs/reference/migrations.rst
+++ b/docs/reference/migrations.rst
@@ -7,6 +7,8 @@ This page can help when migrating Taskgraph across major versions.
 ----------
 
 * Upgrade to Python 3.8 or higher
+* Replace references to `taskgraph.transforms.job` with `taskgraph.transforms.run`.
+* Rename the `run_job_using` decorator to `run_task_using`.
 
 5.x -> 6.x
 ----------

--- a/docs/reference/source/taskgraph.transforms.rst
+++ b/docs/reference/source/taskgraph.transforms.rst
@@ -7,7 +7,7 @@ Subpackages
 .. toctree::
    :maxdepth: 4
 
-   taskgraph.transforms.job
+   taskgraph.transforms.run
 
 Submodules
 ----------

--- a/docs/reference/source/taskgraph.transforms.run.rst
+++ b/docs/reference/source/taskgraph.transforms.run.rst
@@ -1,37 +1,37 @@
-taskgraph.transforms.job package
+taskgraph.transforms.run package
 ================================
 
 Submodules
 ----------
 
-taskgraph.transforms.job.common module
+taskgraph.transforms.run.common module
 --------------------------------------
 
-.. automodule:: taskgraph.transforms.job.common
+.. automodule:: taskgraph.transforms.run.common
    :members:
    :undoc-members:
    :show-inheritance:
 
-taskgraph.transforms.job.index\_search module
+taskgraph.transforms.run.index\_search module
 ---------------------------------------------
 
-.. automodule:: taskgraph.transforms.job.index_search
+.. automodule:: taskgraph.transforms.run.index_search
    :members:
    :undoc-members:
    :show-inheritance:
 
-taskgraph.transforms.job.run\_task module
+taskgraph.transforms.run.run\_task module
 -----------------------------------------
 
-.. automodule:: taskgraph.transforms.job.run_task
+.. automodule:: taskgraph.transforms.run.run_task
    :members:
    :undoc-members:
    :show-inheritance:
 
-taskgraph.transforms.job.toolchain module
+taskgraph.transforms.run.toolchain module
 -----------------------------------------
 
-.. automodule:: taskgraph.transforms.job.toolchain
+.. automodule:: taskgraph.transforms.run.toolchain
    :members:
    :undoc-members:
    :show-inheritance:
@@ -39,7 +39,7 @@ taskgraph.transforms.job.toolchain module
 Module contents
 ---------------
 
-.. automodule:: taskgraph.transforms.job
+.. automodule:: taskgraph.transforms.run
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/reference/transforms/from_deps.rst
+++ b/docs/reference/transforms/from_deps.rst
@@ -272,7 +272,7 @@ entry:
              - artifact: target.tar.gz
 
 The above block will add a ``fetches`` entry to the task that is compatible with ``taskgraph`` 's
-:mod:`~taskgraph.transforms.job` transforms.
+:mod:`~taskgraph.transforms.run` transforms.
 
 In some cases, artifact names may be different for different upstream tasks within the same kind.
 You can often handle this by setting an attribute in the upstream tasks, which ``from_deps`` can

--- a/docs/tutorials/creating-a-task-graph.rst
+++ b/docs/tutorials/creating-a-task-graph.rst
@@ -85,7 +85,7 @@ you have a ``hello`` kind. For this next section we'll be editing
 
 #. Declare the set of :term:`transforms <transform>` that will be applied
    to tasks. By default, taskgraph will include the
-   :mod:`-taskgraph.transforms.job` and :mod:`-taskgraph.transforms.tasks`
+   :mod:`-taskgraph.transforms.run` and :mod:`-taskgraph.transforms.task`
    transforms, which are used by the vast majority of simple tasks. It is also
    quite common for kind-specific transforms to be used, which we will do here
    for the purpose of demonstration. In our example:
@@ -99,7 +99,7 @@ you have a ``hello`` kind. For this next section we'll be editing
    initial definition here can vary wildly from one kind to another, it all
    depends on the transforms that are used. It's conventional for transforms to
    define a schema (but not required). So often you can look at the first
-   transform file to see what schema is expected of your job. But since we
+   transform file to see what schema is expected of your task. But since we
    haven't created the first transforms yet, let's define our task like this
    for now:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ exclude = [  # TODO fix errors in these files
     "src/taskgraph/run-task/robustcheckout.py",
     "src/taskgraph/transforms/fetch.py",
     "src/taskgraph/transforms/task.py",
-    "src/taskgraph/transforms/job/run_task.py",
+    "src/taskgraph/transforms/run/run_task.py",
     "src/taskgraph/util/cached_tasks.py",
     "src/taskgraph/util/decision.py",
     "src/taskgraph/util/python_path.py",

--- a/src/taskgraph/create.py
+++ b/src/taskgraph/create.py
@@ -104,7 +104,7 @@ def create_tasks(graph_config, taskgraph, label_to_taskid, params, decision_task
 
 def create_task(session, task_id, label, task_def):
     # create the task using 'http://taskcluster/queue', which is proxied to the queue service
-    # with credentials appropriate to this job.
+    # with credentials appropriate to this task.
 
     # Resolve timestamps
     now = current_json_time(datetime_format=True)

--- a/src/taskgraph/decision.py
+++ b/src/taskgraph/decision.py
@@ -46,21 +46,21 @@ try_task_config_schema_v2 = Schema(
 )
 
 
-def full_task_graph_to_runnable_jobs(full_task_json):
-    runnable_jobs = {}
+def full_task_graph_to_runnable_tasks(full_task_json):
+    runnable_tasks = {}
     for label, node in full_task_json.items():
         if not ("extra" in node["task"] and "treeherder" in node["task"]["extra"]):
             continue
 
         th = node["task"]["extra"]["treeherder"]
-        runnable_jobs[label] = {"symbol": th["symbol"]}
+        runnable_tasks[label] = {"symbol": th["symbol"]}
 
         for i in ("groupName", "groupSymbol", "collection"):
             if i in th:
-                runnable_jobs[label][i] = th[i]
+                runnable_tasks[label][i] = th[i]
         if th.get("machine", {}).get("platform"):
-            runnable_jobs[label]["platform"] = th["machine"]["platform"]
-    return runnable_jobs
+            runnable_tasks[label]["platform"] = th["machine"]["platform"]
+    return runnable_tasks
 
 
 def taskgraph_decision(options, parameters=None):
@@ -104,7 +104,7 @@ def taskgraph_decision(options, parameters=None):
 
     # write out the public/runnable-jobs.json file
     write_artifact(
-        "runnable-jobs.json", full_task_graph_to_runnable_jobs(full_task_json)
+        "runnable-jobs.json", full_task_graph_to_runnable_tasks(full_task_json)
     )
 
     # this is just a test to check whether the from_json() function is working

--- a/src/taskgraph/loader/default.py
+++ b/src/taskgraph/loader/default.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_TRANSFORMS = [
-    "taskgraph.transforms.job:transforms",
+    "taskgraph.transforms.run:transforms",
     "taskgraph.transforms.task:transforms",
 ]
 
@@ -20,7 +20,7 @@ def loader(kind, path, config, params, loaded_tasks):
     """
     This default loader builds on the `transform` loader by providing sensible
     default transforms that the majority of simple tasks will need.
-    Specifically, `job` and `task` transforms will be appended to the end of the
+    Specifically, `run` and `task` transforms will be appended to the end of the
     list of transforms in the kind being loaded.
     """
     transform_refs = config.setdefault("transforms", [])

--- a/src/taskgraph/transforms/base.py
+++ b/src/taskgraph/transforms/base.py
@@ -147,7 +147,7 @@ class ValidateSchema:
                     kind=config.kind, name=task["name"]
                 )
             elif "label" in task:
-                error = "In job {label!r}:".format(label=task["label"])
+                error = "In task {label!r}:".format(label=task["label"])
             elif "primary-dependency" in task:
                 error = "In {kind} kind task for {dependency!r}:".format(
                     kind=config.kind, dependency=task["primary-dependency"].label

--- a/src/taskgraph/transforms/code_review.py
+++ b/src/taskgraph/transforms/code_review.py
@@ -12,12 +12,12 @@ transforms = TransformSequence()
 
 
 @transforms.add
-def add_dependencies(config, jobs):
-    for job in jobs:
-        job.setdefault("soft-dependencies", [])
-        job["soft-dependencies"] += [
+def add_dependencies(config, tasks):
+    for task in tasks:
+        task.setdefault("soft-dependencies", [])
+        task["soft-dependencies"] += [
             dep_task.label
             for dep_task in config.kind_dependencies_tasks.values()
             if dep_task.attributes.get("code-review") is True
         ]
-        yield job
+        yield task

--- a/src/taskgraph/transforms/fetch.py
+++ b/src/taskgraph/transforms/fetch.py
@@ -35,8 +35,8 @@ FETCH_SCHEMA = Schema(
         Optional("docker-image"): object,
         Optional(
             "fetch-alias",
-            description="An alias that can be used instead of the real fetch job name in "
-            "fetch stanzas for jobs.",
+            description="An alias that can be used instead of the real fetch task name in "
+            "fetch stanzas for tasks.",
         ): str,
         Optional(
             "artifact-prefix",
@@ -78,20 +78,20 @@ transforms.add_validate(FETCH_SCHEMA)
 
 
 @transforms.add
-def process_fetch_job(config, jobs):
-    # Converts fetch-url entries to the job schema.
-    for job in jobs:
-        typ = job["fetch"]["type"]
-        name = job["name"]
-        fetch = job.pop("fetch")
+def process_fetch_task(config, tasks):
+    # Converts fetch-url entries to the run schema.
+    for task in tasks:
+        typ = task["fetch"]["type"]
+        name = task["name"]
+        fetch = task.pop("fetch")
 
         if typ not in fetch_builders:
             raise Exception(f"Unknown fetch type {typ} in fetch {name}")
         validate_schema(fetch_builders[typ].schema, fetch, f"In task.fetch {name!r}:")
 
-        job.update(configure_fetch(config, typ, name, fetch))
+        task.update(configure_fetch(config, typ, name, fetch))
 
-        yield job
+        yield task
 
 
 def configure_fetch(config, typ, name, fetch):
@@ -103,7 +103,7 @@ def configure_fetch(config, typ, name, fetch):
 
 
 @transforms.add
-def make_task(config, jobs):
+def make_task(config, tasks):
     # Fetch tasks are idempotent and immutable. Have them live for
     # essentially forever.
     if config.params["level"] == "3":
@@ -111,33 +111,33 @@ def make_task(config, jobs):
     else:
         expires = "28 days"
 
-    for job in jobs:
-        name = job["name"]
-        artifact_prefix = job.get("artifact-prefix", "public")
-        env = job.get("env", {})
+    for task in tasks:
+        name = task["name"]
+        artifact_prefix = task.get("artifact-prefix", "public")
+        env = task.get("env", {})
         env.update({"UPLOAD_DIR": "/builds/worker/artifacts"})
-        attributes = job.get("attributes", {})
-        attributes["fetch-artifact"] = path.join(artifact_prefix, job["artifact_name"])
-        alias = job.get("fetch-alias")
+        attributes = task.get("attributes", {})
+        attributes["fetch-artifact"] = path.join(artifact_prefix, task["artifact_name"])
+        alias = task.get("fetch-alias")
         if alias:
             attributes["fetch-alias"] = alias
 
-        task = {
+        task_desc = {
             "attributes": attributes,
             "name": name,
-            "description": job["description"],
+            "description": task["description"],
             "expires-after": expires,
             "label": "fetch-%s" % name,
             "run-on-projects": [],
             "run": {
                 "using": "run-task",
                 "checkout": False,
-                "command": job["command"],
+                "command": task["command"],
             },
             "worker-type": "images",
             "worker": {
                 "chain-of-trust": True,
-                "docker-image": job.get("docker-image", {"in-tree": "fetch"}),
+                "docker-image": task.get("docker-image", {"in-tree": "fetch"}),
                 "env": env,
                 "max-run-time": 900,
                 "artifacts": [
@@ -151,29 +151,29 @@ def make_task(config, jobs):
         }
 
         if "treeherder" in config.graph_config:
-            task["treeherder"] = {
+            task_desc["treeherder"] = {
                 "symbol": join_symbol("Fetch", name),
                 "kind": "build",
                 "platform": "fetch/opt",
                 "tier": 1,
             }
 
-        if job.get("secret", None):
-            task["scopes"] = ["secrets:get:" + job.get("secret")]
-            task["worker"]["taskcluster-proxy"] = True
+        if task.get("secret", None):
+            task_desc["scopes"] = ["secrets:get:" + task.get("secret")]
+            task_desc["worker"]["taskcluster-proxy"] = True
 
         if not taskgraph.fast:
-            cache_name = task["label"].replace(f"{config.kind}-", "", 1)
+            cache_name = task_desc["label"].replace(f"{config.kind}-", "", 1)
 
             # This adds the level to the index path automatically.
             add_optimization(
                 config,
-                task,
+                task_desc,
                 cache_type=CACHE_TYPE,
                 cache_name=cache_name,
-                digest_data=job["digest_data"],
+                digest_data=task["digest_data"],
             )
-        yield task
+        yield task_desc
 
 
 @fetch_builder(

--- a/src/taskgraph/transforms/from_deps.py
+++ b/src/taskgraph/transforms/from_deps.py
@@ -16,7 +16,7 @@ from textwrap import dedent
 from voluptuous import Any, Extra, Optional, Required
 
 from taskgraph.transforms.base import TransformSequence
-from taskgraph.transforms.job import fetches_schema
+from taskgraph.transforms.run import fetches_schema
 from taskgraph.util.attributes import attrmatch
 from taskgraph.util.dependencies import GROUP_BY_MAP, get_dependencies
 from taskgraph.util.schema import Schema, validate_schema

--- a/src/taskgraph/transforms/run/__init__.py
+++ b/src/taskgraph/transforms/run/__init__.py
@@ -2,11 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """
-Convert a job description into a task description.
+Convert a run description into a task description.
 
-Jobs descriptions are similar to task descriptions, but they specify how to run
-the job at a higher level, using a "run" field that can be interpreted by
-run-using handlers in `taskcluster/taskgraph/transforms/job`.
+Run descriptions are similar to task descriptions, but they specify how to run
+the task at a higher level, using a "run" field that can be interpreted by
+run-using handlers in `taskcluster/taskgraph/transforms/run`.
 """
 
 
@@ -28,7 +28,7 @@ from taskgraph.util.workertypes import worker_type_implementation
 logger = logging.getLogger(__name__)
 
 # Fetches may be accepted in other transforms and eventually passed along
-# to a `job` (eg: from_deps). Defining this here allows them to re-use
+# to a `task` (eg: from_deps). Defining this here allows them to re-use
 # the schema and avoid duplication.
 fetches_schema = {
     Required("artifact"): str,
@@ -38,9 +38,9 @@ fetches_schema = {
 }
 
 # Schema for a build description
-job_description_schema = Schema(
+run_description_schema = Schema(
     {
-        # The name of the job and the job's label.  At least one must be specified,
+        # The name of the task and the task's label.  At least one must be specified,
         # and the label will be generated from the name if necessary, by prepending
         # the kind.
         Optional("name"): str,
@@ -74,7 +74,7 @@ job_description_schema = Schema(
         Optional("needs-sccache"): task_description_schema["needs-sccache"],
         # The "when" section contains descriptions of the circumstances under which
         # this task should be included in the task graph.  This will be converted
-        # into an optimization, so it cannot be specified in a job description that
+        # into an optimization, so it cannot be specified in a run description that
         # also gives 'optimization'.
         Exclusive("when", "optimization"): {
             # This task only needs to be run if a file matching one of the given
@@ -90,33 +90,33 @@ job_description_schema = Schema(
                 fetches_schema,
             ],
         },
-        # A description of how to run this job.
+        # A description of how to run this task.
         "run": {
-            # The key to a job implementation in a peer module to this one
+            # The key to a run implementation in a peer module to this one
             "using": str,
             # Base work directory used to set up the task.
             Optional("workdir"): str,
-            # Any remaining content is verified against that job implementation's
+            # Any remaining content is verified against that run implementation's
             # own schema.
             Extra: object,
         },
         Required("worker-type"): task_description_schema["worker-type"],
         # This object will be passed through to the task description, with additions
-        # provided by the job's run-using function
+        # provided by the task's run-using function
         Optional("worker"): dict,
     }
 )
 
 transforms = TransformSequence()
-transforms.add_validate(job_description_schema)
+transforms.add_validate(run_description_schema)
 
 
 @transforms.add
-def rewrite_when_to_optimization(config, jobs):
-    for job in jobs:
-        when = job.pop("when", {})
+def rewrite_when_to_optimization(config, tasks):
+    for task in tasks:
+        when = task.pop("when", {})
         if not when:
-            yield job
+            yield task
             continue
 
         files_changed = when.get("files-changed")
@@ -125,63 +125,63 @@ def rewrite_when_to_optimization(config, jobs):
         files_changed.append(f"{config.path}/**")
 
         # "only when files changed" implies "skip if files have not changed"
-        job["optimization"] = {"skip-unless-changed": files_changed}
+        task["optimization"] = {"skip-unless-changed": files_changed}
 
-        assert "when" not in job
-        yield job
+        assert "when" not in task
+        yield task
 
 
 @transforms.add
-def set_implementation(config, jobs):
-    for job in jobs:
-        impl, os = worker_type_implementation(config.graph_config, job["worker-type"])
+def set_implementation(config, tasks):
+    for task in tasks:
+        impl, os = worker_type_implementation(config.graph_config, task["worker-type"])
         if os:
-            job.setdefault("tags", {})["os"] = os
+            task.setdefault("tags", {})["os"] = os
         if impl:
-            job.setdefault("tags", {})["worker-implementation"] = impl
-        worker = job.setdefault("worker", {})
+            task.setdefault("tags", {})["worker-implementation"] = impl
+        worker = task.setdefault("worker", {})
         assert "implementation" not in worker
         worker["implementation"] = impl
         if os:
             worker["os"] = os
-        yield job
+        yield task
 
 
 @transforms.add
-def set_label(config, jobs):
-    for job in jobs:
-        if "label" not in job:
-            if "name" not in job:
-                raise Exception("job has neither a name nor a label")
-            job["label"] = "{}-{}".format(config.kind, job["name"])
-        if job.get("name"):
-            del job["name"]
-        yield job
+def set_label(config, tasks):
+    for task in tasks:
+        if "label" not in task:
+            if "name" not in task:
+                raise Exception("task has neither a name nor a label")
+            task["label"] = "{}-{}".format(config.kind, task["name"])
+        if task.get("name"):
+            del task["name"]
+        yield task
 
 
 @transforms.add
-def add_resource_monitor(config, jobs):
-    for job in jobs:
-        if job.get("attributes", {}).get("resource-monitor"):
+def add_resource_monitor(config, tasks):
+    for task in tasks:
+        if task.get("attributes", {}).get("resource-monitor"):
             worker_implementation, worker_os = worker_type_implementation(
-                config.graph_config, job["worker-type"]
+                config.graph_config, task["worker-type"]
             )
             # Normalise worker os so that linux-bitbar and similar use linux tools.
             worker_os = worker_os.split("-")[0]
-            if "win7" in job["worker-type"]:
+            if "win7" in task["worker-type"]:
                 arch = "32"
             else:
                 arch = "64"
-            job.setdefault("fetches", {})
-            job["fetches"].setdefault("toolchain", [])
-            job["fetches"]["toolchain"].append(f"{worker_os}{arch}-resource-monitor")
+            task.setdefault("fetches", {})
+            task["fetches"].setdefault("toolchain", [])
+            task["fetches"]["toolchain"].append(f"{worker_os}{arch}-resource-monitor")
 
             if worker_implementation == "docker-worker":
                 artifact_source = "/builds/worker/monitoring/resource-monitor.json"
             else:
                 artifact_source = "monitoring/resource-monitor.json"
-            job["worker"].setdefault("artifacts", [])
-            job["worker"]["artifacts"].append(
+            task["worker"].setdefault("artifacts", [])
+            task["worker"]["artifacts"].append(
                 {
                     "name": "public/monitoring/resource-monitor.json",
                     "type": "file",
@@ -189,10 +189,10 @@ def add_resource_monitor(config, jobs):
                 }
             )
             # Set env for output file
-            job["worker"].setdefault("env", {})
-            job["worker"]["env"]["RESOURCE_MONITOR_OUTPUT"] = artifact_source
+            task["worker"].setdefault("env", {})
+            task["worker"]["env"]["RESOURCE_MONITOR_OUTPUT"] = artifact_source
 
-        yield job
+        yield task
 
 
 def get_attribute(dict, key, attributes, attribute_name):
@@ -204,16 +204,16 @@ def get_attribute(dict, key, attributes, attribute_name):
 
 
 @transforms.add
-def use_fetches(config, jobs):
+def use_fetches(config, tasks):
     artifact_names = {}
     aliases = {}
     extra_env = {}
 
     if config.kind in ("toolchain", "fetch"):
-        jobs = list(jobs)
-        for job in jobs:
-            run = job.get("run", {})
-            label = job["label"]
+        tasks = list(tasks)
+        for task in tasks:
+            run = task.get("run", {})
+            label = task["label"]
             get_attribute(artifact_names, label, run, "toolchain-artifact")
             value = run.get(f"{config.kind}-alias")
             if value:
@@ -233,20 +233,20 @@ def use_fetches(config, jobs):
                 aliases[f"{task.kind}-{value}"] = task.label
 
     artifact_prefixes = {}
-    for job in order_tasks(config, jobs):
-        artifact_prefixes[job["label"]] = get_artifact_prefix(job)
+    for task in order_tasks(config, tasks):
+        artifact_prefixes[task["label"]] = get_artifact_prefix(task)
 
-        fetches = job.pop("fetches", None)
+        fetches = task.pop("fetches", None)
         if not fetches:
-            yield job
+            yield task
             continue
 
-        job_fetches = []
-        name = job.get("name", job.get("label"))
-        dependencies = job.setdefault("dependencies", {})
-        worker = job.setdefault("worker", {})
+        task_fetches = []
+        name = task.get("name", task.get("label"))
+        dependencies = task.setdefault("dependencies", {})
+        worker = task.setdefault("worker", {})
         env = worker.setdefault("env", {})
-        prefix = get_artifact_prefix(job)
+        prefix = get_artifact_prefix(task)
         for kind in sorted(fetches):
             artifacts = fetches[kind]
             if kind in ("fetch", "toolchain"):
@@ -255,7 +255,7 @@ def use_fetches(config, jobs):
                     label = aliases.get(label, label)
                     if label not in artifact_names:
                         raise Exception(
-                            "Missing fetch job for {kind}-{name}: {fetch}".format(
+                            "Missing fetch task for {kind}-{name}: {fetch}".format(
                                 kind=config.kind, name=name, fetch=fetch_name
                             )
                         )
@@ -265,7 +265,7 @@ def use_fetches(config, jobs):
                     path = artifact_names[label]
 
                     dependencies[label] = label
-                    job_fetches.append(
+                    task_fetches.append(
                         {
                             "artifact": path,
                             "task": f"<{label}>",
@@ -329,41 +329,43 @@ def use_fetches(config, jobs):
                         fetch["dest"] = dest
                     if verify_hash:
                         fetch["verify-hash"] = verify_hash
-                    job_fetches.append(fetch)
+                    task_fetches.append(fetch)
 
-        job_artifact_prefixes = {
+        task_artifact_prefixes = {
             mozpath.dirname(fetch["artifact"])
-            for fetch in job_fetches
+            for fetch in task_fetches
             if not fetch["artifact"].startswith("public/")
         }
-        if job_artifact_prefixes:
+        if task_artifact_prefixes:
             # Use taskcluster-proxy and request appropriate scope.  For example, add
             # 'scopes: [queue:get-artifact:path/to/*]' for 'path/to/artifact.tar.xz'.
             worker["taskcluster-proxy"] = True
-            for prefix in sorted(job_artifact_prefixes):
+            for prefix in sorted(task_artifact_prefixes):
                 scope = f"queue:get-artifact:{prefix}/*"
-                if scope not in job.setdefault("scopes", []):
-                    job["scopes"].append(scope)
+                if scope not in task.setdefault("scopes", []):
+                    task["scopes"].append(scope)
 
-        env["MOZ_FETCHES"] = {"task-reference": json.dumps(job_fetches, sort_keys=True)}
+        env["MOZ_FETCHES"] = {
+            "task-reference": json.dumps(task_fetches, sort_keys=True)
+        }
 
         env.setdefault("MOZ_FETCHES_DIR", "fetches")
 
-        yield job
+        yield task
 
 
 @transforms.add
-def make_task_description(config, jobs):
+def make_task_description(config, tasks):
     """Given a build description, create a task description"""
-    # import plugin modules first, before iterating over jobs
+    # import plugin modules first, before iterating over tasks
     import_sibling_modules(exceptions=("common.py",))
 
-    for job in jobs:
+    for task in tasks:
         # always-optimized tasks never execute, so have no workdir
-        if job["worker"]["implementation"] in ("docker-worker", "generic-worker"):
-            job["run"].setdefault("workdir", "/builds/worker")
+        if task["worker"]["implementation"] in ("docker-worker", "generic-worker"):
+            task["run"].setdefault("workdir", "/builds/worker")
 
-        taskdesc = copy.deepcopy(job)
+        taskdesc = copy.deepcopy(task)
 
         # fill in some empty defaults to make run implementations easier
         taskdesc.setdefault("attributes", {})
@@ -373,27 +375,27 @@ def make_task_description(config, jobs):
         taskdesc.setdefault("scopes", [])
         taskdesc.setdefault("extra", {})
 
-        # give the function for job.run.using on this worker implementation a
+        # give the function for task.run.using on this worker implementation a
         # chance to set up the task description.
         configure_taskdesc_for_run(
-            config, job, taskdesc, job["worker"]["implementation"]
+            config, task, taskdesc, task["worker"]["implementation"]
         )
         del taskdesc["run"]
 
-        # yield only the task description, discarding the job description
+        # yield only the task description, discarding the task description
         yield taskdesc
 
 
-# A registry of all functions decorated with run_job_using
+# A registry of all functions decorated with run_task_using
 registry = {}
 
 
-def run_job_using(worker_implementation, run_using, schema=None, defaults={}):
+def run_task_using(worker_implementation, run_using, schema=None, defaults={}):
     """Register the decorated function as able to set up a task description for
-    jobs with the given worker implementation and `run.using` property.  If
-    `schema` is given, the job's run field will be verified to match it.
+    tasks with the given worker implementation and `run.using` property.  If
+    `schema` is given, the task's run field will be verified to match it.
 
-    The decorated function should have the signature `using_foo(config, job, taskdesc)`
+    The decorated function should have the signature `using_foo(config, task, taskdesc)`
     and should modify the task description in-place.  The skeleton of
     the task description is already set up, but without a payload."""
 
@@ -401,7 +403,7 @@ def run_job_using(worker_implementation, run_using, schema=None, defaults={}):
         for_run_using = registry.setdefault(run_using, {})
         if worker_implementation in for_run_using:
             raise Exception(
-                "run_job_using({!r}, {!r}) already exists: {!r}".format(
+                "run_task_using({!r}, {!r}) already exists: {!r}".format(
                     run_using,
                     worker_implementation,
                     for_run_using[worker_implementation],
@@ -413,22 +415,22 @@ def run_job_using(worker_implementation, run_using, schema=None, defaults={}):
     return wrap
 
 
-@run_job_using(
+@run_task_using(
     "always-optimized", "always-optimized", Schema({"using": "always-optimized"})
 )
-def always_optimized(config, job, taskdesc):
+def always_optimized(config, task, taskdesc):
     pass
 
 
-def configure_taskdesc_for_run(config, job, taskdesc, worker_implementation):
+def configure_taskdesc_for_run(config, task, taskdesc, worker_implementation):
     """
-    Run the appropriate function for this job against the given task
+    Run the appropriate function for this task against the given task
     description.
 
-    This will raise an appropriate error if no function exists, or if the job's
+    This will raise an appropriate error if no function exists, or if the task's
     run is not valid according to the schema.
     """
-    run_using = job["run"]["using"]
+    run_using = task["run"]["using"]
     if run_using not in registry:
         raise Exception(f"no functions for run.using {run_using!r}")
 
@@ -441,14 +443,14 @@ def configure_taskdesc_for_run(config, job, taskdesc, worker_implementation):
 
     func, schema, defaults = registry[run_using][worker_implementation]
     for k, v in defaults.items():
-        job["run"].setdefault(k, v)
+        task["run"].setdefault(k, v)
 
     if schema:
         validate_schema(
             schema,
-            job["run"],
-            "In job.run using {!r}/{!r} for job {!r}:".format(
-                job["run"]["using"], worker_implementation, job["label"]
+            task["run"],
+            "In task.run using {!r}/{!r} for task {!r}:".format(
+                task["run"]["using"], worker_implementation, task["label"]
             ),
         )
-    func(config, job, taskdesc)
+    func(config, task, taskdesc)

--- a/src/taskgraph/transforms/run/common.py
+++ b/src/taskgraph/transforms/run/common.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """
-Common support for various job types.  These functions are all named after the
+Common support for various task types.  These functions are all named after the
 worker implementation they operate on, and take the same three parameters, for
 consistency.
 """
@@ -21,21 +21,21 @@ def get_vcsdir_name(os):
         return "vcs"
 
 
-def add_cache(job, taskdesc, name, mount_point, skip_untrusted=False):
+def add_cache(task, taskdesc, name, mount_point, skip_untrusted=False):
     """Adds a cache based on the worker's implementation.
 
     Args:
-        job (dict): Task's job description.
+        task (dict): Tasks object.
         taskdesc (dict): Target task description to modify.
         name (str): Name of the cache.
         mount_point (path): Path on the host to mount the cache.
         skip_untrusted (bool): Whether cache is used in untrusted environments
             (default: False). Only applies to docker-worker.
     """
-    if not job["run"].get("use-caches", True):
+    if not task["run"].get("use-caches", True):
         return
 
-    worker = job["worker"]
+    worker = task["worker"]
 
     if worker["implementation"] == "docker-worker":
         taskdesc["worker"].setdefault("caches", []).append(
@@ -60,7 +60,7 @@ def add_cache(job, taskdesc, name, mount_point, skip_untrusted=False):
         pass
 
 
-def add_artifacts(config, job, taskdesc, path):
+def add_artifacts(config, task, taskdesc, path):
     taskdesc["worker"].setdefault("artifacts", []).append(
         {
             "name": get_artifact_prefix(taskdesc),
@@ -70,28 +70,28 @@ def add_artifacts(config, job, taskdesc, path):
     )
 
 
-def docker_worker_add_artifacts(config, job, taskdesc):
+def docker_worker_add_artifacts(config, task, taskdesc):
     """Adds an artifact directory to the task"""
-    path = "{workdir}/artifacts/".format(**job["run"])
+    path = "{workdir}/artifacts/".format(**task["run"])
     taskdesc["worker"]["env"]["UPLOAD_DIR"] = path
-    add_artifacts(config, job, taskdesc, path)
+    add_artifacts(config, task, taskdesc, path)
 
 
-def generic_worker_add_artifacts(config, job, taskdesc):
+def generic_worker_add_artifacts(config, task, taskdesc):
     """Adds an artifact directory to the task"""
     # The path is the location on disk; it doesn't necessarily
     # mean the artifacts will be public or private; that is set via the name
     # attribute in add_artifacts.
-    add_artifacts(config, job, taskdesc, path=get_artifact_prefix(taskdesc))
+    add_artifacts(config, task, taskdesc, path=get_artifact_prefix(taskdesc))
 
 
-def support_vcs_checkout(config, job, taskdesc, repo_configs, sparse=False):
-    """Update a job/task with parameters to enable a VCS checkout.
+def support_vcs_checkout(config, task, taskdesc, repo_configs, sparse=False):
+    """Update a task with parameters to enable a VCS checkout.
 
     This can only be used with ``run-task`` tasks, as the cache name is
     reserved for ``run-task`` tasks.
     """
-    worker = job["worker"]
+    worker = task["worker"]
     is_mac = worker["os"] == "macosx"
     is_win = worker["os"] == "windows"
     is_linux = worker["os"] == "linux"
@@ -102,7 +102,7 @@ def support_vcs_checkout(config, job, taskdesc, repo_configs, sparse=False):
         checkoutdir = "./build"
         hgstore = "y:/hg-shared"
     elif is_docker:
-        checkoutdir = "{workdir}/checkouts".format(**job["run"])
+        checkoutdir = "{workdir}/checkouts".format(**task["run"])
         hgstore = f"{checkoutdir}/hg-store"
     else:
         checkoutdir = "./checkouts"
@@ -130,7 +130,7 @@ def support_vcs_checkout(config, job, taskdesc, repo_configs, sparse=False):
     if sparse:
         cache_name += "-sparse"
 
-    add_cache(job, taskdesc, cache_name, checkoutdir)
+    add_cache(task, taskdesc, cache_name, checkoutdir)
 
     env = taskdesc["worker"].setdefault("env", {})
     env.update(
@@ -161,5 +161,5 @@ def support_vcs_checkout(config, job, taskdesc, repo_configs, sparse=False):
             taskdesc["scopes"].append(f"secrets:get:{repo_config.ssh_secret_name}")
 
     # only some worker platforms have taskcluster-proxy enabled
-    if job["worker"]["implementation"] in ("docker-worker",):
+    if task["worker"]["implementation"] in ("docker-worker",):
         taskdesc["worker"]["taskcluster-proxy"] = True

--- a/src/taskgraph/transforms/run/index_search.py
+++ b/src/taskgraph/transforms/run/index_search.py
@@ -12,7 +12,7 @@ phase will replace the task with the task from the other graph.
 from voluptuous import Required
 
 from taskgraph.transforms.base import TransformSequence
-from taskgraph.transforms.job import run_job_using
+from taskgraph.transforms.run import run_task_using
 from taskgraph.util.schema import Schema
 
 transforms = TransformSequence()
@@ -29,9 +29,9 @@ run_task_schema = Schema(
 )
 
 
-@run_job_using("always-optimized", "index-search", schema=run_task_schema)
-def fill_template(config, job, taskdesc):
-    run = job["run"]
+@run_task_using("always-optimized", "index-search", schema=run_task_schema)
+def fill_template(config, task, taskdesc):
+    run = task["run"]
     taskdesc["optimization"] = {
         "index-search": [index.format(**config.params) for index in run["index-search"]]
     }

--- a/src/taskgraph/transforms/run/toolchain.py
+++ b/src/taskgraph/transforms/run/toolchain.py
@@ -2,14 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """
-Support for running toolchain-building jobs via dedicated scripts
+Support for running toolchain-building tasks via dedicated scripts
 """
 
 from voluptuous import ALLOW_EXTRA, Any, Optional, Required
 
 import taskgraph
-from taskgraph.transforms.job import configure_taskdesc_for_run, run_job_using
-from taskgraph.transforms.job.common import (
+from taskgraph.transforms.run import configure_taskdesc_for_run, run_task_using
+from taskgraph.transforms.run.common import (
     docker_worker_add_artifacts,
     generic_worker_add_artifacts,
     get_vcsdir_name,
@@ -36,12 +36,12 @@ toolchain_run_schema = Schema(
         # Paths/patterns pointing to files that influence the outcome of a
         # toolchain build.
         Optional("resources"): [str],
-        # Path to the artifact produced by the toolchain job
+        # Path to the artifact produced by the toolchain task
         Required("toolchain-artifact"): str,
         Optional(
             "toolchain-alias",
-            description="An alias that can be used instead of the real toolchain job name in "
-            "fetch stanzas for jobs.",
+            description="An alias that can be used instead of the real toolchain task name in "
+            "fetch stanzas for tasks.",
         ): Any(str, [str]),
         Optional(
             "toolchain-env",
@@ -82,10 +82,10 @@ def get_digest_data(config, run, taskdesc):
     return data
 
 
-def common_toolchain(config, job, taskdesc, is_docker):
-    run = job["run"]
+def common_toolchain(config, task, taskdesc, is_docker):
+    run = task["run"]
 
-    worker = taskdesc["worker"] = job["worker"]
+    worker = taskdesc["worker"] = task["worker"]
     worker["chain-of-trust"] = True
 
     srcdir = get_vcsdir_name(worker["os"])
@@ -94,14 +94,14 @@ def common_toolchain(config, job, taskdesc, is_docker):
         # If the task doesn't have a docker-image, set a default
         worker.setdefault("docker-image", {"in-tree": "toolchain-build"})
 
-    # Allow the job to specify where artifacts come from, but add
+    # Allow the task to specify where artifacts come from, but add
     # public/build if it's not there already.
     artifacts = worker.setdefault("artifacts", [])
     if not any(artifact.get("name") == "public/build" for artifact in artifacts):
         if is_docker:
-            docker_worker_add_artifacts(config, job, taskdesc)
+            docker_worker_add_artifacts(config, task, taskdesc)
         else:
-            generic_worker_add_artifacts(config, job, taskdesc)
+            generic_worker_add_artifacts(config, task, taskdesc)
 
     env = worker["env"]
     env.update(
@@ -147,7 +147,7 @@ def common_toolchain(config, job, taskdesc, is_docker):
 
     run["command"] = command
 
-    configure_taskdesc_for_run(config, job, taskdesc, worker["implementation"])
+    configure_taskdesc_for_run(config, task, taskdesc, worker["implementation"])
 
 
 toolchain_defaults = {
@@ -155,21 +155,21 @@ toolchain_defaults = {
 }
 
 
-@run_job_using(
+@run_task_using(
     "docker-worker",
     "toolchain-script",
     schema=toolchain_run_schema,
     defaults=toolchain_defaults,
 )
-def docker_worker_toolchain(config, job, taskdesc):
-    common_toolchain(config, job, taskdesc, is_docker=True)
+def docker_worker_toolchain(config, task, taskdesc):
+    common_toolchain(config, task, taskdesc, is_docker=True)
 
 
-@run_job_using(
+@run_task_using(
     "generic-worker",
     "toolchain-script",
     schema=toolchain_run_schema,
     defaults=toolchain_defaults,
 )
-def generic_worker_toolchain(config, job, taskdesc):
-    common_toolchain(config, job, taskdesc, is_docker=False)
+def generic_worker_toolchain(config, task, taskdesc):
+    common_toolchain(config, task, taskdesc, is_docker=False)

--- a/src/taskgraph/transforms/task.py
+++ b/src/taskgraph/transforms/task.py
@@ -110,7 +110,7 @@ task_description_schema = Schema(
                 # section of the kind (delimited by "-") all smooshed together.
                 # Eg: "test" becomes "T", "docker-image" becomes "DI", etc.
                 "symbol": Optional(str),
-                # the job kind
+                # the task kind
                 # If "build" or "test" is found in the kind name, this defaults
                 # to the appropriate value. Otherwise, defaults to "other"
                 "kind": Optional(Any("build", "test", "other")),
@@ -129,7 +129,7 @@ task_description_schema = Schema(
         Optional("index"): {
             # the name of the product this build produces
             "product": str,
-            # the names to use for this job in the TaskCluster index
+            # the names to use for this task in the TaskCluster index
             "job-name": str,
             # Type of gecko v2 index to use
             "type": str,
@@ -179,7 +179,7 @@ task_description_schema = Schema(
         # be substituted in this string:
         #  {level} -- the scm level of this push
         "worker-type": str,
-        # Whether the job should use sccache compiler caching.
+        # Whether the task should use sccache compiler caching.
         Required("needs-sccache"): bool,
         # information specific to the worker implementation that will run this task
         Optional("worker"): {
@@ -756,7 +756,7 @@ def build_generic_worker_payload(config, task, task_def):
     schema={
         # the maximum time to run, in seconds
         Required("max-run-time"): int,
-        # locale key, if this is a locale beetmover job
+        # locale key, if this is a locale beetmover task
         Optional("locale"): str,
         Optional("partner-public"): bool,
         Required("release-properties"): {
@@ -1292,7 +1292,7 @@ def check_caches_are_volumes(task):
 
     Caches and volumes are the only filesystem locations whose content
     isn't defined by the Docker image itself. Some caches are optional
-    depending on the job environment. We want paths that are potentially
+    depending on the task environment. We want paths that are potentially
     caches to have as similar behavior regardless of whether a cache is
     used. To help enforce this, we require that all paths used as caches
     to be declared as Docker volumes. This check won't catch all offenders.

--- a/src/taskgraph/transforms/task_context.py
+++ b/src/taskgraph/transforms/task_context.py
@@ -81,9 +81,9 @@ transforms.add_validate(SCHEMA)
 
 
 @transforms.add
-def render_task(config, jobs):
-    for job in jobs:
-        sub_config = job.pop("task-context")
+def render_task(config, tasks):
+    for task in tasks:
+        sub_config = task.pop("task-context")
         params_context = {}
         for var, path in sub_config.pop("from-parameters", {}).items():
             if isinstance(path, str):
@@ -111,11 +111,11 @@ def render_task(config, jobs):
 
         # Now that we have our combined context, we can substitute.
         for field in fields:
-            container, subfield = job, field
+            container, subfield = task, field
             while "." in subfield:
                 f, subfield = subfield.split(".", 1)
                 container = container[f]
 
             container[subfield] = substitute(container[subfield], **subs)
 
-        yield job
+        yield task

--- a/src/taskgraph/util/schema.py
+++ b/src/taskgraph/util/schema.py
@@ -74,7 +74,7 @@ def resolve_keyed_by(
 
     For example, given item::
 
-        job:
+        task:
             test-platform: linux128
             chunks:
                 by-test-platform:
@@ -82,10 +82,10 @@ def resolve_keyed_by(
                     win.*: 6
                     default: 12
 
-    a call to `resolve_keyed_by(item, 'job.chunks', item['thing-name'])`
+    a call to `resolve_keyed_by(item, 'task.chunks', item['thing-name'])`
     would mutate item in-place to::
 
-        job:
+        task:
             test-platform: linux128
             chunks: 12
 

--- a/src/taskgraph/util/treeherder.py
+++ b/src/taskgraph/util/treeherder.py
@@ -42,22 +42,25 @@ def replace_group(treeherder_symbol, new_group):
     return join_symbol(new_group, symbol)
 
 
-def inherit_treeherder_from_dep(job, dep_job):
-    """Inherit treeherder defaults from dep_job"""
-    treeherder = job.get("treeherder", {})
+def inherit_treeherder_from_dep(task, dep_task):
+    """Inherit treeherder defaults from dep_task"""
+    treeherder = task.get("treeherder", {})
 
     dep_th_platform = (
-        dep_job.task.get("extra", {})
+        dep_task.task.get("extra", {})
         .get("treeherder", {})
         .get("machine", {})
         .get("platform", "")
     )
     dep_th_collection = list(
-        dep_job.task.get("extra", {}).get("treeherder", {}).get("collection", {}).keys()
+        dep_task.task.get("extra", {})
+        .get("treeherder", {})
+        .get("collection", {})
+        .keys()
     )[0]
     treeherder.setdefault("platform", f"{dep_th_platform}/{dep_th_collection}")
     treeherder.setdefault(
-        "tier", dep_job.task.get("extra", {}).get("treeherder", {}).get("tier", 1)
+        "tier", dep_task.task.get("extra", {}).get("treeherder", {}).get("tier", 1)
     )
     # Does not set symbol
     treeherder.setdefault("kind", "build")

--- a/taskcluster/ci/codecov/kind.yml
+++ b/taskcluster/ci/codecov/kind.yml
@@ -5,7 +5,7 @@
 loader: taskgraph.loader.transform:loader
 
 transforms:
-    - taskgraph.transforms.job:transforms
+    - taskgraph.transforms.run:transforms
     - taskgraph.transforms.task:transforms
 
 kind-dependencies:

--- a/taskcluster/ci/doc/kind.yml
+++ b/taskcluster/ci/doc/kind.yml
@@ -6,7 +6,7 @@
 loader: taskgraph.loader.transform:loader
 
 transforms:
-    - taskgraph.transforms.job:transforms
+    - taskgraph.transforms.run:transforms
     - taskgraph.transforms.task:transforms
 
 task-defaults:

--- a/taskcluster/ci/fetch/kind.yml
+++ b/taskcluster/ci/fetch/kind.yml
@@ -6,7 +6,7 @@ loader: taskgraph.loader.transform:loader
 
 transforms:
     - taskgraph.transforms.fetch:transforms
-    - taskgraph.transforms.job:transforms
+    - taskgraph.transforms.run:transforms
     - taskgraph.transforms.task:transforms
 
 tasks:

--- a/taskcluster/ci/tests/kind.yml
+++ b/taskcluster/ci/tests/kind.yml
@@ -6,7 +6,7 @@
 loader: taskgraph.loader.transform:loader
 
 transforms:
-    - taskgraph.transforms.job:transforms
+    - taskgraph.transforms.run:transforms
     - taskgraph.transforms.task:transforms
 
 task-defaults:

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -182,7 +182,7 @@ def test_load_tasks_for_kind(monkeypatch):
         pytest.param(
             {},
             [
-                "taskgraph.transforms.job:transforms",
+                "taskgraph.transforms.run:transforms",
                 "taskgraph.transforms.task:transforms",
             ],
             id="no_transforms",
@@ -191,7 +191,7 @@ def test_load_tasks_for_kind(monkeypatch):
             {"transforms": ["taskgraph.transforms.notify:transforms"]},
             [
                 "taskgraph.transforms.notify:transforms",
-                "taskgraph.transforms.job:transforms",
+                "taskgraph.transforms.run:transforms",
                 "taskgraph.transforms.task:transforms",
             ],
             id="additional_transform_specified",
@@ -214,15 +214,15 @@ def test_default_loader(config, expected_transforms):
         pytest.param(
             {
                 "transforms": [
-                    "taskgraph.transforms.job:transforms",
+                    "taskgraph.transforms.run:transforms",
                     "taskgraph.transforms.task:transforms",
                 ]
             },
-            id="job_and_task_transforms_specified",
+            id="run_and_task_transforms_specified",
         ),
         pytest.param(
-            {"transforms": ["taskgraph.transforms.job:transforms"]},
-            id="only_job_transform_specified",
+            {"transforms": ["taskgraph.transforms.run:transforms"]},
+            id="only_run_transform_specified",
         ),
         pytest.param(
             {"transforms": ["taskgraph.transforms.task:transforms"]},

--- a/test/test_transforms_run.py
+++ b/test/test_transforms_run.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
-Tests for the 'job' transform subsystem.
+Tests for the 'run' transform subsystem.
 """
 
 import os
@@ -15,9 +15,9 @@ import pytest
 
 # prevent pytest thinking this is a test
 from taskgraph.task import Task
-from taskgraph.transforms import job
-from taskgraph.transforms.job import run_task  # noqa: F401
-from taskgraph.transforms.job.common import add_cache
+from taskgraph.transforms import run
+from taskgraph.transforms.run import run_task  # noqa: F401
+from taskgraph.transforms.run.common import add_cache
 from taskgraph.transforms.task import payload_builders
 from taskgraph.util.schema import Schema, validate_schema
 from taskgraph.util.templates import merge
@@ -36,7 +36,7 @@ TASK_DEFAULTS = {
 
 @pytest.fixture
 def transform(monkeypatch, run_transform):
-    """Run the job transforms on the specified task but return the inputs to
+    """Run the run transforms on the specified task but return the inputs to
     `configure_taskdesc_for_run` without executing it.
 
     This gives test functions an easy way to generate the inputs required for
@@ -49,9 +49,9 @@ def transform(monkeypatch, run_transform):
         task = deepcopy(TASK_DEFAULTS)
         task.update(task_input)
 
-        with patch("taskgraph.transforms.job.configure_taskdesc_for_run") as m:
+        with patch("taskgraph.transforms.run.configure_taskdesc_for_run") as m:
             # This forces the generator to be evaluated
-            run_transform(job.transforms, task)
+            run_transform(run.transforms, task)
             return m.call_args[0]
 
     return inner
@@ -69,9 +69,9 @@ def transform(monkeypatch, run_transform):
     ids=["docker-worker", "generic-worker"],
 )
 def test_worker_caches(task, transform):
-    config, job, taskdesc, impl = transform(task)
-    add_cache(job, taskdesc, "cache1", "/cache1")
-    add_cache(job, taskdesc, "cache2", "/cache2", skip_untrusted=True)
+    config, task, taskdesc, impl = transform(task)
+    add_cache(task, taskdesc, "cache1", "/cache1")
+    add_cache(task, taskdesc, "cache2", "/cache2", skip_untrusted=True)
 
     if impl not in ("docker-worker", "generic-worker"):
         pytest.xfail(f"caches not implemented for '{impl}'")
@@ -120,7 +120,7 @@ def test_use_fetches(
         kind_dependencies_tasks={t.label: t for t in kind_dependencies_tasks}
     )
     task = merge(TASK_DEFAULTS, task)
-    result = run_transform(job.use_fetches, task, config=transform_config)[0]
+    result = run_transform(run.use_fetches, task, config=transform_config)[0]
     pprint(result)
 
     param_id = request.node.callspec.id

--- a/test/test_transforms_run_run_task.py
+++ b/test/test_transforms_run_run_task.py
@@ -6,7 +6,7 @@ from pprint import pprint
 
 import pytest
 
-from taskgraph.transforms.job import make_task_description
+from taskgraph.transforms.run import make_task_description
 from taskgraph.util.templates import merge
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -25,7 +25,7 @@ TASK_DEFAULTS = {
 
 
 @pytest.fixture
-def run_job_using(mocker, run_transform):
+def run_task_using(mocker, run_transform):
     m = mocker.patch("taskgraph.util.hash._get_all_files")
     m.return_value = [
         "taskcluster/scripts/toolchain/run.sh",
@@ -209,8 +209,8 @@ def assert_run_task_command_generic_worker(task):
         ),
     ),
 )
-def test_run_task(request, run_job_using, task):
-    taskdesc = run_job_using(task)
+def test_run_task(request, run_task_using, task):
+    taskdesc = run_task_using(task)
     print("Task Description:")
     pprint(taskdesc)
     param_id = request.node.callspec.id


### PR DESCRIPTION
BREAKING CHANGE: `taskgraph.transforms.job` moved to `taskgraph.transforms.run`