### PR TITLE
Don't chmod /dev/kvm if it already has the right mode

### DIFF
--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -1148,7 +1148,10 @@ def main(args):
     if running_as_root and os.path.exists("/dev/kvm"):
         # Ensure kvm permissions for worker, required for Android x86
         st = os.stat("/dev/kvm")
-        os.chmod("/dev/kvm", st.st_mode | 0o666)
+
+        # Podman mounts `/dev/kvm` as 0o666 already and doesn't allow chmoding it
+        if stat.S_IMODE(st.st_mode) != 0o666:
+            os.chmod("/dev/kvm", st.st_mode | 0o666)
 
     # Validate caches.
     #


### PR DESCRIPTION
This fixes using `run-task` in privileged podman containers