### PR TITLE
Update verify_routes_notification_filters for Taskcluster > 37.5.0

### DIFF
--- a/src/taskgraph/util/verify.py
+++ b/src/taskgraph/util/verify.py
@@ -5,6 +5,7 @@
 
 import logging
 import sys
+import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Union
@@ -192,7 +193,17 @@ def verify_routes_notification_filters(
     if task is None:
         return
     route_prefix = "notify."
-    valid_filters = ("on-any", "on-completed", "on-failed", "on-exception")
+    valid_filters = (
+        "on-any",
+        "on-completed",
+        "on-defined",
+        "on-failed",
+        "on-exception",
+        "on-pending",
+        "on-resolved",
+        "on-running",
+        "on-transition",
+    )
     task_dict = task.task
     routes = task_dict.get("routes", [])
 
@@ -203,6 +214,13 @@ def verify_routes_notification_filters(
             if route_filter not in valid_filters:
                 raise Exception(
                     f"{task.label} has invalid notification filter ({route_filter})"
+                )
+            if route_filter == "on-any":
+                warnings.warn(
+                    DeprecationWarning(
+                        f"notification filter '{route_filter}' is deprecated. Use "
+                        "'on-transition' or 'on-resolved'."
+                    )
                 )
 
 

--- a/test/test_util_verify.py
+++ b/test/test_util_verify.py
@@ -169,14 +169,12 @@ def make_task_treeherder(label, symbol, platform="linux/opt"):
                 make_task(
                     "good1",
                     task_def={
-                        "routes": [
-                            "notify.email.default@email.address.on-completed"
-                        ]
+                        "routes": ["notify.email.default@email.address.on-completed"]
                     },
                 ),
             ),
             None,
-            id="routes_notfication_filter: valid"
+            id="routes_notfication_filter: valid",
         ),
         pytest.param(
             "verify_routes_notification_filters",
@@ -184,29 +182,23 @@ def make_task_treeherder(label, symbol, platform="linux/opt"):
                 make_task(
                     "bad1",
                     task_def={
-                        "routes": [
-                            "notify.email.default@email.address.on-bogus"
-                        ]
+                        "routes": ["notify.email.default@email.address.on-bogus"]
                     },
                 ),
             ),
             Exception,
-            id="routes_notfication_filter: invalid"
+            id="routes_notfication_filter: invalid",
         ),
         pytest.param(
             "verify_routes_notification_filters",
             make_graph(
                 make_task(
                     "deprecated",
-                    task_def={
-                        "routes": [
-                            "notify.email.default@email.address.on-any"
-                        ]
-                    },
+                    task_def={"routes": ["notify.email.default@email.address.on-any"]},
                 ),
             ),
             DeprecationWarning,
-            id="routes_notfication_filter: deprecated"
+            id="routes_notfication_filter: deprecated",
         ),
     ),
 )

--- a/test/test_util_verify.py
+++ b/test/test_util_verify.py
@@ -163,8 +163,54 @@ def make_task_treeherder(label, symbol, platform="linux/opt"):
             Exception,
             id="task_graph_symbol: too many collections",
         ),
+        pytest.param(
+            "verify_routes_notification_filters",
+            make_graph(
+                make_task(
+                    "good1",
+                    task_def={
+                        "routes": [
+                            "notify.email.default@email.address.on-completed"
+                        ]
+                    },
+                ),
+            ),
+            None,
+            id="routes_notfication_filter: valid"
+        ),
+        pytest.param(
+            "verify_routes_notification_filters",
+            make_graph(
+                make_task(
+                    "bad1",
+                    task_def={
+                        "routes": [
+                            "notify.email.default@email.address.on-bogus"
+                        ]
+                    },
+                ),
+            ),
+            Exception,
+            id="routes_notfication_filter: invalid"
+        ),
+        pytest.param(
+            "verify_routes_notification_filters",
+            make_graph(
+                make_task(
+                    "deprecated",
+                    task_def={
+                        "routes": [
+                            "notify.email.default@email.address.on-any"
+                        ]
+                    },
+                ),
+            ),
+            DeprecationWarning,
+            id="routes_notfication_filter: deprecated"
+        ),
     ),
 )
+@pytest.mark.filterwarnings("error")
 def test_verification(run_verification, name, graph, exception):
     func = partial(run_verification, name, graph=graph)
     if exception:


### PR DESCRIPTION
PR #3662 introduced `on-defined`, `on-pending` and `on-running`, and deprecated `on-any` in favor of `on-transition` or `on-resolved`.