### PR TITLE
feat(config): implement 'get()' for GraphConfig

### DIFF
--- a/src/taskgraph/config.py
+++ b/src/taskgraph/config.py
@@ -106,6 +106,9 @@ class GraphConfig:
     def __contains__(self, name):
         return name in self._config
 
+    def get(self, name):
+        return self._config.get(name)
+
     def register(self):
         """
         Add the project's taskgraph directory to the python path, and register

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,28 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from taskgraph.config import GraphConfig
+
+
+def test_graph_config_basic():
+    graph_config = GraphConfig({"foo": "bar"}, "root")
+
+    assert "foo" in graph_config
+    assert graph_config["foo"] == "bar"
+    assert graph_config.get("foo") == "bar"
+
+    assert "missing" not in graph_config
+    assert graph_config.get("missing") is None
+
+    with pytest.raises(KeyError):
+        graph_config["missing"]
+
+    # does not support assignment
+    with pytest.raises(TypeError):
+        graph_config["foo"] = "different"
+
+    with pytest.raises(TypeError):
+        graph_config["baz"] = 2


### PR DESCRIPTION
I keep tripping up over the fact that `graph_config` isn't a dict and trying to use things like `get`. Maybe we should make it subclass a dict, but for now simply implementing `.get()` will solve most of my problems.