### PR TITLE
actions: support non-indexed decision tasks

### DIFF
--- a/src/taskgraph/actions/add_new_jobs.py
+++ b/src/taskgraph/actions/add_new_jobs.py
@@ -40,7 +40,7 @@ from taskgraph.actions.util import (
 )
 def add_new_jobs_action(parameters, graph_config, input, task_group_id, task_id):
     decision_task_id, full_task_graph, label_to_taskid = fetch_graph_and_labels(
-        parameters, graph_config
+        parameters, graph_config, task_group_id=task_group_id
     )
 
     to_run = []

--- a/src/taskgraph/actions/rebuild_cached_tasks.py
+++ b/src/taskgraph/actions/rebuild_cached_tasks.py
@@ -18,7 +18,7 @@ def rebuild_cached_tasks_action(
     parameters, graph_config, input, task_group_id, task_id
 ):
     decision_task_id, full_task_graph, label_to_taskid = fetch_graph_and_labels(
-        parameters, graph_config
+        parameters, graph_config, task_group_id=task_group_id
     )
     cached_tasks = [
         label

--- a/src/taskgraph/actions/retrigger.py
+++ b/src/taskgraph/actions/retrigger.py
@@ -142,7 +142,7 @@ def retrigger_decision_action(parameters, graph_config, input, task_group_id, ta
 )
 def retrigger_action(parameters, graph_config, input, task_group_id, task_id):
     decision_task_id, full_task_graph, label_to_taskid = fetch_graph_and_labels(
-        parameters, graph_config
+        parameters, graph_config, task_group_id=task_group_id
     )
 
     task = taskcluster.get_task_definition(task_id)
@@ -199,7 +199,7 @@ def rerun_action(parameters, graph_config, input, task_group_id, task_id):
     task = taskcluster.get_task_definition(task_id)
     parameters = dict(parameters)
     decision_task_id, full_task_graph, label_to_taskid = fetch_graph_and_labels(
-        parameters, graph_config
+        parameters, graph_config, task_group_id=task_group_id
     )
     label = task["metadata"]["name"]
     if task_id not in label_to_taskid.values():
@@ -257,7 +257,7 @@ def _rerun_task(task_id, label):
 )
 def retrigger_multiple(parameters, graph_config, input, task_group_id, task_id):
     decision_task_id, full_task_graph, label_to_taskid = fetch_graph_and_labels(
-        parameters, graph_config
+        parameters, graph_config, task_group_id=task_group_id
     )
 
     suffixes = []

--- a/src/taskgraph/actions/util.py
+++ b/src/taskgraph/actions/util.py
@@ -32,8 +32,15 @@ def get_parameters(decision_task_id):
     return get_artifact(decision_task_id, "public/parameters.yml")
 
 
-def fetch_graph_and_labels(parameters, graph_config):
-    decision_task_id = find_decision_task(parameters, graph_config)
+def fetch_graph_and_labels(parameters, graph_config, task_group_id=None):
+    try:
+        # Look up the decision_task id in the index
+        decision_task_id = find_decision_task(parameters, graph_config)
+    except KeyError:
+        if not task_group_id:
+            raise
+        # Not found (e.g. from github-pull-request), fall back to the task group id.
+        decision_task_id = task_group_id
 
     # First grab the graph and labels generated during the initial decision task
     full_task_graph = get_artifact(decision_task_id, "public/full-task-graph.json")


### PR DESCRIPTION
The decision task id is the action task's group id, so it's already available without a round-trip through the tc index.  This helps in case of e.g. PRs that don't necessarily index decision tasks (and even if they do, don't index them where `find_decision_task` is currently looking for them).