### PR TITLE
fix(morph): return original function in 'register_morph' decorator

### DIFF
--- a/src/taskgraph/morph.py
+++ b/src/taskgraph/morph.py
@@ -38,6 +38,7 @@ registered_morphs = []
 
 def register_morph(func):
     registered_morphs.append(func)
+    return func
 
 
 def amend_taskgraph(taskgraph, label_to_taskid, to_add):

--- a/test/test_morph.py
+++ b/test/test_morph.py
@@ -82,6 +82,7 @@ def test_register_morph(monkeypatch, make_taskgraph):
         label_to_taskid["count"] += 1
         return taskgraph, label_to_taskid
 
+    assert callable(fake_morph)
     assert label_to_taskid == {}
     morph.morph(taskgraph, label_to_taskid, None, None)
     assert label_to_taskid == {"count": 1}


### PR DESCRIPTION
While this isn't needed for Taskgraph operation, it makes testing morphs difficult as test functions are unable to call the decorated functions directly.