### PR TITLE
Fix readthedocs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,13 +1,14 @@
 ---
 version: 2
 build:
-    os: ubuntu-20.04
+    os: ubuntu-22.04
     tools:
-        python: "3.9"
-python:
-    install:
-        - requirements: requirements/docs.txt
-        - method: pip
-          path: .
+        python: "3.12"
+    commands:
+        - asdf plugin add uv
+        - asdf install uv latest
+        - asdf global uv latest
+        - uv sync --only-dev
+        - uv run -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
 sphinx:
     configuration: docs/conf.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,0 @@
-include requirements/base.in
-include requirements/base.txt
-include requirements/test.in
-include requirements/test.txt
-include requirements/dev.in
-include requirements/dev.txt


### PR DESCRIPTION
The fix was copy/pasted directly from the readthedocs documentation:
https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-uv