### PR TITLE
[run-task] Add the ability to configure submodule checkouts.

### DIFF
--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -598,6 +598,7 @@ def git_checkout(
     commit: Optional[str],
     ssh_key_file: Optional[Path],
     ssh_known_hosts_file: Optional[Path],
+    submodules: Optional[str | bool],
 ):
     env = {
         # abort if transfer speed is lower than 1kB/s for 1 minute
@@ -705,23 +706,40 @@ def git_checkout(
 
     run_required_command(b"vcs", args, cwd=destination_path)
 
-    if os.path.exists(os.path.join(destination_path, ".gitmodules")):
-        args = [
-            "git",
-            "submodule",
-            "init",
+    if submodules is not None:
+        def _filter_submodule(status):
+            # A boolean value selects/disables all submodules.
+            if isinstance(submodules, bool):
+                return submodules
+
+            # Otherwise, a colon-separated stringlist of selected submodules.
+            smpath = status.split()[1]
+            return smpath in submodules.split(':')
+
+        submodpaths = [
+            status.split()[1]
+            for status in subprocess.check_output(["git", "submodule", "status"],
+                cwd=destination_path, universal_newlines=True).splitlines()
+            if _filter_submodule(status)
         ]
 
-        run_required_command(b"vcs", args, cwd=destination_path)
+        for p in submodpaths:
+            args = [
+                "git",
+                "submodule",
+                "init",
+                p
+            ]
+            run_required_command(b"vcs", args, cwd=destination_path)
 
-        args = [
-            "git",
-            "submodule",
-            "update",
-            "--force",  # Overrides any potential local changes
-        ]
-
-        run_required_command(b"vcs", args, cwd=destination_path)
+            args = [
+                "git",
+                "submodule",
+                "update",
+                "--force",  # Overrides any potential local changes
+                p
+            ]
+            run_required_command(b"vcs", args, cwd=destination_path)
 
     _clean_git_checkout(destination_path)
 
@@ -894,6 +912,12 @@ def collect_vcs_options(args, project, name):
     ref = os.environ.get("%s_HEAD_REF" % env_prefix)
     pip_requirements = os.environ.get("%s_PIP_REQUIREMENTS" % env_prefix)
     private_key_secret = os.environ.get("%s_SSH_SECRET_NAME" % env_prefix)
+    submodules = os.environ.get("%s_SUBMODULES" % env_prefix)
+
+    # Some special values can be used to request all submodules.
+    if submodules is not None:
+        if submodules.lower() in ["auto", "true", "yes"]:
+            submodules = True
 
     store_path = os.environ.get("HG_STORE_PATH")
 
@@ -928,6 +952,7 @@ def collect_vcs_options(args, project, name):
         "repo-type": repo_type,
         "ssh-secret-name": private_key_secret,
         "pip-requirements": pip_requirements,
+        "submodules": submodules,
     }
 
 
@@ -976,6 +1001,7 @@ def vcs_checkout_from_args(options):
                 revision,
                 ssh_key_file,
                 ssh_known_hosts_file,
+                options["submodules"],
             )
         elif options["repo-type"] == "hg":
             if not revision and not ref:

--- a/src/taskgraph/transforms/base.py
+++ b/src/taskgraph/transforms/base.py
@@ -26,6 +26,7 @@ class RepoConfig:
     path: str = ""
     head_rev: Union[str, None] = None
     ssh_secret_name: Union[str, None] = None
+    submodules: Union[bool, str, None] = None
 
 
 @dataclass(frozen=True, eq=False)

--- a/src/taskgraph/transforms/run/common.py
+++ b/src/taskgraph/transforms/run/common.py
@@ -143,6 +143,10 @@ def support_vcs_checkout(config, task, taskdesc, repo_configs, sparse=False):
         }
     )
     for repo_config in repo_configs.values():
+        repo_submods = repo_config.submodules
+        if not isinstance(repo_config.submodules, str):
+            repo_submods = "auto" if repo_config.submodules else None
+
         env.update(
             {
                 f"{repo_config.prefix.upper()}_{key}": value
@@ -153,6 +157,7 @@ def support_vcs_checkout(config, task, taskdesc, repo_configs, sparse=False):
                     "HEAD_REF": repo_config.head_ref,
                     "REPOSITORY_TYPE": repo_config.type,
                     "SSH_SECRET_NAME": repo_config.ssh_secret_name,
+                    "SUBMODULES": repo_submods
                 }.items()
                 if value is not None
             }

--- a/test/test_transforms_run_run_task.py
+++ b/test/test_transforms_run_run_task.py
@@ -180,6 +180,37 @@ def assert_no_checkouts(task):
         "echo hello world",
     ]
 
+
+def assert_with_all_submodules(task):
+    assert task["worker"]["env"] == {
+        "CI_BASE_REPOSITORY": "http://hg.example.com",
+        "CI_HEAD_REF": "default",
+        "CI_HEAD_REPOSITORY": "http://hg.example.com",
+        "CI_HEAD_REV": "abcdef",
+        "CI_REPOSITORY_TYPE": "hg",
+        "CI_SUBMODULES": "auto",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZ_SCM_LEVEL": "1",
+        "REPOSITORIES": '{"ci": "Taskgraph"}',
+        "VCS_PATH": "/builds/worker/checkouts/vcs",
+    }
+
+
+def assert_with_one_submodule(task):
+    assert task["worker"]["env"] == {
+        "CI_BASE_REPOSITORY": "http://hg.example.com",
+        "CI_HEAD_REF": "default",
+        "CI_HEAD_REPOSITORY": "http://hg.example.com",
+        "CI_HEAD_REV": "abcdef",
+        "CI_REPOSITORY_TYPE": "hg",
+        "CI_SUBMODULES": "xyz",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZ_SCM_LEVEL": "1",
+        "REPOSITORIES": '{"ci": "Taskgraph"}',
+        "VCS_PATH": "/builds/worker/checkouts/vcs",
+    }
+
+
 def assert_change_head(task):
     assert task["worker"]["env"] == {
         "CI_BASE_REPOSITORY": "http://hg.example.com",
@@ -192,6 +223,7 @@ def assert_change_head(task):
         "REPOSITORIES": '{"ci": "Taskgraph"}',
         "VCS_PATH": "/builds/worker/checkouts/vcs",
     }
+
 
 @pytest.mark.parametrize(
     "task",
@@ -240,6 +272,30 @@ def assert_change_head(task):
                 },
             },
             id="no_checkouts",
+        ),
+        pytest.param(
+            {
+                "run": {
+                    "checkout": {
+                        "ci": {
+                            "submodules": True,
+                        }
+                    },
+                },
+            },
+            id="with_all_submodules",
+        ),
+        pytest.param(
+            {
+                "run": {
+                    "checkout": {
+                        "ci": {
+                            "submodules": "xyz",
+                        }
+                    },
+                },
+            },
+            id="with_one_submodule",
         ),
         pytest.param(
             {

--- a/test/test_transforms_run_run_task.py
+++ b/test/test_transforms_run_run_task.py
@@ -168,6 +168,31 @@ def assert_run_task_command_generic_worker(task):
     ]
 
 
+def assert_no_checkouts(task):
+    assert task["worker"]["env"] == {
+        "MOZ_SCM_LEVEL": "1",
+    }
+    assert task["worker"]["command"] == [
+        "/usr/local/bin/run-task",
+        "--",
+        "bash",
+        "-cx",
+        "echo hello world",
+    ]
+
+def assert_change_head(task):
+    assert task["worker"]["env"] == {
+        "CI_BASE_REPOSITORY": "http://hg.example.com",
+        "CI_HEAD_REF": "default",
+        "CI_HEAD_REPOSITORY": "http://hg.somewhere.com",
+        "CI_HEAD_REV": "an-awesome-branch",
+        "CI_REPOSITORY_TYPE": "hg",
+        "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+        "MOZ_SCM_LEVEL": "1",
+        "REPOSITORIES": '{"ci": "Taskgraph"}',
+        "VCS_PATH": "/builds/worker/checkouts/vcs",
+    }
+
 @pytest.mark.parametrize(
     "task",
     (
@@ -207,6 +232,27 @@ def assert_run_task_command_generic_worker(task):
                 },
             },
             id="run_task_command_generic_worker",
+        ),
+        pytest.param(
+            {
+                "run": {
+                    "checkout": False,
+                },
+            },
+            id="no_checkouts",
+        ),
+        pytest.param(
+            {
+                "run": {
+                    "checkout": {
+                        "ci": {
+                            "head_repository": "http://hg.somewhere.com",
+                            "head_rev": "an-awesome-branch",
+                        },
+                    },
+                },
+            },
+            id="change_head",
         ),
     ),
 )


### PR DESCRIPTION
Thi Implements #504 and adds a bunch of tests to verify the behaviour of `run-task` when it comes to handling checkouts and their git submodules.

The first major change is to `run-task` which now checks for an environment variable of the form `<reponame>_SUBMODULES` to control how to handle git submodules. This variable can take the following values:
- unset: No submodules are checked out.
- `true`, `auto` or `yes`: All submodules are checked out.
- otherwise, a list of submodule paths to checkout, delimited by colons.

The second set of changes addresses the run-task transforms so that this behaviour can be controlled by a YAML task description. In this stream of work we extend the `RepoConfig` class to include an optional `submodules` value, which can take one of the following values:
- `None` or `False`: No submodules are checked out.
- `True`: All submodules are checked out.
- Otherwise, a list of strings naming the submodules to check out.

Note! This changes the default behavior of tasks! Submodules are *not* checked out by default as a result of this change. But I figured I would write it in the most sensible way first and then grapple with the challenges of how to handle compatibility.