### PR TITLE
ci: add push.base_branch to tc.yml (bug 1641282)

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -53,7 +53,8 @@ tasks:
                   'tasks_for == "github-push" && event.base_ref': ${event.base_ref}
                   'tasks_for == "github-push" && !(event.base_ref)': ${event.ref}
                   'tasks_for == "github-release"': ${event.release.tag_name}
-                  'tasks_for in ["cron", "action", "pr-action"]': '${push.branch}'
+                  'tasks_for in ["cron", "action"]': '${push.branch}'
+                  'tasks_for == "pr-action"': '${push.base_branch}'
           head_ref:
               $switch:
                   'tasks_for[:19] == "github-pull-request"': ${event.pull_request.head.ref}


### PR DESCRIPTION
PR actions need to know both the base repo and branch to check out.