### PR TITLE
fix(init): strip '.git' out of repo_url if it exists

### DIFF
--- a/src/taskgraph/main.py
+++ b/src/taskgraph/main.py
@@ -862,6 +862,8 @@ def init_taskgraph(options):
         return 1
 
     context["repo_name"] = urlparse(repo_url).path.rsplit("/", 1)[-1]
+    if context["repo_name"].endswith(".git"):
+        context["repo_name"] = context["repo_name"][:-len(".git")]
 
     # Generate the project.
     cookiecutter(

--- a/src/taskgraph/main.py
+++ b/src/taskgraph/main.py
@@ -863,7 +863,7 @@ def init_taskgraph(options):
 
     context["repo_name"] = urlparse(repo_url).path.rsplit("/", 1)[-1]
     if context["repo_name"].endswith(".git"):
-        context["repo_name"] = context["repo_name"][:-len(".git")]
+        context["repo_name"] = context["repo_name"][: -len(".git")]
 
     # Generate the project.
     cookiecutter(

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -205,7 +205,7 @@ def test_init_taskgraph(mocker, tmp_path, project_root, repo_with_upstream):
         fake_url = f"https://hg.mozilla.org/foo/{name}"
         mocker.patch.object(HgRepository, "get_url").return_value = fake_url
     else:
-        fake_url = f"https://github.com/foo/{name}"
+        fake_url = f"https://github.com/foo/{name}.git"
         mocker.patch.object(GitRepository, "get_url").return_value = fake_url
 
     # Point cookiecutter at temporary directories.


### PR DESCRIPTION
This was causing directories like `my_repo.git_taskgraph` to be created.