### PR TITLE
fix(init): Don't set 'base_ref' on github-release events

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -52,7 +52,7 @@ tasks:
                   # [1] https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#push
                   'tasks_for == "github-push" && event.base_ref': ${event.base_ref}
                   'tasks_for == "github-push" && !(event.base_ref)': ${event.ref}
-                  'tasks_for == "github-release"': ${event.release.tag_name}
+                  'tasks_for == "github-release"': ''
                   'tasks_for in ["cron", "action"]': '${push.branch}'
                   'tasks_for == "pr-action"': '${push.base_branch}'
           head_ref:

--- a/template/{{cookiecutter.project_name}}/taskcluster.github.yml
+++ b/template/{{cookiecutter.project_name}}/taskcluster.github.yml
@@ -46,7 +46,7 @@ tasks:
                   'tasks_for[:19] == "github-pull-request"': ${event.pull_request.base.ref}
                   'tasks_for == "github-push" && event.base_ref': ${event.base_ref}
                   'tasks_for == "github-push"': ${event.ref}
-                  'tasks_for == "github-release"': ${event.release.tag_name}
+                  'tasks_for == "github-release"': ''
                   'tasks_for in ["cron", "action"]': '${push.branch}'
                   'tasks_for == "pr-action"': '${push.base_branch}'
           head_ref:


### PR DESCRIPTION
We were previously setting this to the tag of the release, but run-task doesn't handle the case where base_ref is a tag well. This could be fixed, but the release tag is the `head_ref` rather than the `base_ref`. So it's best to just not pass it in at all in this case.