### PR TITLE
fix: use base repo for project name in github .taskcluster.yml template

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -34,7 +34,7 @@ tasks:
           project:
               $switch:
                   'tasks_for in ["github-push", "github-release"]': '${event.repository.name}'
-                  'tasks_for[:19] == "github-pull-request"': '${event.pull_request.head.repo.name}'
+                  'tasks_for[:19] == "github-pull-request"': '${event.pull_request.base.repo.name}'
                   'tasks_for in ["cron", "action", "pr-action"]': '${repository.project}'
           head_branch:
               $switch:

--- a/template/{{cookiecutter.project_name}}/taskcluster.github.yml
+++ b/template/{{cookiecutter.project_name}}/taskcluster.github.yml
@@ -32,7 +32,7 @@ tasks:
           project:
               $switch:
                   'tasks_for in ["github-push", "github-release"]': '${event.repository.name}'
-                  'tasks_for[:19] == "github-pull-request"': '${event.pull_request.head.repo.name}'
+                  'tasks_for[:19] == "github-pull-request"': '${event.pull_request.base.repo.name}'
                   'tasks_for in ["cron", "action", "pr-action"]': '${repository.project}'
           head_branch:
               $switch:


### PR DESCRIPTION
project name is mainly used in routes, which require specific scopes to be set. Because of this, we should always use the `base` version of this. In cases where the `head` repository has a different name this ends up breaking things like actions in PRs.