### PR TITLE
fix: Improve command_static_url repack archive logic

### DIFF
--- a/src/taskgraph/run-task/fetch-content
+++ b/src/taskgraph/run-task/fetch-content
@@ -435,11 +435,49 @@ def extract_archive(path, dest_dir):
     log("%s extracted in %.3fs" % (path, time.time() - t0))
 
 
+def should_repack_archive(orig: pathlib.Path, dest: pathlib.Path, strip_components=0, add_prefix="") -> bool:
+    """
+    Determines whether we should attempt to repack an archive based on the naming conventions used
+    in the original file path, the destination file path, and any modifications such as stripping
+    components or adding a prefix.
+    """
+
+    if strip_components or add_prefix:
+        # If strip_components or add_prefix is specified, we should always repack.
+        return True
+
+    if orig.suffixes == dest.suffixes:
+        # If all suffixes are exactly the same, then a rename will suffice.
+        return False
+
+    if dest.suffixes[-2:] == [".tar", ".zst"]:
+        # If the destination is a ".tar.zst" file then we will always try to repack it ourselves.
+        return True
+
+    if orig.suffix == dest.suffix:
+        # If the final suffix is the same, this is likely just a rename.
+        #
+        # This may be a case where multiple suffixes were detected unnecessarily due to the file name
+        # containing a semantic version. For example the file "python-3.8.10-amd64.exe" would be detected
+        # to have three suffixes [".8", ".10-amd64", ".exe"]. Changing this to "python.exe" should be a
+        # simple rename, rather than a repack.
+        #
+        # In this case, we will try to determine if the original path has a supported archive suffix.
+        # If the original path is detected to be an archive, we will try to repack, otherwise rename.
+        return archive_type(orig) is not None
+
+    # Otherwise, if the paths aren't the same, assume it's an archive and try to repack.
+    #
+    # It would be best to fail early if the repack fails than to fail during a test because a renamed
+    # file was incorrect type after all.
+    return True
+
+
 def repack_archive(
     orig: pathlib.Path, dest: pathlib.Path, strip_components=0, prefix=""
 ):
     assert orig != dest
-    log("Repacking as %s" % dest)
+    log(f"Repacking {orig} as {dest}")
     orig_typ, ifh = open_stream(orig)
     typ = archive_type(dest)
     if not typ:
@@ -533,6 +571,9 @@ def repack_archive(
             else:
                 # We only change compression here. The tar stream is unchanged.
                 ctx.copy_stream(ifh, fh)
+
+        else:
+            raise Exception(f"Attempt to repack an archive of unsupported type {orig_typ}")
 
 
 def fetch_and_extract(url, dest_dir, extract=True, sha256=None, size=None):
@@ -773,8 +814,13 @@ def command_static_url(args):
         if gpg_sig_url:
             gpg_verify_path(dl_dest, gpg_key, gpg_signature)
 
-        if dl_dest != dest or args.strip_components or args.add_prefix:
-            repack_archive(dl_dest, dest, args.strip_components, args.add_prefix)
+        if dl_dest != dest:
+            if should_repack_archive(dl_dest, dest, args.strip_components, args.add_prefix):
+                repack_archive(dl_dest, dest, args.strip_components, args.add_prefix)
+            else:
+                log(f"Renaming {dl_dest} to {dest}")
+                dl_dest.rename(dest)
+
     except Exception:
         try:
             dl_dest.unlink()
@@ -783,7 +829,7 @@ def command_static_url(args):
 
         raise
 
-    if dl_dest != dest:
+    if dl_dest != dest and dl_dest.exists():
         log("Removing %s" % dl_dest)
         dl_dest.unlink()
 


### PR DESCRIPTION
### Description

This patch improves the logic of static URL fetch tasks to better be able to determine if a file simply needs to be renamed, or if it is an archive that needs to be repackaged.

---

### Background

I was attempting to add the following fetch task to Firefox CI:
```
translations.esen.model:
    description: The Spanish to English translation model artifact (version 1.0)
    fetch:
        artifact-name: model.esen.intgemm.alphas.bin
        type: static-url
        url: https://firefox-settings-attachments.cdn.mozilla.net/main-workspace/translations-models/9ee26e91-9b52-44ba-8d30-c0230dd587b2.bin
        sha256: 4b6b7f451094aaa447d012658af158ffc708fc8842dde2f871a58404f5457fe0
        size: 17140755
```

The issue is that the downloaded artifact (`dl_path`) is `9ee26e91-9b52-44ba-8d30-c0230dd587b2.bin`, however the desired artifact-name (`path`) is `model.esen.intgemm.alphas.bin`

If you look at the [log file](https://firefoxci.taskcluster-artifacts.net/WV5c2R_-Rda0oTLMilu4dw/0/public/logs/live_backing.log) for this fetch task in the current state of the code, you will see:
```
[task 2024-10-14T17:35:43.004Z] ArchiveTypeNotSupported: Archive type not supported for /builds/worker/artifacts/9ee26e91-9b52-44ba-8d30-c0230dd587b2.bin
```

---

### The Problem

The problem lies in [these lines of code](https://github.com/taskcluster/taskgraph/blob/86210faa82d387068d0d66a133fdc9084d295e6e/src/taskgraph/run-task/fetch-content#L763-L766) where we compare the suffixes for the file. If the suffixes don't match exactly, then we [treat it as an archive that needs to be repacked](https://github.com/taskcluster/taskgraph/blob/86210faa82d387068d0d66a133fdc9084d295e6e/src/taskgraph/run-task/fetch-content#L776-L777). 

I added some [extra logging](https://firefoxci.taskcluster-artifacts.net/fb0j1RedRRSRNvrBRUgQ4Q/0/public/logs/live_backing.log) (prefixed by `!!!`), and you can see that my original file only has the suffix of `.bin`, but the detination file has the suffixes of `['.esen', '.intgemm', '.alphas', '.bin']`. This causes it to be unnecessarily treated as an archive, which fails the fetch. 

Now, this isn't the only case of a suffix mismatch that should be a rename. Consider [this example](https://firefoxci.taskcluster-artifacts.net/cD12GO3VQWymzhUjk7cpOg/0/public/logs/live_backing.log). 

In this case we have the file `python-3.8.10-amd64.exe`, which has the detected suffixes of `['.8', '.10-amd64', '.exe']` due to the semantic version being included in the file name. This fetch task _happens_ to be working in production because we are not renaming the artifact and the suffixes happen to match. However, if we were to try to do `artifact-name: python.exe`, we would run into the same situation where the suffixes mismatch (`['.8', '.10-amd64', '.exe']` vs. `['.exe']`) and the `.exe` file would be treated as an archive, which would result in the fetch task failing. 

---

### The Solution

I have attempted to amend the code in a way that is both backward compatible with all of the current fetch tasks, and that is forward compatible with the naming conventions that I need to support with multiple suffixes. This code attempts to determine whether a file simply needs to be renamed, or whether it is an archive that needs to be repacked. 

You can see a working group of fetch tasks here: 
https://treeherder.mozilla.org/jobs?repo=try&revision=1cd59eed16adb9711a73e4d27cf253ffe3b3e100

I've also added some extra pytests to this repository. 

---

### The Outcome

My hope is that we can get these changes approved and published as a dot release, then re-vendored into the Firefox source tree so that I can land my new fetch tasks as soon as possible. 
