### PR TITLE
Upstream some fixes in `taskgraph.util.templates` from gecko_taskgraph

### DIFF
--- a/src/taskgraph/util/copy.py
+++ b/src/taskgraph/util/copy.py
@@ -1,0 +1,47 @@
+from typing import Any
+
+from taskgraph.task import Task
+from taskgraph.util.readonlydict import ReadOnlyDict
+
+immutable_types = {int, float, bool, str, type(None), ReadOnlyDict}
+
+
+def deepcopy(obj: Any) -> Any:
+    """Perform a deep copy of an object with a tree like structure.
+
+    This is a re-implementation of Python's `copy.deepcopy` function with a few key differences:
+
+    1. Unlike the stdlib, this does *not* support copying graph-like structure,
+    which allows it to be more efficient than deepcopy on tree-like structures
+    (such as Tasks).
+    2. This special cases support for `taskgraph.task.Task` objects.
+
+    Args:
+        obj: The object to deep copy.
+
+    Returns:
+        A deep copy of the object.
+    """
+    ty = type(obj)
+    if ty in immutable_types:
+        return obj
+    if ty is dict:
+        return {k: deepcopy(v) for k, v in obj.items()}
+    if ty is list:
+        return [deepcopy(elt) for elt in obj]
+    if ty is Task:
+        task = Task(
+            kind=deepcopy(obj.kind),
+            label=deepcopy(obj.label),
+            attributes=deepcopy(obj.attributes),
+            task=deepcopy(obj.task),
+            description=deepcopy(obj.description),
+            optimization=deepcopy(obj.optimization),
+            dependencies=deepcopy(obj.dependencies),
+            soft_dependencies=deepcopy(obj.soft_dependencies),
+            if_dependencies=deepcopy(obj.if_dependencies),
+        )
+        if obj.task_id:
+            task.task_id = obj.task_id
+        return task
+    raise NotImplementedError(f"copying '{ty}' from '{obj}'")

--- a/src/taskgraph/util/templates.py
+++ b/src/taskgraph/util/templates.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import copy
+from taskgraph.util.copy import deepcopy
 
 
 def merge_to(source, dest):
@@ -55,7 +55,7 @@ def merge(*objects):
     Returns the result without modifying any arguments.
     """
     if len(objects) == 1:
-        return copy.deepcopy(objects[0])
+        return deepcopy(objects[0])
     return merge_to(objects[-1], merge(*objects[:-1]))
 
 

--- a/src/taskgraph/util/templates.py
+++ b/src/taskgraph/util/templates.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-
 import copy
 
 
@@ -18,9 +17,19 @@ def merge_to(source, dest):
     """
 
     for key, value in source.items():
+        if (
+            isinstance(value, dict)
+            and len(value) == 1
+            and list(value)[0].startswith("by-")
+        ):
+            # Do not merge by-* values as it will almost certainly not do what
+            # the user expects.
+            dest[key] = value
+            continue
+
         # Override mismatching or empty types
         if type(value) != type(dest.get(key)):  # noqa
-            dest[key] = source[key]
+            dest[key] = value
             continue
 
         # Merge dict
@@ -29,10 +38,10 @@ def merge_to(source, dest):
             continue
 
         if isinstance(value, list):
-            dest[key] = dest[key] + source[key]
+            dest[key] = dest[key] + value
             continue
 
-        dest[key] = source[key]
+        dest[key] = value
 
     return dest
 

--- a/test/test_util_copy.py
+++ b/test/test_util_copy.py
@@ -1,0 +1,34 @@
+import pytest
+
+from taskgraph.task import Task
+from taskgraph.util.copy import deepcopy, immutable_types
+from taskgraph.util.readonlydict import ReadOnlyDict
+
+
+@pytest.mark.parametrize(
+    "input",
+    (
+        1,
+        False,
+        "foo",
+        ReadOnlyDict(a=1, b="foo"),
+        ["foo", "bar"],
+        {
+            "foo": Task(
+                label="abc",
+                kind="kind",
+                attributes={"bar": "baz"},
+                dependencies={"dep": "bar"},
+                task={"payload": {"command": ["echo hello"]}},
+            )
+        },
+    ),
+)
+def test_deepcopy(input):
+    result = deepcopy(input)
+    assert result == input
+
+    if type(result) in immutable_types:
+        assert id(result) == id(input)
+    else:
+        assert id(result) != id(input)

--- a/test/test_util_templates.py
+++ b/test/test_util_templates.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-
 import unittest
 
 from taskgraph.util.templates import merge, merge_to
@@ -50,3 +49,24 @@ class MergeTest(unittest.TestCase):
         self.assertEqual(first, {"a": 1, "b": 2, "d": 11})
         self.assertEqual(second, {"b": 20, "c": 30})
         self.assertEqual(third, {"c": 300, "d": 400})
+
+    def test_merge_by(self):
+        source = {
+            "x": "abc",
+            "y": {"by-foo": {"quick": "fox", "default": ["a", "b", "c"]}},
+        }
+        dest = {"y": {"by-foo": {"purple": "rain", "default": ["x", "y", "z"]}}}
+        expected = {
+            "x": "abc",
+            "y": {"by-foo": {"quick": "fox", "default": ["a", "b", "c"]}},
+        }  # source wins
+        self.assertEqual(merge_to(source, dest), expected)
+        self.assertEqual(dest, expected)
+
+    def test_merge_multiple_by(self):
+        source = {"x": {"by-foo": {"quick": "fox", "default": ["a", "b", "c"]}}}
+        dest = {"x": {"by-bar": {"purple": "rain", "default": ["x", "y", "z"]}}}
+        expected = {
+            "x": {"by-foo": {"quick": "fox", "default": ["a", "b", "c"]}}
+        }  # source wins
+        self.assertEqual(merge_to(source, dest), expected)


### PR DESCRIPTION
This upstreams a pair of changes to this file, one of which is breaking.