### PR TITLE
feat!: support setting action permissions independently from the call…

### DIFF
--- a/docs/howto/create-actions.rst
+++ b/docs/howto/create-actions.rst
@@ -251,6 +251,37 @@ The feature is illustrated below:
 
 See :doc:`/reference/parameters` for a reference on the available parameters.
 
+Permissions
+...........
+
+Actions can be grouped together with a "permission" string. Scopes can then be
+granted to use these actions in the `fxci-config repo`_. By default, actions
+have the "generic" permission. Any actions with this default "generic" permission,
+can be run in contexts where ``action:generic`` is granted in ``fxci-config``.
+
+But if certain actions are more sensitive, or should be granted in *different* contexts
+than the "generic" ones, you can pass in the ``permission`` argument to ``register_callback_action``:
+
+.. code-block:: python
+
+   from taskgraph.actions.registry import register_callback_action
+
+   @register_callback_action(
+       name='hello',
+       title='Say Hello',
+       symbol='hw',
+       description="Simple **proof-of-concept** callback action",
+       permission="sensitive"
+   )
+   def try_only_action(parameters, graph_config, input, task_group_id, task_id, task):
+       pass
+
+Now, this action can only be run in contexts where ``fxci-config`` grants
+``action:sensitive``. Presumably in more restricted places than
+``action:generic``.
+
+.. _fxci-config repo: https://github.com/mozilla-releng/fxci-config
+
 Creating Tasks
 --------------
 

--- a/docs/reference/migrations.rst
+++ b/docs/reference/migrations.rst
@@ -3,6 +3,18 @@ Migration Guide
 
 This page can help when migrating Taskgraph across major versions.
 
+10.x -> 11.x
+------------
+
+* When defining custom actions with
+  ``taskgraph.actions.registry.register_callback_action``, make the following
+  changes:
+
+  * If you are passing ``generic=True`` to the function, remove this argument.
+  * If the argument isn't present, or you are passing ``generic=False``, then
+    add a new argument called ``permission=<cb_name>``, where ``<cb_name>`` is
+    the value of whatever you are passing to the ``cb_name`` argument.
+
 9.x -> 10.x
 -----------
 

--- a/src/taskgraph/actions/add_new_jobs.py
+++ b/src/taskgraph/actions/add_new_jobs.py
@@ -14,7 +14,6 @@ from taskgraph.actions.util import (
 @register_callback_action(
     name="add-new-jobs",
     title="Add new jobs",
-    generic=True,
     symbol="add-new",
     description="Add new jobs using task labels.",
     order=100,

--- a/src/taskgraph/actions/cancel.py
+++ b/src/taskgraph/actions/cancel.py
@@ -18,7 +18,6 @@ logger = logging.getLogger(__name__)
     title="Cancel Task",
     name="cancel",
     symbol="cx",
-    generic=True,
     description=("Cancel the given task"),
     order=350,
     context=[{}],

--- a/src/taskgraph/actions/cancel_all.py
+++ b/src/taskgraph/actions/cancel_all.py
@@ -23,7 +23,6 @@ logger = logging.getLogger(__name__)
 @register_callback_action(
     title="Cancel All",
     name="cancel-all",
-    generic=True,
     symbol="cAll",
     description=(
         "Cancel all running and pending tasks created by the decision task "

--- a/src/taskgraph/actions/rebuild_cached_tasks.py
+++ b/src/taskgraph/actions/rebuild_cached_tasks.py
@@ -11,6 +11,7 @@ from .util import create_tasks, fetch_graph_and_labels
     title="Rebuild Cached Tasks",
     symbol="rebuild-cached",
     description="Rebuild cached tasks.",
+    permission="rebuild-cached-tasks",
     order=1000,
     context=[],
 )

--- a/src/taskgraph/actions/registry.py
+++ b/src/taskgraph/actions/registry.py
@@ -19,7 +19,7 @@ from taskgraph.util.python_path import import_sibling_modules
 actions = []
 callbacks = {}
 
-Action = namedtuple("Action", ["order", "cb_name", "generic", "action_builder"])
+Action = namedtuple("Action", ["order", "cb_name", "permission", "action_builder"])
 
 
 def is_json(data):
@@ -56,7 +56,7 @@ def register_callback_action(
     context=[],
     available=lambda parameters: True,
     schema=None,
-    generic=True,
+    permission="generic",
     cb_name=None,
 ):
     """
@@ -113,8 +113,10 @@ def register_callback_action(
         schema (dict):
             JSON schema specifying input accepted by the action.
             This is optional and can be left ``null`` if no input is taken.
-        generic (bool)
-            Whether this is a generic action or has its own permissions.
+        permission (str):
+            This defaults to ``generic`` and needs to be set for actions that
+            need additional permissions. It appears in fxci-config and various
+            role and hook names.
         cb_name (str):
             The name under which this function should be registered, defaulting to
             `name`.  This is used to generation actionPerm for non-generic hook
@@ -132,12 +134,15 @@ def register_callback_action(
     title = title.strip()
     description = description.strip()
 
+    if not cb_name:
+        cb_name = name
+
     # ensure that context is callable
     if not callable(context):
         context_value = context
         context = lambda params: context_value  # noqa
 
-    def register_callback(cb, cb_name=cb_name):
+    def register_callback(cb):
         assert isinstance(name, str), "name must be a string"
         assert isinstance(order, int), "order must be an integer"
         assert callable(schema) or is_json(
@@ -152,15 +157,11 @@ def register_callback_action(
         assert not mem[
             "registered"
         ], "register_callback_action must be used as decorator"
-        if not cb_name:
-            cb_name = name
         assert cb_name not in callbacks, f"callback name {cb_name} is not unique"
 
         def action_builder(parameters, graph_config, decision_task_id):
             if not available(parameters):
                 return None
-
-            actionPerm = "generic" if generic else cb_name
 
             # gather up the common decision-task-supplied data for this action
             repository = {
@@ -213,13 +214,13 @@ def register_callback_action(
             # action was named `myaction/release`, then the `*` in the scope would also
             # match that action.  To prevent such an accident, we prohibit `/` in hook
             # names.
-            if "/" in actionPerm:
+            if "/" in permission:
                 raise Exception("`/` is not allowed in action names; use `-`")
 
             if parameters["tasks_for"].startswith("github-pull-request"):
-                hookId = f"in-tree-pr-action-{level}-{actionPerm}/{tcyml_hash}"
+                hookId = f"in-tree-pr-action-{level}-{permission}/{tcyml_hash}"
             else:
-                hookId = f"in-tree-action-{level}-{actionPerm}/{tcyml_hash}"
+                hookId = f"in-tree-action-{level}-{permission}/{tcyml_hash}"
 
             rv.update(
                 {
@@ -243,14 +244,14 @@ def register_callback_action(
                         },
                     },
                     "extra": {
-                        "actionPerm": actionPerm,
+                        "actionPerm": permission,
                     },
                 }
             )
 
             return rv
 
-        actions.append(Action(order, cb_name, generic, action_builder))
+        actions.append(Action(order, cb_name, permission, action_builder))
 
         mem["registered"] = True
         callbacks[cb_name] = cb
@@ -299,13 +300,13 @@ def sanity_check_task_scope(callback, parameters, graph_config):
     else:
         raise ValueError(f"No action with cb_name {callback}")
 
-    actionPerm = "generic" if action.generic else action.cb_name
-
     raw_url = parameters["base_repository"]
     parsed_url = parse(raw_url)
-    action_scope = f"assume:{parsed_url.taskcluster_role_prefix}:action:{actionPerm}"
+    action_scope = (
+        f"assume:{parsed_url.taskcluster_role_prefix}:action:{action.permission}"
+    )
     pr_action_scope = (
-        f"assume:{parsed_url.taskcluster_role_prefix}:pr-action:{actionPerm}"
+        f"assume:{parsed_url.taskcluster_role_prefix}:pr-action:{action.permission}"
     )
 
     # the scope should appear literally; no need for a satisfaction check. The use of

--- a/src/taskgraph/actions/retrigger.py
+++ b/src/taskgraph/actions/retrigger.py
@@ -44,6 +44,7 @@ def _should_retrigger(task_graph, label):
     name="retrigger",
     symbol="rt",
     cb_name="retrigger-decision",
+    permission="retrigger-decision",
     description=textwrap.dedent(
         """\
         Create a clone of the task (retriggering decision, action, and cron tasks requires
@@ -74,7 +75,6 @@ def retrigger_decision_action(parameters, graph_config, input, task_group_id, ta
     title="Retrigger",
     name="retrigger",
     symbol="rt",
-    generic=True,
     description=("Create a clone of the task."),
     order=19,  # must be greater than other orders in this file, as this is the fallback version
     context=[{"retrigger": "true"}],
@@ -105,7 +105,6 @@ def retrigger_decision_action(parameters, graph_config, input, task_group_id, ta
     name="retrigger",
     cb_name="retrigger-disabled",
     symbol="rt",
-    generic=True,
     description=(
         "Create a clone of the task.\n\n"
         "This type of task should typically be re-run instead of re-triggered."
@@ -186,7 +185,6 @@ def retrigger_action(parameters, graph_config, input, task_group_id, task_id):
 @register_callback_action(
     title="Rerun",
     name="rerun",
-    generic=True,
     symbol="rr",
     description=(
         "Rerun a task.\n\n"
@@ -227,7 +225,6 @@ def _rerun_task(task_id, label):
     title="Retrigger",
     name="retrigger-multiple",
     symbol="rt",
-    generic=True,
     description=("Create a clone of the task."),
     context=[],
     schema={

--- a/test/test_actions_registry.py
+++ b/test/test_actions_registry.py
@@ -1,8 +1,52 @@
+from types import FunctionType
+
 import pytest
 from mozilla_repo_urls import InvalidRepoUrlError
 
 from taskgraph.actions import registry
 from test import does_not_raise
+
+
+def test_action(*args, **kwargs):
+    pass
+
+
+def assert_basic(action):
+    assert action.order == 10000
+    assert action.permission == "generic"
+    assert action.cb_name == "test-action"
+    assert isinstance(action.action_builder, FunctionType)
+
+
+def assert_permission(action):
+    assert action.permission == "sensitive"
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    (
+        pytest.param({}, id="basic"),
+        pytest.param({"permission": "sensitive"}, id="permission"),
+    ),
+)
+def test_register_callback_action(request, monkeypatch, kwargs):
+    actions = []
+    callbacks = {}
+    monkeypatch.setattr(registry, "actions", actions)
+    monkeypatch.setattr(registry, "callbacks", callbacks)
+
+    kwargs.setdefault("name", "test-action")
+    kwargs.setdefault("title", "Test Action")
+    kwargs.setdefault("symbol", "ta")
+    kwargs.setdefault("description", "Used for a test")
+
+    cb = registry.register_callback_action(**kwargs)(test_action)
+    assert cb == test_action
+    assert len(actions) == 1
+
+    param_id = request.node.callspec.id
+    assert_func = globals()[f"assert_{param_id}"]
+    assert_func(actions[0])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
…back name

BREAKING CHANGE: register_action_callback interface has changed

This is a port of Gecko's:
https://hg.mozilla.org/mozilla-central/rev/71961455f5a1b734bfc934c9569757d280e57eb8