### PR TITLE
ci: don't use 'docker-image' as dependency name

### DIFF
--- a/taskcluster/kinds/push-image/kind.yml
+++ b/taskcluster/kinds/push-image/kind.yml
@@ -20,7 +20,7 @@ task-defaults:
         use-caches: false
         command: "sh /usr/local/bin/push_image.sh"
     fetches:
-        docker-image:
+        image:
             - artifact: image.tar.zst
               extract: false
     run-on-tasks-for: ["github-release"]
@@ -40,4 +40,4 @@ task-defaults:
 tasks:
     decision:
         dependencies:
-            docker-image: build-docker-image-decision
+            image: build-docker-image-decision


### PR DESCRIPTION
This is implicitly set by the `docker.py` file when you use an in-tree Docker image.