### PR TITLE
Don't assume the proxy is running on `http://taskcluster`

### DIFF
--- a/src/taskgraph/create.py
+++ b/src/taskgraph/create.py
@@ -124,7 +124,9 @@ def create_task(session, task_id, label, task_def):
         return
 
     logger.info(f"Creating task with taskId {task_id} for {label}")
-    proxy_url = os.environ.get("TASKCLUSTER_PROXY_URL", "http://taskcluster")
+    proxy_url = os.environ.get("TASKCLUSTER_PROXY_URL", "http://taskcluster").rstrip(
+        "/"
+    )
     res = session.put(
         f"{proxy_url}/queue/v1/task/{task_id}",
         json=task_def,

--- a/src/taskgraph/create.py
+++ b/src/taskgraph/create.py
@@ -5,6 +5,7 @@
 
 import json
 import logging
+import os
 import sys
 from concurrent import futures
 
@@ -123,7 +124,11 @@ def create_task(session, task_id, label, task_def):
         return
 
     logger.info(f"Creating task with taskId {task_id} for {label}")
-    res = session.put(f"http://taskcluster/queue/v1/task/{task_id}", json=task_def)
+    proxy_url = os.environ.get("TASKCLUSTER_PROXY_URL", "http://taskcluster")
+    res = session.put(
+        f"{proxy_url}/queue/v1/task/{task_id}",
+        json=task_def,
+    )
     if res.status_code != 200:
         try:
             logger.error(res.json()["message"])

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -39,7 +39,7 @@ from pathlib import Path
 from threading import Thread
 from typing import Optional
 
-SECRET_BASEURL_TPL = "http://taskcluster/secrets/v1/secret/{}"
+SECRET_BASEURL_TPL = "{}/secrets/v1/secret/{{}}".format(os.environ.get("TASKCLUSTER_PROXY_URL", "http://taskcluster"))
 
 GITHUB_SSH_FINGERPRINT = (
     b"github.com ssh-ed25519 "

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -39,7 +39,7 @@ from pathlib import Path
 from threading import Thread
 from typing import Optional
 
-SECRET_BASEURL_TPL = "{}/secrets/v1/secret/{{}}".format(os.environ.get("TASKCLUSTER_PROXY_URL", "http://taskcluster"))
+SECRET_BASEURL_TPL = "{}/secrets/v1/secret/{{}}".format(os.environ.get("TASKCLUSTER_PROXY_URL", "http://taskcluster").rstrip('/'))
 
 GITHUB_SSH_FINGERPRINT = (
     b"github.com ssh-ed25519 "


### PR DESCRIPTION
This fixes the two places where taskgraph assumed the proxy would be running on `http://taskcluster` instead of looking at the `TASKCLUSTER_PROXY_URL` environment variable.