### PR TITLE
fix: make sorting work for toolchain and fetch tasks defined as dicts

### DIFF
--- a/src/taskgraph/transforms/run/__init__.py
+++ b/src/taskgraph/transforms/run/__init__.py
@@ -251,7 +251,9 @@ def use_fetches(config, tasks):
         for kind in sorted(fetches):
             artifacts = fetches[kind]
             if kind in ("fetch", "toolchain"):
-                for artifact in sorted(artifacts):
+                for artifact in sorted(
+                    artifacts, key=lambda a: a if isinstance(a, str) else a["artifact"]
+                ):
                     # Convert name only fetch entries to full fledged ones for
                     # easier processing.
                     if isinstance(artifact, str):

--- a/test/test_transforms_run.py
+++ b/test/test_transforms_run.py
@@ -163,7 +163,7 @@ def assert_use_fetches_toolchain_mixed(task):
                         "toolchain-artifact": "bar.zip",
                     },
                     task={},
-                )
+                ),
             ],
             id="toolchain_mixed",
         ),

--- a/test/test_transforms_run.py
+++ b/test/test_transforms_run.py
@@ -96,6 +96,23 @@ def assert_use_fetches_toolchain_extract_false(task):
     assert fetches[0]["extract"] is False
 
 
+def assert_use_fetches_toolchain_mixed(task):
+    fetches = json.loads(task["worker"]["env"]["MOZ_FETCHES"]["task-reference"])
+    assert len(fetches) == 2
+    assert fetches == [
+        {
+            "artifact": "bar.zip",
+            "extract": True,
+            "task": "<toolchain-bar>",
+        },
+        {
+            "artifact": "target.whl",
+            "extract": False,
+            "task": "<toolchain-foo>",
+        },
+    ]
+
+
 @pytest.mark.parametrize(
     "task,kind_dependencies_tasks",
     (
@@ -127,6 +144,28 @@ def assert_use_fetches_toolchain_extract_false(task):
                 )
             ],
             id="toolchain_extract_false",
+        ),
+        pytest.param(
+            {"fetches": {"toolchain": [{"artifact": "foo", "extract": False}, "bar"]}},
+            [
+                Task(
+                    kind="toolchain",
+                    label="toolchain-foo",
+                    attributes={
+                        "toolchain-artifact": "target.whl",
+                    },
+                    task={},
+                ),
+                Task(
+                    kind="toolchain",
+                    label="toolchain-bar",
+                    attributes={
+                        "toolchain-artifact": "bar.zip",
+                    },
+                    task={},
+                )
+            ],
+            id="toolchain_mixed",
         ),
     ),
 )


### PR DESCRIPTION
Technically not a regression, but a pretty serious oversight in #545