### PR TITLE
fix: update ReadOnlyDict to match latest mozbuild vendor

### DIFF
--- a/src/taskgraph/util/readonlydict.py
+++ b/src/taskgraph/util/readonlydict.py
@@ -3,7 +3,9 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # Imported from
-# https://searchfox.org/mozilla-central/rev/c3ebaf6de2d481c262c04bb9657eaf76bf47e2ac/python/mozbuild/mozbuild/util.py#115-127
+# https://searchfox.org/mozilla-central/rev/ece43b04e7baa4680dac46a06d5ad42b27b124f4/python/mozbuild/mozbuild/util.py#102
+
+import copy
 
 
 class ReadOnlyDict(dict):
@@ -20,3 +22,20 @@ class ReadOnlyDict(dict):
 
     def update(self, *args, **kwargs):
         raise Exception("Object does not support update.")
+
+    def __copy__(self, *args, **kwargs):
+        return ReadOnlyDict(**dict.copy(self, *args, **kwargs))
+
+    def __deepcopy__(self, memo):
+        result = {}
+        for k, v in self.items():
+            result[k] = copy.deepcopy(v, memo)
+
+        return ReadOnlyDict(**result)
+
+    def __reduce__(self, *args, **kwargs):
+        """
+        Support for `pickle`.
+        """
+
+        return (self.__class__, (dict(self),))

--- a/test/test_util_readonlydict.py
+++ b/test/test_util_readonlydict.py
@@ -2,45 +2,69 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# Imported from
-# https://searchfox.org/mozilla-central/rev/c3ebaf6de2d481c262c04bb9657eaf76bf47e2ac/python/mozbuild/mozbuild/util.py#115-127
+import copy
+import pickle
 
-import unittest
+import pytest
 
 from taskgraph.util.readonlydict import ReadOnlyDict
 
 
-class TestReadOnlyDict(unittest.TestCase):
-    def test_basic(self):
-        original = {"foo": 1, "bar": 2}
+def test_basic():
+    original = {"foo": 1, "bar": 2}
 
-        test = ReadOnlyDict(original)
+    test = ReadOnlyDict(original)
 
-        self.assertEqual(original, test)
-        self.assertEqual(test["foo"], 1)
+    assert original == test
+    assert test["foo"] == 1
 
-        with self.assertRaises(KeyError):
-            test["missing"]
+    with pytest.raises(KeyError):
+        test["missing"]
 
-        with self.assertRaises(Exception):
-            test["baz"] = True
+    with pytest.raises(Exception):
+        test["baz"] = True
 
-    def test_update(self):
-        original = {"foo": 1, "bar": 2}
 
-        test = ReadOnlyDict(original)
+def test_update():
+    original = {"foo": 1, "bar": 2}
 
-        with self.assertRaises(Exception):
-            test.update(foo=2)
+    test = ReadOnlyDict(original)
 
-        self.assertEqual(original, test)
+    with pytest.raises(Exception):
+        test.update(foo=2)
 
-    def test_del(self):
-        original = {"foo": 1, "bar": 2}
+    assert original == test
 
-        test = ReadOnlyDict(original)
 
-        with self.assertRaises(Exception):
-            del test["foo"]
+def test_del():
+    original = {"foo": 1, "bar": 2}
 
-        self.assertEqual(original, test)
+    test = ReadOnlyDict(original)
+
+    with pytest.raises(Exception):
+        del test["foo"]
+
+    assert original == test
+
+
+def test_copy():
+    d = ReadOnlyDict(foo="bar")
+
+    d_copy = d.copy()
+    assert d == d_copy
+    # TODO Returning a dict here feels like a bug, but there are places in-tree
+    # relying on this behaviour.
+    assert isinstance(d_copy, dict)
+
+    d_copy = copy.copy(d)
+    assert d == d_copy
+    assert isinstance(d_copy, ReadOnlyDict)
+
+    d_copy = copy.deepcopy(d)
+    assert d == d_copy
+    assert isinstance(d_copy, ReadOnlyDict)
+
+
+def test_pickle():
+    d = ReadOnlyDict(foo="bar")
+    pickle.loads(pickle.dumps(d))


### PR DESCRIPTION
The mozbuild version of ReadOnlyDict has a few extra dunder methods that allow copying and pickling it. This discrepency caused some regressions in mozilla-central when we switched over to using the Taskgraph version of it in bug 1901281.

Bug: 1903576