### PR TITLE
fix: ensure strip_components and add_prefix are respected in repack_archive

### DIFF
--- a/src/taskgraph/run-task/fetch-content
+++ b/src/taskgraph/run-task/fetch-content
@@ -814,12 +814,11 @@ def command_static_url(args):
         if gpg_sig_url:
             gpg_verify_path(dl_dest, gpg_key, gpg_signature)
 
-        if dl_dest != dest:
-            if should_repack_archive(dl_dest, dest, args.strip_components, args.add_prefix):
-                repack_archive(dl_dest, dest, args.strip_components, args.add_prefix)
-            else:
-                log(f"Renaming {dl_dest} to {dest}")
-                dl_dest.rename(dest)
+        if should_repack_archive(dl_dest, dest, args.strip_components, args.add_prefix):
+            repack_archive(dl_dest, dest, args.strip_components, args.add_prefix)
+        elif dl_dest != dest:
+            log(f"Renaming {dl_dest} to {dest}")
+            dl_dest.rename(dest)
 
     except Exception:
         try:


### PR DESCRIPTION
In #591 I implemented a new function [should_repack_archive](https://github.com/taskcluster/taskgraph/blob/70654ce321c7b1bea7553895dc9a02c78757dab8/src/taskgraph/run-task/fetch-content#L438-L473) that aimed to improve the robustness of renaming files while preserving the preexisting logic of when to repack an archive in a fetch task. 

Unfortunately, I left an outer if-statement that leaves one edge case in which the behavior is slightly changed.

Whenever `args.strip_components` or `args.add_prefix` is defined, we are supposed to repack the archive regardless, however the new logic stays to do it only if the files are not the same. 

The logic is correct within the new function, but the outer if-statement needs to be removed. 
