### PR TITLE
docs: remove explicit directory from the Pytest run

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -29,7 +29,7 @@ Tests are run with the `pytest`_ framework:
 
 .. code-block::
 
-  pytest src
+  pytest
 
 We use `tox`_ to run tests across multiple versions of Python.
 


### PR DESCRIPTION
This turned the operation into a no-op, a plain `pytest` call finds the tests just fine.