### PR TITLE
feat: add 'project' and 'trust-domain' to set of tags applied to all …

### DIFF
--- a/src/taskgraph/transforms/task.py
+++ b/src/taskgraph/transforms/task.py
@@ -1114,6 +1114,8 @@ def build_task(config, tasks):
                 "createdForUser": config.params["owner"],
                 "kind": config.kind,
                 "label": task["label"],
+                "project": config.params["project"],
+                "trust-domain": config.graph_config["trust-domain"],
             }
         )
 

--- a/test/test_transforms_task.py
+++ b/test/test_transforms_task.py
@@ -43,6 +43,15 @@ def assert_common(task_dict):
     assert "extra" in task_dict["task"]
     assert "payload" in task_dict["task"]
     assert "routes" in task_dict["task"]
+    assert task_dict["task"].get("tags", {}) == {
+        "createdForUser": "some-owner",
+        "kind": "test",
+        "label": "test-fake-task-name",
+        "os": "linux",
+        "project": "some-project",
+        "trust-domain": "test-domain",
+        "worker-implementation": "docker-worker",
+    }
     assert (
         "index.test-domain.v2.some-project.latest.fake.fake-job"
         in task_dict["task"]["routes"]


### PR DESCRIPTION
…tasks

Task tags will show up in the Firefox-CI ETL, so adding these tags will make it possible to group costs by project and trust domain respectively.

Note that Taskgraph is already inconsistent with the global tags it applies. There is `worker-implementation` and `createdForUser`. I decided to use dashes instead of camel case, but don't have a strong preference. We should make the tag format consistent, but that's a breaking change which I'll leave for another time.