### PR TITLE
fix: typedef for TaskGraph.tasks

### DIFF
--- a/src/taskgraph/taskgraph.py
+++ b/src/taskgraph/taskgraph.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from dataclasses import dataclass
-from typing import List
+from typing import Dict
 
 from .graph import Graph
 from .task import Task
@@ -21,7 +21,7 @@ class TaskGraph:
     tasks are "linked from" their dependents.
     """
 
-    tasks: List[Task]
+    tasks: Dict[str, Task]
     graph: Graph
 
     def __post_init__(self):


### PR DESCRIPTION
This was a small oversight in https://github.com/taskcluster/taskgraph/pull/264; TaskGraph.tasks is quite clearly a dict, as evidenced by code such as:
```
        for task_label in self.graph.visit_postorder():
            task = self.tasks[task_label]
            f(task, self, *args, **kwargs)
```