### PR TITLE
Call raise_for_status on hg.mozilla.org json-automationrelevance response

### DIFF
--- a/src/taskgraph/files_changed.py
+++ b/src/taskgraph/files_changed.py
@@ -49,6 +49,7 @@ def _get_changed_files_json_automationrelevance(head_repository_url, head_rev):
 
     def get_automationrelevance():
         response = requests.get(url, timeout=30)
+        response.raise_for_status()
         return response.json()
 
     contents = retry(get_automationrelevance, attempts=10, sleeptime=10)

--- a/test/test_files_changed.py
+++ b/test/test_files_changed.py
@@ -36,6 +36,9 @@ class FakeResponse:
         ) as f:
             return json.load(f)
 
+    def raise_for_status(self):
+        pass
+
 
 class TestGetChangedFiles(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Makes more sense to get an http exception rather than a json decode error.