### PR TITLE
Remove useless tasks list allocation in `transforms.docker_image`

### DIFF
--- a/src/taskgraph/transforms/docker_image.py
+++ b/src/taskgraph/transforms/docker_image.py
@@ -75,8 +75,6 @@ def fill_template(config, tasks):
 
     context_hashes = {}
 
-    tasks = list(tasks)
-
     if not taskgraph.fast and config.write_artifacts:
         if not os.path.isdir(CONTEXTS_DIR):
             os.makedirs(CONTEXTS_DIR)


### PR DESCRIPTION
This was allocating a list of tasks from the passed in `tasks` generator before iterating over it. The reason this was here is because when that code got imported into this repo, (see be320c2b3a22c03d5fe7583f761456f75267c9b0), it was reordering the tasks before iterating over them. Said reordering got removed in ff0097edea821f8bab8ac9975f3ffc740956d683 but the allocation stayed.

I'm not expecting this to have any impact whatsoever but it confused me and ended up being useless so we might as well remove it.