### PR TITLE
fix(decision): add --no-cache to another uv command

### DIFF
--- a/taskcluster/docker/decision/system-setup.sh
+++ b/taskcluster/docker/decision/system-setup.sh
@@ -9,7 +9,7 @@ apt-get install -y --force-yes --no-install-recommends \
     python3-pip
 
 pushd /setup/taskgraph
-uv export --no-dev > /setup/requirements.txt
+uv export --no-cache --no-dev > /setup/requirements.txt
 uv pip install --no-cache --system --break-system-packages -r /setup/requirements.txt
 uv pip install --no-cache --system --break-system-packages --no-deps .
 popd


### PR DESCRIPTION
We don't want to leave a root-owned cache in the worker user's HOME directory.