### PR TITLE
Do not apply skip-unless-changed for cron triggers.

### DIFF
--- a/docs/reference/optimization-strategies.rst
+++ b/docs/reference/optimization-strategies.rst
@@ -10,15 +10,11 @@ Strategies for Removing Tasks
 skip-unless-changed
 ~~~~~~~~~~~~~~~~~~~
 
-.. note::
-
-   This strategy is only implemented for Mercurial repositories hosted on
-   ``hg.mozilla.org``.
-
 The :class:`skip-unless-changed
 <taskgraph.optimize.strategies.SkipUnlessChanged>` strategy will optimize the
-target task away *unless* a specified file is modified. Glob patterns are
-supported.
+target task away *unless* a specified file is modified. When there is no
+difference between head and base revs (for example, cron or action tasks), this
+optimization will not apply. Glob patterns are supported.
 
 Example:
 

--- a/src/taskgraph/optimize/strategies.py
+++ b/src/taskgraph/optimize/strategies.py
@@ -80,8 +80,9 @@ class SkipUnlessChanged(OptimizationStrategy):
         return False
 
     def should_remove_task(self, task, params, file_patterns):
-        # pushlog_id == -1 - this is the case when run from a cron.yml job or on a git repository
-        if params.get("repository_type") == "hg" and params.get("pushlog_id") == -1:
+        # skip-unless-changed should not apply when there is no commit delta,
+        # such as for cron and action tasks (there will never be file changes)
+        if params.get("head_rev") == params.get("base_rev"):
             return False
 
         changed = self.check(params["files_changed"], file_patterns)

--- a/src/taskgraph/optimize/strategies.py
+++ b/src/taskgraph/optimize/strategies.py
@@ -82,7 +82,7 @@ class SkipUnlessChanged(OptimizationStrategy):
     def should_remove_task(self, task, params, file_patterns):
         # skip-unless-changed should not apply when there is no commit delta,
         # such as for cron and action tasks (there will never be file changes)
-        if params.get("head_rev") == params.get("base_rev"):
+        if params.get("base_rev") and params.get("head_rev") == params.get("base_rev"):
             return False
 
         changed = self.check(params["files_changed"], file_patterns)

--- a/test/test_optimize_strategies.py
+++ b/test/test_optimize_strategies.py
@@ -135,7 +135,7 @@ def test_index_search(caplog, responses, params, state, expires, expected, logs)
             {"files_changed": ["bar.txt"]}, ["foo.txt"], True, id="files don't match"
         ),
         pytest.param(
-            {"repository_type": "hg", "pushlog_id": -1, "files_changed": ["bar.txt"]},
+            {"head_rev": "8843d7f92416211de9ebb963ff4ce28125932878", "base_rev": "8843d7f92416211de9ebb963ff4ce28125932878", "files_changed": ["bar.txt"]},
             ["foo.txt"],
             False,
             id="cron task",

--- a/test/test_optimize_strategies.py
+++ b/test/test_optimize_strategies.py
@@ -135,7 +135,11 @@ def test_index_search(caplog, responses, params, state, expires, expected, logs)
             {"files_changed": ["bar.txt"]}, ["foo.txt"], True, id="files don't match"
         ),
         pytest.param(
-            {"head_rev": "8843d7f92416211de9ebb963ff4ce28125932878", "base_rev": "8843d7f92416211de9ebb963ff4ce28125932878", "files_changed": ["bar.txt"]},
+            {
+                "head_rev": "8843d7f92416211de9ebb963ff4ce28125932878",
+                "base_rev": "8843d7f92416211de9ebb963ff4ce28125932878",
+                "files_changed": ["bar.txt"],
+            },
             ["foo.txt"],
             False,
             id="cron task",


### PR DESCRIPTION
If we want a little more flexibility, we could add an additional optional parameter to turn this behavior on or off (there _might_ be some utility in tasks that strictly only run if some files changed, so that you can trigger all tasks with cron and those will be optimized away).