### PR TITLE
fix!: stop hardcoding path to Python in MacOS generic-worker tasks

### DIFF
--- a/docs/reference/migrations.rst
+++ b/docs/reference/migrations.rst
@@ -3,6 +3,20 @@ Migration Guide
 
 This page can help when migrating Taskgraph across major versions.
 
+10.x -> 11.x
+------------
+
+* A hardcoded path to a Python installation was removed for MacOS
+  generic-workers. If Mac tasks start failing after upgrade and you are able to
+  change the worker environment, ensure the ``python3`` binary is available on
+  the ``$PATH``. If you cannot change the worker environment, add the following
+  to the definitions of the failing tasks:
+
+  .. code-block:: yaml
+
+     run:
+       run-task-command: ["/tools/python36/bin/python3", "run-task"]
+
 9.x -> 10.x
 -----------
 

--- a/src/taskgraph/transforms/run/run_task.py
+++ b/src/taskgraph/transforms/run/run_task.py
@@ -165,15 +165,12 @@ def generic_worker_run_task(config, task, taskdesc):
     run = task["run"]
     worker = taskdesc["worker"] = task["worker"]
     is_win = worker["os"] == "windows"
-    is_mac = worker["os"] == "macosx"
     is_bitbar = worker["os"] == "linux-bitbar"
 
     command = run.pop("run-task-command", None)
     if not command:
         if is_win:
             command = ["C:/mozilla-build/python3/python3.exe", "run-task"]
-        elif is_mac:
-            command = ["/tools/python36/bin/python3", "run-task"]
         else:
             command = ["./run-task"]
 


### PR DESCRIPTION
BREAKING CHANGE: Path to Python installation on MacOS no longer hardcoded.