### PR TITLE
refactor!: change 'root_dir' to point to main 'taskcluster' directory

### DIFF
--- a/src/taskgraph/config.py
+++ b/src/taskgraph/config.py
@@ -102,28 +102,27 @@ class GraphConfig:
         Add the project's taskgraph directory to the python path, and register
         any extensions present.
         """
-        modify_path = os.path.dirname(self.root_dir)
         if GraphConfig._PATH_MODIFIED:
-            if GraphConfig._PATH_MODIFIED == modify_path:
+            if GraphConfig._PATH_MODIFIED == self.root_dir:
                 # Already modified path with the same root_dir.
                 # We currently need to do this to enable actions to call
                 # taskgraph_decision, e.g. relpro.
                 return
             raise Exception("Can't register multiple directories on python path.")
-        GraphConfig._PATH_MODIFIED = modify_path
-        sys.path.insert(0, modify_path)
+        GraphConfig._PATH_MODIFIED = self.root_dir
+        sys.path.insert(0, self.root_dir)
         register_path = self["taskgraph"].get("register")
         if register_path:
             find_object(register_path)(self)
 
     @property
     def vcs_root(self):
-        if path.split(self.root_dir)[-2:] != ["taskcluster", "kinds"]:
+        if path.split(self.root_dir)[-1:] != ["taskcluster"]:
             raise Exception(
                 "Not guessing path to vcs root. "
                 "Graph config in non-standard location."
             )
-        return os.path.dirname(os.path.dirname(self.root_dir))
+        return os.path.dirname(self.root_dir)
 
     @property
     def taskcluster_yml(self):
@@ -135,8 +134,7 @@ def validate_graph_config(config):
 
 
 def load_graph_config(root_dir):
-    config_dir = path.dirname(root_dir)
-    config_yml = os.path.join(config_dir, "config.yml")
+    config_yml = os.path.join(root_dir, "config.yml")
     if not os.path.exists(config_yml):
         raise Exception(f"Couldn't find taskgraph configuration: {config_yml}")
 

--- a/src/taskgraph/generator.py
+++ b/src/taskgraph/generator.py
@@ -91,7 +91,7 @@ class Kind:
 
     @classmethod
     def load(cls, root_dir, graph_config, kind_name):
-        path = os.path.join(root_dir, kind_name)
+        path = os.path.join(root_dir, "kinds", kind_name)
         kind_yml = os.path.join(path, "kind.yml")
         if not os.path.exists(kind_yml):
             raise KindNotFound(kind_yml)
@@ -125,13 +125,13 @@ class TaskGraphGenerator:
         write_artifacts=False,
     ):
         """
-        @param root_dir: root directory, with subdirectories for each kind
+        @param root_dir: root directory containing the Taskgraph config.yml file
         @param parameters: parameters for this task-graph generation, or callable
             taking a `GraphConfig` and returning parameters
         @type parameters: Union[Parameters, Callable[[GraphConfig], Parameters]]
         """
         if root_dir is None:
-            root_dir = "taskcluster/kinds"
+            root_dir = "taskcluster"
         self.root_dir = root_dir
         self._parameters = parameters
         self._decision_task_id = decision_task_id
@@ -243,7 +243,7 @@ class TaskGraphGenerator:
                 yield kind
                 queue.extend(kind.config.get("kind-dependencies", []))
         else:
-            for kind_name in os.listdir(self.root_dir):
+            for kind_name in os.listdir(os.path.join(self.root_dir, "kinds")):
                 try:
                     yield Kind.load(self.root_dir, graph_config, kind_name)
                 except KindNotFound:

--- a/test/fixtures/gen.py
+++ b/test/fixtures/gen.py
@@ -103,7 +103,7 @@ def fake_load_graph_config(root_dir):
 
 @pytest.fixture
 def graph_config(datadir):
-    return fake_load_graph_config(str(datadir / "taskcluster" / "kinds"))
+    return fake_load_graph_config(str(datadir / "taskcluster"))
 
 
 class FakeParameters(dict):

--- a/test/test_morph.py
+++ b/test/test_morph.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-import os
-
 import pytest
 
 from taskgraph import morph
@@ -17,7 +15,7 @@ from taskgraph.taskgraph import TaskGraph
 
 @pytest.fixture(scope="module")
 def graph_config():
-    return load_graph_config(os.path.join("taskcluster", "kinds"))
+    return load_graph_config("taskcluster")
 
 
 @pytest.fixture


### PR DESCRIPTION
BREAKING CHANGE: root dir should now point to the 'taskcluster' dir rather than 'taskcluster/kinds'.

This only impacts projects that use `taskgraph.config.load_graph_config` or `taskgraph.generator.TaskGraphGenerator` directly.