### PR TITLE
actions: look up action tasks by revision in fetch_graph_and_labels

### DIFF
--- a/src/taskgraph/actions/util.py
+++ b/src/taskgraph/actions/util.py
@@ -64,12 +64,19 @@ def fetch_graph_and_labels(parameters, graph_config, task_group_id=None):
                     raise
                 logger.debug(f"No label-to-taskid.json found for {task_id}: {e}")
 
-        namespace = "{}.v2.{}.pushlog-id.{}.actions".format(
+        # for backwards compatibility, look up actions via pushlog-id
+        pushlog_namespace = "{}.v2.{}.pushlog-id.{}.actions".format(
             graph_config["trust-domain"],
             parameters["project"],
             parameters["pushlog_id"],
         )
-        for task_id in list_tasks(namespace):
+        # ... but also look by revision, since github doesn't have pushlog-id
+        rev_namespace = "{}.v2.{}.revision.{}.actions".format(
+            graph_config["trust-domain"],
+            parameters["project"],
+            parameters["head_rev"],
+        )
+        for task_id in set(list_tasks(pushlog_namespace) + list_tasks(rev_namespace)):
             fetches.append(e.submit(fetch_action, task_id))
 
         # Similarly for cron tasks..


### PR DESCRIPTION
Projects on github don't have a meaningful pushlog-id, so we don't use it in the index path for action tasks.  When building the label-to-taskid mapping for a revision, look up action tasks in the index using the head_rev, where we can actually find them.

This can potentially do the wrong thing if a revision is pushed to two different branches, where we'd be mixing up the graphs, but we don't currently include the branch name in the index paths.