### PR TITLE
fetch-content: use urlopen's context parameter instead of cafile

### DIFF
--- a/src/taskgraph/run-task/fetch-content
+++ b/src/taskgraph/run-task/fetch-content
@@ -18,6 +18,7 @@ import os
 import pathlib
 import random
 import re
+import ssl
 import stat
 import subprocess
 import sys
@@ -190,9 +191,11 @@ def stream_download(url, sha256=None, size=None, headers=None):
         req_headers[key.strip()] = val.strip()
 
     req = urllib.request.Request(url, None, req_headers)
-    with urllib.request.urlopen(
-        req, timeout=60, cafile=certifi.where()
-    ) if certifi else urllib.request.urlopen(req, timeout=60) as fh:
+    kwargs = {}
+    if certifi:
+        ssl_context = ssl.create_default_context(cafile=certifi.where())
+        kwargs["context"] = context = ssl_context
+    with urllib.request.urlopen(req, timeout=60, **kwargs) as fh:
         if not url.endswith(".gz") and fh.info().get("Content-Encoding") == "gzip":
             fh = gzip.GzipFile(fileobj=fh)
         else:

--- a/test/test_scripts_fetch_content.py
+++ b/test/test_scripts_fetch_content.py
@@ -60,7 +60,7 @@ def fetch_content_mod():
 def test_stream_download(
     monkeypatch, fetch_content_mod, url, sha256, size, headers, raises
 ):
-    def mock_urlopen(req, timeout=None, *, cafile=None):
+    def mock_urlopen(req, timeout=None, *, context=None):
         assert req._full_url == url
         assert timeout is not None
         if headers:


### PR DESCRIPTION
The latter was removed in python 3.13.