### PR TITLE
Add support for pr-action in .taskcluster.yml (bug 1641282)

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -19,28 +19,29 @@ tasks:
                   'tasks_for == "github-push"': '${event.pusher.email}'
                   'tasks_for == "github-release"': 'release+taskgraph-ci@mozilla.com'
                   'tasks_for[:19] == "github-pull-request"': '${event.pull_request.user.login}@users.noreply.github.com'
-                  'tasks_for in ["cron", "action"]': '${tasks_for}@noreply.mozilla.org'
+                  'tasks_for in ["cron", "action", "pr-action"]': '${tasks_for}@noreply.mozilla.org'
           baseRepoUrl:
               $switch:
                   'tasks_for[:19] == "github-pull-request"': '${event.pull_request.base.repo.html_url}'
                   'tasks_for in ["cron", "action"]': '${repository.url}'
+                  'tasks_for == "pr-action"': '${repository.base_url}'
                   $default: '${event.repository.html_url}'
           repoUrl:
               $switch:
                   'tasks_for[:19] == "github-pull-request"': '${event.pull_request.head.repo.html_url}'
-                  'tasks_for in ["cron", "action"]': '${repository.url}'
+                  'tasks_for in ["cron", "action", "pr-action"]': '${repository.url}'
                   $default: '${event.repository.html_url}'
           project:
               $switch:
                   'tasks_for in ["github-push", "github-release"]': '${event.repository.name}'
                   'tasks_for[:19] == "github-pull-request"': '${event.pull_request.head.repo.name}'
-                  'tasks_for in ["cron", "action"]': '${repository.project}'
+                  'tasks_for in ["cron", "action", "pr-action"]': '${repository.project}'
           head_branch:
               $switch:
                   'tasks_for[:19] == "github-pull-request"': ${event.pull_request.head.ref}
                   'tasks_for == "github-push"': ${event.ref}
                   'tasks_for == "github-release"': '${event.release.target_commitish}'
-                  'tasks_for in ["action", "cron"]': '${push.branch}'
+                  'tasks_for in ["cron", "action", "pr-action"]': '${push.branch}'
           base_ref:
               $switch:
                   'tasks_for[:19] == "github-pull-request"': ${event.pull_request.base.ref}
@@ -52,29 +53,29 @@ tasks:
                   'tasks_for == "github-push" && event.base_ref': ${event.base_ref}
                   'tasks_for == "github-push" && !(event.base_ref)': ${event.ref}
                   'tasks_for == "github-release"': ${event.release.tag_name}
-                  'tasks_for in ["cron", "action"]': '${push.branch}'
+                  'tasks_for in ["cron", "action", "pr-action"]': '${push.branch}'
           head_ref:
               $switch:
                   'tasks_for[:19] == "github-pull-request"': ${event.pull_request.head.ref}
                   'tasks_for == "github-push"': ${event.ref}
-                  'tasks_for in ["cron", "action"]': '${push.branch}'
+                  'tasks_for in ["cron", "action", "pr-action"]': '${push.branch}'
                   'tasks_for == "github-release"': ${event.release.tag_name}
           base_sha:
               $switch:
                   'tasks_for == "github-push"': '${event.before}'
                   'tasks_for == "github-release"': '${event.release.target_commitish}'
                   'tasks_for[:19] == "github-pull-request"': '${event.pull_request.base.sha}'
-                  'tasks_for in ["cron", "action"]': '${push.revision}'
+                  'tasks_for in ["cron", "action", "pr-action"]': '${push.revision}'
           head_sha:
               $switch:
                   'tasks_for == "github-push"': '${event.after}'
                   'tasks_for[:19] == "github-pull-request"': '${event.pull_request.head.sha}'
-                  'tasks_for in ["cron", "action"]': '${push.revision}'
+                  'tasks_for in ["cron", "action", "pr-action"]': '${push.revision}'
                   'tasks_for == "github-release"': '${event.release.tag_name}'
           ownTaskId:
               $switch:
                   '"github" in tasks_for': {$eval: as_slugid("decision_task")}
-                  'tasks_for in ["cron", "action"]': '${ownTaskId}'
+                  'tasks_for in ["cron", "action", "pr-action"]': '${ownTaskId}'
           pullRequestAction:
               $switch:
                   'tasks_for[:19] == "github-pull-request"': ${event.action}
@@ -87,7 +88,7 @@ tasks:
               $eval: 'tasks_for[:19] == "github-pull-request"'
       in:
           $if: >
-            tasks_for in ["action", "cron"]
+            tasks_for in ["action", "pr-action", "cron"]
             || (tasks_for == "github-release" && releaseAction == "published")
             || (tasks_for == "github-push" && head_branch == "refs/heads/main")
             || (tasks_for == "github-release" && )
@@ -106,9 +107,9 @@ tasks:
                           then: {$eval: 'head_ref[11:]'}
                           else: ${head_ref}
               in:
-                  taskId: {$if: 'tasks_for != "action"', then: '${ownTaskId}'}
+                  taskId: {$if: 'tasks_for != "action" && tasks_for != "pr-action"', then: '${ownTaskId}'}
                   taskGroupId:
-                      $if: 'tasks_for == "action"'
+                      $if: 'tasks_for == "action" || tasks_for == "pr-action"'
                       then:
                           '${action.taskGroupId}'
                       else:
@@ -132,6 +133,12 @@ tasks:
                                         ${action.description}
 
                                         Action triggered by clientID `${clientId}`
+                                'tasks_for == "pr-action"':
+                                    name: "PR action: ${action.title}"
+                                    description: |
+                                        ${action.description}
+
+                                        PR action triggered by clientID `${clientId}`
                                 $default:
                                     name: "Decision Task for cron job ${cron.job_name}"
                                     description: 'Created by a [cron task](https://firefox-ci-tc.services.mozilla.com/tasks/${cron.task_id})'
@@ -144,7 +151,7 @@ tasks:
                           'tasks_for == "github-push" || isPullRequest':
                               createdForUser: "${ownerEmail}"
                               kind: decision-task
-                          'tasks_for == "action"':
+                          'tasks_for == "action" || tasks_for == "pr-action"':
                               createdForUser: '${ownerEmail}'
                               kind: 'action-callback'
                           'tasks_for == "cron"':
@@ -153,7 +160,7 @@ tasks:
                   routes:
                       $flatten:
                           - checks
-                          - {$if: '!isPullRequest', then: ["tc-treeherder.v2.${project}.${head_sha}"], else: []}
+                          - {$if: '!isPullRequest && tasks_for != "pr-action"', then: ["tc-treeherder.v2.${project}.${head_sha}"], else: []}
                           - $switch:
                                 'tasks_for == "github-push"':
                                     - "index.${trustDomain}.v2.${project}.latest.taskgraph.decision"
@@ -177,6 +184,8 @@ tasks:
                               - 'assume:repo:github.com/${event.pull_request.base.repo.full_name}:${tasks_for[7:]}'
                           'tasks_for == "action"':
                               - 'assume:repo:${repoUrl[8:]}:action:${action.action_perm}'
+                          'tasks_for == "pr-action"':
+                              - 'assume:repo:${baseRepoUrl[8:]}:pr-action:${action.action_perm}'
                           $default:
                               - 'assume:repo:${repoUrl[8:]}:cron:${cron.job_name}'
 
@@ -217,7 +226,7 @@ tasks:
                               - $if: 'isPullRequest'
                                 then:
                                     TASKGRAPH_PULL_REQUEST_NUMBER: '${event.pull_request.number}'
-                              - $if: 'tasks_for == "action"'
+                              - $if: 'tasks_for == "action" || tasks_for == "pr-action"'
                                 then:
                                     ACTION_TASK_GROUP_ID: '${action.taskGroupId}'  # taskGroupId of the target task
                                     ACTION_TASK_ID: {$json: {$eval: 'taskId'}}  # taskId of the target task (JSON-encoded)
@@ -244,7 +253,7 @@ tasks:
                           - $let:
                                 extraArgs: {$if: 'tasks_for == "cron"', then: '${cron.quoted_args}', else: ''}
                             in:
-                                $if: 'tasks_for == "action"'
+                                $if: 'tasks_for == "action" || tasks_for == "pr-action"'
                                 then: >
                                     cd /builds/worker/checkouts/src &&
                                     ln -s /builds/worker/artifacts artifacts &&
@@ -294,14 +303,14 @@ tasks:
                                     - $switch:
                                           'tasks_for in ["github-push", "github-release"] || isPullRequest':
                                               symbol: D
-                                          'tasks_for == "action"':
+                                          'tasks_for == "action" || tasks_for == "pr-action"':
                                               groupName: 'action-callback'
                                               groupSymbol: AC
                                               symbol: "${action.symbol}"
                                           $default:
                                               groupSymbol: cron
                                               symbol: "${cron.job_symbol}"
-                          - $if: 'tasks_for == "action"'
+                          - $if: 'tasks_for == "action" || tasks_for == "pr-action"'
                             then:
                                 parent: '${action.taskGroupId}'
                                 action:


### PR DESCRIPTION
"tasks_for" can now be "pr-action", which runs as level1 and asserts a scope based on the base repo instead of head.