### PR TITLE
fix: pick up upstream enhancements for tarfile reproducability (fixes #421)

### DIFF
--- a/src/taskgraph/util/archive.py
+++ b/src/taskgraph/util/archive.py
@@ -43,7 +43,7 @@ class TarInfo(tarfile.TarInfo):
         info["type"] = HackedType(info["type"])
         # ignore type checking because it looks like pyright complains because we're calling a
         # non-public method
-        return tarfile.TarInfo._create_header(info, format, encoding, errors) # type: ignore
+        return tarfile.TarInfo._create_header(info, format, encoding, errors)  # type: ignore
 
 
 def create_tar_from_files(fp, files):

--- a/src/taskgraph/util/archive.py
+++ b/src/taskgraph/util/archive.py
@@ -12,6 +12,40 @@ import tarfile
 DEFAULT_MTIME = 1451606400
 
 
+# Python 3.9 contains this change:
+#  https://github.com/python/cpython/commit/674935b8caf33e47c78f1b8e197b1b77a04992d2
+# which changes the output of tar creation compared to earlier versions.
+# As this code is used to generate tar files that are meant to be deterministic
+# across versions of python (specifically, it's used as part of computing the hash
+# of docker images, which needs to be identical between CI (which uses python 3.8),
+# and developer environments (using arbitrary versions of python, at this point,
+# most probably more recent than 3.9)).
+# What we do is subblass TarInfo so that if used on python >= 3.9, it reproduces the
+# behavior from python < 3.9.
+# Here's how it goes:
+# - the behavior in python >= 3.9 is the same as python < 3.9 when the type encoded
+# in the tarinfo is CHRTYPE or BLKTYPE.
+# - the value of the type is only compared in the context of choosing which behavior
+# to take
+# - we replace the type with the same value (so that using the value has no changes)
+# but that pretends to be the same as CHRTYPE so that the condition that enables the
+# old behavior is taken.
+class HackedType(bytes):
+    def __eq__(self, other):
+        if other == tarfile.CHRTYPE:
+            return True
+        return self == other
+
+
+class TarInfo(tarfile.TarInfo):
+    @staticmethod
+    def _create_header(info, format, encoding, errors):
+        info["type"] = HackedType(info["type"])
+        # ignore type checking because it looks like pyright complains because we're calling a
+        # non-public method
+        return tarfile.TarInfo._create_header(info, format, encoding, errors) # type: ignore
+
+
 def create_tar_from_files(fp, files):
     """Create a tar file deterministically.
 
@@ -25,15 +59,23 @@ def create_tar_from_files(fp, files):
 
     FUTURE accept a filename argument (or create APIs to write files)
     """
-    with tarfile.open(name="", mode="w", fileobj=fp, dereference=True) as tf:
+    # The format is explicitly set to tarfile.GNU_FORMAT, because this default format
+    # has been changed in Python 3.8.
+    with tarfile.open(
+        name="", mode="w", fileobj=fp, dereference=True, format=tarfile.GNU_FORMAT
+    ) as tf:
         for archive_path, f in sorted(files.items()):
             if isinstance(f, str):
-                mode = os.stat(f).st_mode
+                s = os.stat(f)
+                mode = s.st_mode
+                size = s.st_size
                 f = open(f, "rb")
             else:
                 mode = 0o0644
+                size = len(f.read())
+                f.seek(0)
 
-            ti = tarfile.TarInfo(archive_path)
+            ti = TarInfo(archive_path)
             ti.mode = mode
             ti.type = tarfile.REGTYPE
 
@@ -56,9 +98,7 @@ def create_tar_from_files(fp, files):
             # Set mtime to a constant value.
             ti.mtime = DEFAULT_MTIME
 
-            f.seek(0, 2)
-            ti.size = f.tell()
-            f.seek(0, 0)
+            ti.size = size
             # tarfile wants to pass a size argument to read(). So just
             # wrap/buffer in a proper file object interface.
             tf.addfile(ti, f)

--- a/test/test_util_archive.py
+++ b/test/test_util_archive.py
@@ -13,8 +13,6 @@ import unittest
 
 import pytest
 
-from taskgraph.util.archive import create_tar_from_files
-
 from taskgraph.util.archive import (
     DEFAULT_MTIME,
     create_tar_from_files,
@@ -48,7 +46,7 @@ class TestArchive(unittest.TestCase):
             files["file%02d" % i] = p
 
         for i in range(10):
-            files["file%02d" % (i + 10)] = io.BytesIO((b"file%02d" % (i + 10)))
+            files["file%02d" % (i + 10)] = io.BytesIO(b"file%02d" % (i + 10))
 
         return files
 
@@ -74,7 +72,7 @@ class TestArchive(unittest.TestCase):
         try:
             tp = os.path.join(d, "test.tar")
             with open(tp, "wb") as fh:
-                with self.assertRaisesRegexp(ValueError, "not a regular"):
+                with self.assertRaisesRegex(ValueError, "not a regular"):
                     create_tar_from_files(fh, {"test": d})
         finally:
             shutil.rmtree(d)
@@ -94,9 +92,9 @@ class TestArchive(unittest.TestCase):
 
             tp = os.path.join(d, "test.tar")
             with open(tp, "wb") as fh:
-                with self.assertRaisesRegexp(ValueError, "cannot add file with setuid"):
+                with self.assertRaisesRegex(ValueError, "cannot add file with setuid"):
                     create_tar_from_files(fh, {"test": uid})
-                with self.assertRaisesRegexp(ValueError, "cannot add file with setuid"):
+                with self.assertRaisesRegex(ValueError, "cannot add file with setuid"):
                     create_tar_from_files(fh, {"test": gid})
         finally:
             shutil.rmtree(d)

--- a/test/test_util_archive.py
+++ b/test/test_util_archive.py
@@ -1,0 +1,176 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import hashlib
+import io
+import os
+import shutil
+import stat
+import tarfile
+import tempfile
+import unittest
+
+import pytest
+
+from taskgraph.util.archive import create_tar_from_files
+
+from taskgraph.util.archive import (
+    DEFAULT_MTIME,
+    create_tar_from_files,
+    create_tar_gz_from_files,
+)
+
+MODE_STANDARD = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
+
+
+def file_hash(path):
+    h = hashlib.sha1()
+    with open(path, "rb") as fh:
+        while True:
+            data = fh.read(8192)
+            if not data:
+                break
+            h.update(data)
+
+    return h.hexdigest()
+
+
+class TestArchive(unittest.TestCase):
+    def _create_files(self, root):
+        files = {}
+        for i in range(10):
+            p = os.path.join(root, "file%02d" % i)
+            with open(p, "wb") as fh:
+                fh.write(b"file%02d" % i)
+            # Need to set permissions or umask may influence testing.
+            os.chmod(p, MODE_STANDARD)
+            files["file%02d" % i] = p
+
+        for i in range(10):
+            files["file%02d" % (i + 10)] = io.BytesIO((b"file%02d" % (i + 10)))
+
+        return files
+
+    def _verify_basic_tarfile(self, tf):
+        self.assertEqual(len(tf.getmembers()), 20)
+
+        names = ["file%02d" % i for i in range(20)]
+        self.assertEqual(tf.getnames(), names)
+
+        for ti in tf.getmembers():
+            self.assertEqual(ti.uid, 0)
+            self.assertEqual(ti.gid, 0)
+            self.assertEqual(ti.uname, "")
+            self.assertEqual(ti.gname, "")
+            self.assertEqual(ti.mode, MODE_STANDARD)
+            self.assertEqual(ti.mtime, DEFAULT_MTIME)
+
+    @pytest.mark.xfail(
+        reason="ValueError is not thrown despite being provided directory."
+    )
+    def test_dirs_refused(self):
+        d = tempfile.mkdtemp()
+        try:
+            tp = os.path.join(d, "test.tar")
+            with open(tp, "wb") as fh:
+                with self.assertRaisesRegexp(ValueError, "not a regular"):
+                    create_tar_from_files(fh, {"test": d})
+        finally:
+            shutil.rmtree(d)
+
+    def test_setuid_setgid_refused(self):
+        d = tempfile.mkdtemp()
+        try:
+            uid = os.path.join(d, "setuid")
+            gid = os.path.join(d, "setgid")
+            with open(uid, "a"):
+                pass
+            with open(gid, "a"):
+                pass
+
+            os.chmod(uid, MODE_STANDARD | stat.S_ISUID)
+            os.chmod(gid, MODE_STANDARD | stat.S_ISGID)
+
+            tp = os.path.join(d, "test.tar")
+            with open(tp, "wb") as fh:
+                with self.assertRaisesRegexp(ValueError, "cannot add file with setuid"):
+                    create_tar_from_files(fh, {"test": uid})
+                with self.assertRaisesRegexp(ValueError, "cannot add file with setuid"):
+                    create_tar_from_files(fh, {"test": gid})
+        finally:
+            shutil.rmtree(d)
+
+    def test_create_tar_basic(self):
+        d = tempfile.mkdtemp()
+        try:
+            files = self._create_files(d)
+
+            tp = os.path.join(d, "test.tar")
+            with open(tp, "wb") as fh:
+                create_tar_from_files(fh, files)
+
+            # Output should be deterministic.
+            self.assertEqual(file_hash(tp), "01cd314e277f060e98c7de6c8ea57f96b3a2065c")
+
+            with tarfile.open(tp, "r") as tf:
+                self._verify_basic_tarfile(tf)
+
+        finally:
+            shutil.rmtree(d)
+
+    @pytest.mark.xfail(reason="hash mismatch")
+    def test_executable_preserved(self):
+        d = tempfile.mkdtemp()
+        try:
+            p = os.path.join(d, "exec")
+            with open(p, "wb") as fh:
+                fh.write("#!/bin/bash\n")
+            os.chmod(p, MODE_STANDARD | stat.S_IXUSR)
+
+            tp = os.path.join(d, "test.tar")
+            with open(tp, "wb") as fh:
+                create_tar_from_files(fh, {"exec": p})
+
+            self.assertEqual(file_hash(tp), "357e1b81c0b6cfdfa5d2d118d420025c3c76ee93")
+
+            with tarfile.open(tp, "r") as tf:
+                m = tf.getmember("exec")
+                self.assertEqual(m.mode, MODE_STANDARD | stat.S_IXUSR)
+
+        finally:
+            shutil.rmtree(d)
+
+    def test_create_tar_gz_basic(self):
+        d = tempfile.mkdtemp()
+        try:
+            files = self._create_files(d)
+
+            gp = os.path.join(d, "test.tar.gz")
+            with open(gp, "wb") as fh:
+                create_tar_gz_from_files(fh, files)
+
+            self.assertEqual(file_hash(gp), "7c4da5adc5088cdf00911d5daf9a67b15de714b7")
+
+            with tarfile.open(gp, "r:gz") as tf:
+                self._verify_basic_tarfile(tf)
+
+        finally:
+            shutil.rmtree(d)
+
+    def test_tar_gz_name(self):
+        d = tempfile.mkdtemp()
+        try:
+            files = self._create_files(d)
+
+            gp = os.path.join(d, "test.tar.gz")
+            with open(gp, "wb") as fh:
+                create_tar_gz_from_files(fh, files, filename="foobar")
+
+            self.assertEqual(file_hash(gp), "721e00083c17d16df2edbddf40136298c06d0c49")
+
+            with tarfile.open(gp, "r:gz") as tf:
+                self._verify_basic_tarfile(tf)
+
+        finally:
+            shutil.rmtree(d)

--- a/test/test_util_docker.py
+++ b/test/test_util_docker.py
@@ -25,7 +25,6 @@ MODE_STANDARD = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
 
 @mock.patch.dict("os.environ", {"TASKCLUSTER_ROOT_URL": liburls.test_root_url()})
 class TestDocker(unittest.TestCase):
-    @pytest.mark.xfail(sys.version_info >= (3, 8), reason="Hash is different")
     def test_generate_context_hash(self):
         tmpdir = tempfile.mkdtemp()
         try:
@@ -87,7 +86,6 @@ class TestDocker(unittest.TestCase):
                 docker.docker_image("myimage", by_tag=True), "mozilla/myimage:1.2.3"
             )
 
-    @pytest.mark.xfail(sys.version_info >= (3, 8), reason="Hash is different")
     def test_create_context_tar_basic(self):
         tmp = tempfile.mkdtemp()
         try:
@@ -119,7 +117,6 @@ class TestDocker(unittest.TestCase):
         finally:
             shutil.rmtree(tmp)
 
-    @pytest.mark.xfail(sys.version_info >= (3, 8), reason="Hash is different")
     def test_create_context_topsrcdir_files(self):
         tmp = tempfile.mkdtemp()
         try:
@@ -195,7 +192,6 @@ class TestDocker(unittest.TestCase):
         finally:
             shutil.rmtree(tmp)
 
-    @pytest.mark.xfail(sys.version_info >= (3, 8), reason="Hash is different")
     def test_create_context_extra_directory(self):
         tmp = tempfile.mkdtemp()
         try:
@@ -240,7 +236,6 @@ class TestDocker(unittest.TestCase):
         finally:
             shutil.rmtree(tmp)
 
-    @pytest.mark.xfail(sys.version_info >= (3, 8), reason="Hash is different")
     def test_stream_context_tar(self):
         tmp = tempfile.mkdtemp()
         try:

--- a/test/test_util_docker.py
+++ b/test/test_util_docker.py
@@ -6,14 +6,12 @@
 import os
 import shutil
 import stat
-import sys
 import tarfile
 import tempfile
 import unittest
 from io import BufferedRandom, BytesIO
 from unittest import mock
 
-import pytest
 import taskcluster_urls as liburls
 
 from taskgraph.util import docker


### PR DESCRIPTION
This is mostly copy/pasting from https://searchfox.org/mozilla-central/source/python/mozbuild/mozpack/archive.py, with a couple of tweaks because we don't have the mozpack `file` classes here.
    
The enchancements come from https://bugzilla.mozilla.org/show_bug.cgi?id=1807872 and https://bugzilla.mozilla.org/show_bug.cgi?id=1347582.