### PR TITLE
chore: fix head_ref detection in 'release' target tasks method

### DIFF
--- a/taskcluster/self_taskgraph/custom_target_tasks.py
+++ b/taskcluster/self_taskgraph/custom_target_tasks.py
@@ -9,7 +9,8 @@ def target_tasks_release(full_task_graph, parameters, graph_config):
 
     # Ensure we don't run `taskcluster-taskgraph` release tasks when publishing
     # `pytest-taskgraph`.
-    if parameters["head_ref"].startswith("refs/tags/pytest-taskgraph"):
+    head_ref = parameters.rsplit("/", 1)[-1]
+    if head_ref.startswith("pytest-taskgraph"):
         tasks = {
             l: t
             for l, t in tasks.items()

--- a/taskcluster/test/params/main-repo-release-pytest-taskgraph.yml
+++ b/taskcluster/test/params/main-repo-release-pytest-taskgraph.yml
@@ -12,10 +12,10 @@ files_changed:
   - test/test_decision.py
 filters:
   - target_tasks_method
-head_ref: refs/tags/pytest-taskgraph-v1.0.0
+head_ref: pytest-taskgraph-v1.0.0
 head_repository: https://github.com/taskcluster/taskgraph
-head_rev: release-test
-head_tag: pytest-taskgraph-v1.0.0
+head_rev: pytest-taskgraph-v1.0.0
+head_tag: ''
 level: '3'
 moz_build_date: '20240207083344'
 next_version: null

--- a/taskcluster/test/params/main-repo-release-taskcluster-taskgraph.yml
+++ b/taskcluster/test/params/main-repo-release-taskcluster-taskgraph.yml
@@ -12,10 +12,10 @@ files_changed:
   - test/test_decision.py
 filters:
   - target_tasks_method
-head_ref: refs/tags/1.0.0
+head_ref: 1.0.0
 head_repository: https://github.com/taskcluster/taskgraph
-head_rev: release-test
-head_tag: 1.0.0
+head_rev: 1.0.0
+head_tag: ''
 level: '3'
 moz_build_date: '20240207083344'
 next_version: null


### PR DESCRIPTION
This ensures that the proper head ref is detected whether it is prefixed with `refs/tags/` or not. This also updates the test params to reflect reality.