### PR TITLE
Permit relative script paths in toolchain jobs

### DIFF
--- a/src/taskgraph/transforms/run/toolchain.py
+++ b/src/taskgraph/transforms/run/toolchain.py
@@ -15,6 +15,7 @@ from taskgraph.transforms.run.common import (
     get_vcsdir_name,
 )
 from taskgraph.util.hash import hash_paths
+from taskgraph.util import path as mozpath
 from taskgraph.util.schema import Schema
 from taskgraph.util.shell import quote as shell_quote
 
@@ -57,7 +58,8 @@ toolchain_run_schema = Schema(
 def get_digest_data(config, run, taskdesc):
     files = list(run.pop("resources", []))
     # The script
-    files.append("taskcluster/scripts/toolchain/{}".format(run["script"]))
+    script = mozpath.join("taskcluster/scripts/toolchain/", run["script"])
+    files.append(mozpath.normpath(script))
 
     # Accumulate dependency hashes for index generation.
     data = [hash_paths(config.graph_config.vcs_root, files)]
@@ -126,16 +128,14 @@ def common_toolchain(config, task, taskdesc, is_docker):
             "digest-data": get_digest_data(config, run, taskdesc),
         }
 
-    script = run.pop("script")
+    script = mozpath.join("taskcluster/scripts/toolchain/", run.pop("script"))
     run["using"] = "run-task"
     run["cwd"] = "{checkout}/.."
 
     if script.endswith(".ps1"):
         run["exec-with"] = "powershell"
 
-    command = [f"{srcdir}/taskcluster/scripts/toolchain/{script}"] + run.pop(
-        "arguments", []
-    )
+    command = [f"{srcdir}/{mozpath.normpath(script)}"] + run.pop("arguments", [])
 
     if not is_docker:
         # Don't quote the first item in the command because it purposely contains

--- a/src/taskgraph/transforms/run/toolchain.py
+++ b/src/taskgraph/transforms/run/toolchain.py
@@ -14,8 +14,8 @@ from taskgraph.transforms.run.common import (
     generic_worker_add_artifacts,
     get_vcsdir_name,
 )
-from taskgraph.util.hash import hash_paths
 from taskgraph.util import path as mozpath
+from taskgraph.util.hash import hash_paths
 from taskgraph.util.schema import Schema
 from taskgraph.util.shell import quote as shell_quote
 

--- a/test/test_transforms_run_toolchain.py
+++ b/test/test_transforms_run_toolchain.py
@@ -189,6 +189,9 @@ def assert_forward(task, _):
     """Assert unknown schema args are forwarded to run_task"""
     assert task["run"]["foo"] == "bar"
 
+def assert_relative_script(task, taskdesc):
+    """Assert that a relative script produces the same results"""
+    assert_docker_worker(task, taskdesc)
 
 @pytest.mark.parametrize(
     "task",
@@ -231,6 +234,18 @@ def assert_forward(task, _):
         pytest.param(
             {"run": {"foo": "bar"}},
             id="forward",
+        ),
+        pytest.param(
+            {
+                "run": {
+                    "script": "../toolchain/run.sh",
+                    "toolchain-alias": "foo",
+                    "toolchain-env": {
+                        "FOO": "1",
+                    },
+                }
+            },
+            id="relative_script",
         ),
     ),
 )

--- a/test/test_transforms_run_toolchain.py
+++ b/test/test_transforms_run_toolchain.py
@@ -189,9 +189,11 @@ def assert_forward(task, _):
     """Assert unknown schema args are forwarded to run_task"""
     assert task["run"]["foo"] == "bar"
 
+
 def assert_relative_script(task, taskdesc):
     """Assert that a relative script produces the same results"""
     assert_docker_worker(task, taskdesc)
+
 
 @pytest.mark.parametrize(
     "task",


### PR DESCRIPTION
I encountered a minor annoyance while writing a toolchain job that tries to use a relative path like this:

```
flatpak-sdks:
    description: "Flatpak Bundle SDKs"
    treeherder:
        symbol: TL(flatpak-sdks)
    run:
        use-caches: true
        script: ../podman-worker.py
        arguments:
            - '/root/bundle_sdk.sh'
        toolchain-alias: flatpak-sdks
        toolchain-artifact: public/build/flatpak-sdks.tar.xz
```

This results in an error when trying to compute the file hashes, because it winds up failing to match `taskcluster/scripts/toolchain/../podman-worker.py` against the globbed path of `taskcluster/scripts/podman-worker.py` to work around the path we should run `path.normpath()` on the script before passing it into `hash_paths()`