### PR TITLE
Add cache-pull-requests config option to disable caching of tasks on …

### DIFF
--- a/src/taskgraph/config.py
+++ b/src/taskgraph/config.py
@@ -67,6 +67,10 @@ graph_config_schema = Schema(
                 "Defaults to `trust-domain`.",
             ): str,
             Optional(
+                "cache-pull-requests",
+                description="Should tasks from pull requests populate the cache",
+            ): bool,
+            Optional(
                 "index-path-regexes",
                 description="Regular expressions matching index paths to be summarized.",
             ): [str],

--- a/src/taskgraph/util/cached_tasks.py
+++ b/src/taskgraph/util/cached_tasks.py
@@ -65,7 +65,9 @@ def add_optimization(
     # Pull requests use a different target cache index route. This way we can
     # be confident they won't be used by anything other than the pull request
     # that created the cache in the first place.
-    if config.params["tasks_for"].startswith("github-pull-request"):
+    if config.params["tasks_for"].startswith(
+        "github-pull-request"
+    ) and config.graph_config["taskgraph"].get("cache-pull-requests", True):
         subs["head_ref"] = config.params["head_ref"]
         if subs["head_ref"].startswith("refs/heads/"):
             subs["head_ref"] = subs["head_ref"][11:]
@@ -77,9 +79,10 @@ def add_optimization(
     subs["level"] = config.params["level"]
 
     if config.params["tasks_for"].startswith("github-pull-request"):
-        taskdesc.setdefault("routes", []).append(
-            f"index.{TARGET_PR_CACHE_INDEX.format(**subs)}"
-        )
+        if config.graph_config["taskgraph"].get("cache-pull-requests", True):
+            taskdesc.setdefault("routes", []).append(
+                f"index.{TARGET_PR_CACHE_INDEX.format(**subs)}"
+            )
     else:
         taskdesc.setdefault("routes", []).append(
             f"index.{TARGET_CACHE_INDEX.format(**subs)}"

--- a/test/test_util_cached_tasks.py
+++ b/test/test_util_cached_tasks.py
@@ -93,6 +93,22 @@ def assert_pull_request(task):
     }
 
 
+def assert_pull_request_nocache(task):
+    handle_exception(task)
+    assert task == {
+        "attributes": {
+            "cached_task": {"digest": "abc", "name": "cache-name", "type": "cache-type"}
+        },
+        "optimization": {
+            "index-search": [
+                "test-domain.cache.level-3.cache-type.cache-name.hash.abc",
+                "test-domain.cache.level-2.cache-type.cache-name.hash.abc",
+                "test-domain.cache.level-1.cache-type.cache-name.hash.abc",
+            ]
+        },
+    }
+
+
 @pytest.mark.parametrize(
     "extra_params,extra_graph_config,digest,digest_data",
     (
@@ -150,6 +166,17 @@ def assert_pull_request(task):
             # digest_data
             None,
             id="pull_request",
+        ),
+        pytest.param(
+            # extra_params
+            {"tasks_for": "github-pull-request"},
+            # extra_graph_config
+            {"taskgraph": {"cache-pull-requests": False}},
+            # digest
+            "abc",
+            # digest_data
+            None,
+            id="pull_request_nocache",
         ),
     ),
 )


### PR DESCRIPTION
…pull requests

Caching tasks from pull requests currently breaks chain-of-trust, because it can't rebuild task definitions from earlier pushes.  This provides an escape hatch for projects which need this.