### PR TITLE
feat(cli): support --parameters=index:<index path>

### DIFF
--- a/docs/howto/run-locally.rst
+++ b/docs/howto/run-locally.rst
@@ -78,6 +78,8 @@ following formats are accepted:
   and used.
 * A value of ``project=<project>``. The ``parameters.yml`` artifact from the
   latest decision task on ``<project>`` will be downloaded and used.
+* A value of ``index=<index>``. The ``parameters.yml`` artifact will be
+  downloaded from the decision task pointed to by the specified index path.
 * Path to a directory containing multiple parameter files. Any ``.yml`` file in
   the directory will be considered a parameter set.
 

--- a/src/taskgraph/parameters.py
+++ b/src/taskgraph/parameters.py
@@ -193,7 +193,7 @@ class Parameters(ReadOnlyDict):
         if spec is None:
             return "defaults"
 
-        if any(spec.startswith(s) for s in ("task-id=", "project=")):
+        if any(spec.startswith(s) for s in ("task-id=", "project=", "index=")):
             return spec
 
         result = urlparse(spec)
@@ -327,16 +327,19 @@ def load_parameters_file(
         task_id = None
         if spec.startswith("task-id="):
             task_id = spec.split("=")[1]
-        elif spec.startswith("project="):
-            if trust_domain is None:
-                raise ValueError(
-                    "Can't specify parameters by project "
-                    "if trust domain isn't supplied.",
+        elif spec.startswith("project=") or spec.startswith("index="):
+            if spec.startswith("project="):
+                if trust_domain is None:
+                    raise ValueError(
+                        "Can't specify parameters by project "
+                        "if trust domain isn't supplied.",
+                    )
+                index = "{trust_domain}.v2.{project}.latest.taskgraph.decision".format(
+                    trust_domain=trust_domain,
+                    project=spec.split("=")[1],
                 )
-            index = "{trust_domain}.v2.{project}.latest.taskgraph.decision".format(
-                trust_domain=trust_domain,
-                project=spec.split("=")[1],
-            )
+            else:
+                index = spec.split("=")[1]
             task_id = find_task_id(index)
 
         if task_id:

--- a/test/test_parameters.py
+++ b/test/test_parameters.py
@@ -151,6 +151,7 @@ class TestParameters(TestCase):
         tid = "abc"
         project = "foo"
         trust_domain = "bar"
+        index = f"{trust_domain}.v2.{project}.latest.taskgraph.cron"
         expected = {"some": "data"}
 
         # Setup mocks
@@ -170,6 +171,14 @@ class TestParameters(TestCase):
         )
         self.assertEqual(dict(ret), expected)
         self.assertRaises(ValueError, load_parameters_file, f"project={project}")
+
+        # Test `index=`
+        ret = load_parameters_file(f"index={index}")
+        mock_load_stream.assert_called_with(mock_urlopen())
+        mock_find_task_id.assert_called_with(
+            f"{trust_domain}.v2.{project}.latest.taskgraph.cron"
+        )
+        self.assertEqual(dict(ret), expected)
 
         # Test gzipped data
         r = mock.Mock()
@@ -238,6 +247,7 @@ def test_parameters_id():
         ("http://example.org/bar.yml?id=0", "bar"),
         ("task-id=123", "task-id=123"),
         ("project=autoland", "project=autoland"),
+        ("index=foo.v2.bar.latest", "index=foo.v2.bar.latest"),
     ),
 )
 def test_parameters_format_spec(spec, expected):


### PR DESCRIPTION
Currently we support finding the decision task id based on `project`, from the index, but sometimes we want to find other types of ids (e.g for cron decision tasks).