### PR TITLE
fix(decision): ensure 'taskgraph' is on the $PATH in Decision image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [11.2.2] - 2024-10-15
+
+### Fixed
+
+- Regression in Decision image where `taskgraph` was no longer on the $PATH
+- Decision image no longer contains root owned `uv` cache
+- `uv` now included in the `run-task` image
+
 ## [11.2.1] - 2024-10-03
 
 ### Fixed

--- a/src/taskgraph/__init__.py
+++ b/src/taskgraph/__init__.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-__version__ = "11.2.1"
+__version__ = "11.2.2"
 
 # Maximum number of dependencies a single task can have
 # https://docs.taskcluster.net/docs/reference/platform/queue/api#createTask

--- a/taskcluster/docker/decision/system-setup.sh
+++ b/taskcluster/docker/decision/system-setup.sh
@@ -10,8 +10,8 @@ apt-get install -y --force-yes --no-install-recommends \
 
 pushd /setup/taskgraph
 uv export --no-dev > /setup/requirements.txt
-uv pip install --system --break-system-packages -r /setup/requirements.txt
-uv pip install --system --break-system-packages --no-deps .
+uv pip install --no-cache --system --break-system-packages -r /setup/requirements.txt
+uv pip install --no-cache --system --break-system-packages --no-deps .
 popd
 
 apt-get clean

--- a/taskcluster/docker/decision/system-setup.sh
+++ b/taskcluster/docker/decision/system-setup.sh
@@ -11,6 +11,7 @@ apt-get install -y --force-yes --no-install-recommends \
 pushd /setup/taskgraph
 uv export --no-dev > /setup/requirements.txt
 uv pip install --system --break-system-packages -r /setup/requirements.txt
+uv pip install --system --break-system-packages --no-deps .
 popd
 
 apt-get clean


### PR DESCRIPTION
This was regressed by the switch to `uv` for packaging in the Decision image.