### PR TITLE
fix(decision): cleanup temporary uv lockfiles

### DIFF
--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -1012,9 +1012,10 @@ def install_pip_requirements(repositories):
 
     # TODO: Stop using system Python (#381)
     if shutil.which("uv"):
-        cmd = ["uv", "pip", "install", "--python", sys.executable, "--break-system-packages"]
+        user_site_dir = subprocess.run([sys.executable, "-msite", "--user-site"], capture_output=True, text=True).stdout.strip()
+        cmd = ["uv", "pip", "install", "--python", sys.executable, "--target", user_site_dir]
     else:
-        cmd = [sys.executable, "-mpip", "install", "--break-system-packages"]
+        cmd = [sys.executable, "-mpip", "install", "--user", "--break-system-packages"]
 
     if os.environ.get("PIP_DISABLE_REQUIRE_HASHES") != "1":
         cmd.append("--require-hashes")

--- a/taskcluster/docker/decision/system-setup.sh
+++ b/taskcluster/docker/decision/system-setup.sh
@@ -18,3 +18,4 @@ apt-get clean
 apt-get autoclean
 rm -rf /var/lib/apt/lists/
 rm -rf /setup
+rm /tmp/uv-*.lock

--- a/test/test_scripts_run_task.py
+++ b/test/test_scripts_run_task.py
@@ -1,5 +1,6 @@
 import io
 import os
+import site
 import stat
 import subprocess
 import sys
@@ -85,6 +86,7 @@ def test_install_pip_requirements(
             sys.executable,
             "-mpip",
             "install",
+            "--user",
             "--break-system-packages",
             "--require-hashes",
             "-r",
@@ -105,6 +107,7 @@ def test_install_pip_requirements(
             sys.executable,
             "-mpip",
             "install",
+            "--user",
             "--break-system-packages",
             "--require-hashes",
             "-r",
@@ -137,7 +140,8 @@ def test_install_pip_requirements_with_uv(
             "install",
             "--python",
             sys.executable,
-            "--break-system-packages",
+            "--target",
+            site.getusersitepackages(),
             "--require-hashes",
             "-r",
             str(req),


### PR DESCRIPTION
This was causing problems, as the `worker` user was trying to create the same file, but it already existed and was owned by `root`.

Ensure we don't leave these lying around.