### PR TITLE
fix: chain of trust should influence cache digest

### DIFF
--- a/src/taskgraph/transforms/cached_tasks.py
+++ b/src/taskgraph/transforms/cached_tasks.py
@@ -77,7 +77,14 @@ def cache_task(config, tasks):
                         task["label"], p
                     )
                 )
+
         digest_data = cache["digest-data"] + sorted(dependency_digests)
+
+        # Chain of trust affects task artifacts therefore it should influence
+        # cache digest.
+        if task.get("worker", {}).get("chain-of-trust"):
+            digest_data.append(str(task["worker"]["chain-of-trust"]))
+
         add_optimization(
             config,
             task,

--- a/test/test_transforms_cached_tasks.py
+++ b/test/test_transforms_cached_tasks.py
@@ -218,9 +218,7 @@ def assert_chain_of_trust_influences_digest(tasks):
                         "name": "cache-foo",
                         "digest-data": ["abc"],
                     },
-                    "worker": {
-                        "chain-of-trust": True
-                    },
+                    "worker": {"chain-of-trust": True},
                 },
             ],
             # kind config


### PR DESCRIPTION
Chain of trust being enabled or disabled influences the outcome of a task. Specifically, it controls whether or not chain of trust artifacts will be present on the task. Without this impacting the cache digest, cached tasks will continue to be cached when chain of trust is enabled on them, and if there is a chain of trust verifier downstream, this will cause verification issues.

BREAKING CHANGE: worker.chain-of-trust now influences cache digests