### PR TITLE
Bug 1937801 - Implement mechanism to use caches for common tools in run transforms

### DIFF
--- a/docs/reference/migrations.rst
+++ b/docs/reference/migrations.rst
@@ -3,6 +3,23 @@ Migration Guide
 
 This page can help when migrating Taskgraph across major versions.
 
+12.x -> 13.x
+------------
+
+* Remove all ``run.cache-dotcache`` keys. If it was set to ``true``, replace it
+  with:
+
+  .. code-block:: yaml
+
+     run:
+       use-caches: [checkout, <caches>]
+
+  Where caches can be any of ``cargo``, ``pip``, ``uv`` or ``npm``. If the task
+  was setting up ``.cache`` for another tool, a mount will need to be created
+  for it manually. If ``use-caches`` was previously set to ``false``, omit
+  ``checkout`` in the example above. If ``use-caches`` was previously set to
+  ``true``, replace ``true`` with the value above (including ``checkout``).
+
 11.x -> 12.x
 ------------
 
@@ -110,7 +127,7 @@ This page can help when migrating Taskgraph across major versions.
 5.x -> 6.x
 ----------
 
-* Replace all uses of ``command-context` with the more generalized ``task-context``
+* Replace all uses of ``command-context`` with the more generalized ``task-context``
 
 4.x -> 5.x
 ----------

--- a/packages/pytest-taskgraph/src/pytest_taskgraph/fixtures/gen.py
+++ b/packages/pytest-taskgraph/src/pytest_taskgraph/fixtures/gen.py
@@ -204,7 +204,11 @@ def make_transform_config(parameters, graph_config):
         if extra_params:
             parameters.update(extra_params)
         if extra_graph_config:
-            graph_config._config.update(extra_graph_config)
+            # We need this intermediate variable because `GraphConfig` is
+            # frozen and we can't set attributes on it.
+            new_graph_config = merge(graph_config._config, extra_graph_config)
+            graph_config._config.update(new_graph_config)
+
         return TransformConfig(
             "test",
             str(here),
@@ -220,12 +224,12 @@ def make_transform_config(parameters, graph_config):
 
 @pytest.fixture
 def run_transform(make_transform_config):
-    def inner(func, tasks, config=None):
+    def inner(func, tasks, config=None, **kwargs):
         if not isinstance(tasks, list):
             tasks = [tasks]
 
         if not config:
-            config = make_transform_config()
+            config = make_transform_config(**kwargs)
         return list(func(config, tasks))
 
     return inner

--- a/src/taskgraph/config.py
+++ b/src/taskgraph/config.py
@@ -12,6 +12,7 @@ from typing import Dict
 from voluptuous import All, Any, Extra, Length, Optional, Required
 
 from .util import path
+from .util.caches import CACHES
 from .util.python_path import find_object
 from .util.schema import Schema, optionally_keyed_by, validate_schema
 from .util.yaml import load_yaml
@@ -74,6 +75,16 @@ graph_config_schema = Schema(
                 "index-path-regexes",
                 description="Regular expressions matching index paths to be summarized.",
             ): [str],
+            Optional(
+                "run",
+                description="Configuration related to the 'run' transforms.",
+            ): {
+                Optional(
+                    "use-caches",
+                    description="List of caches to enable, or a boolean to "
+                    "enable/disable all of them.",
+                ): Any(bool, list(CACHES.keys())),
+            },
             Required("repositories"): All(
                 {
                     str: {
@@ -106,8 +117,8 @@ class GraphConfig:
     def __contains__(self, name):
         return name in self._config
 
-    def get(self, name):
-        return self._config.get(name)
+    def get(self, name, default=None):
+        return self._config.get(name, default)
 
     def register(self):
         """

--- a/src/taskgraph/transforms/run/common.py
+++ b/src/taskgraph/transforms/run/common.py
@@ -175,7 +175,7 @@ def support_caches(
         use_caches = (
             config.graph_config.get("taskgraph", {})
             .get("run", {})
-            .get("use-caches", True)
+            .get("use-caches", ["checkout"])
         )
 
     for name, cache_cfg in CACHES.items():

--- a/src/taskgraph/transforms/run/common.py
+++ b/src/taskgraph/transforms/run/common.py
@@ -7,12 +7,12 @@ worker implementation they operate on, and take the same three parameters, for
 consistency.
 """
 
-import hashlib
 import json
 from typing import Any, Dict, List, Union
 
 from taskgraph.transforms.base import TransformConfig
 from taskgraph.util import path
+from taskgraph.util.caches import CACHES, get_checkout_dir
 from taskgraph.util.taskcluster import get_artifact_prefix
 
 
@@ -21,54 +21,6 @@ def get_vcsdir_name(os):
         return "src"
     else:
         return "vcs"
-
-
-def get_checkout_dir(task: Dict[str, Any]) -> str:
-    worker = task["worker"]
-    if worker["os"] == "windows":
-        return "build"
-    elif worker["implementation"] == "docker-worker":
-        return f"{task['run']['workdir']}/checkouts"
-    else:
-        return "checkouts"
-
-
-def get_checkout_cache_name(config: TransformConfig, task: Dict[str, Any]) -> str:
-    repo_configs = config.repo_configs
-    cache_name = "checkouts"
-
-    # Robust checkout does not clean up subrepositories, so ensure  that tasks
-    # that checkout different sets of paths have separate caches.
-    # See https://bugzilla.mozilla.org/show_bug.cgi?id=1631610
-    if len(repo_configs) > 1:
-        checkout_paths = {
-            "\t".join([repo_config.path, repo_config.prefix])
-            for repo_config in sorted(
-                repo_configs.values(), key=lambda repo_config: repo_config.path
-            )
-        }
-        checkout_paths_str = "\n".join(checkout_paths).encode("utf-8")
-        digest = hashlib.sha256(checkout_paths_str).hexdigest()
-        cache_name += f"-repos-{digest}"
-
-    # Sparse checkouts need their own cache because they can interfere
-    # with clients that aren't sparse aware.
-    if task["run"]["sparse-profile"]:
-        cache_name += "-sparse"
-
-    return cache_name
-
-
-CACHES = {
-    "cargo": {"env": "CARGO_HOME"},
-    "checkout": {
-        "cache_dir": get_checkout_dir,
-        "cache_name": get_checkout_cache_name,
-    },
-    "npm": {"env": "npm_config_cache"},
-    "pip": {"env": "PIP_CACHE_DIR"},
-    "uv": {"env": "UV_CACHE_DIR"},
-}
 
 
 def add_cache(task, taskdesc, name, mount_point, skip_untrusted=False):
@@ -216,8 +168,15 @@ def support_caches(
         workdir = workdir or "/builds/worker"
         base_cache_dir = path.join(workdir, base_cache_dir)
 
-    # Default to all caches enabled.
-    use_caches = run.get("use-caches", True)
+    use_caches = run.get("use-caches")
+    if use_caches is None:
+        # Use project default values for filtering caches, default to
+        # checkout cache if no selection is specified.
+        use_caches = (
+            config.graph_config.get("taskgraph", {})
+            .get("run", {})
+            .get("use-caches", True)
+        )
 
     for name, cache_cfg in CACHES.items():
         if not should_use_cache(name, use_caches, run["checkout"]):

--- a/src/taskgraph/transforms/run/run_task.py
+++ b/src/taskgraph/transforms/run/run_task.py
@@ -106,7 +106,7 @@ def common_setup(config, task, taskdesc, command):
     if "cwd" in run:
         command.extend(("--task-cwd", run["cwd"]))
 
-    support_caches(task, taskdesc)
+    support_caches(config, task, taskdesc)
     taskdesc["worker"].setdefault("env", {})["MOZ_SCM_LEVEL"] = config.params["level"]
 
 

--- a/src/taskgraph/transforms/run/run_task.py
+++ b/src/taskgraph/transforms/run/run_task.py
@@ -11,7 +11,10 @@ import os
 from voluptuous import Any, Optional, Required
 
 from taskgraph.transforms.run import run_task_using
-from taskgraph.transforms.run.common import support_vcs_checkout
+from taskgraph.transforms.run.common import (
+    support_caches,
+    support_vcs_checkout,
+)
 from taskgraph.transforms.task import taskref_or_string
 from taskgraph.util import path, taskcluster
 from taskgraph.util.schema import Schema
@@ -103,6 +106,7 @@ def common_setup(config, task, taskdesc, command):
     if "cwd" in run:
         command.extend(("--task-cwd", run["cwd"]))
 
+    support_caches(task, taskdesc)
     taskdesc["worker"].setdefault("env", {})["MOZ_SCM_LEVEL"] = config.params["level"]
 
 

--- a/src/taskgraph/transforms/run/run_task.py
+++ b/src/taskgraph/transforms/run/run_task.py
@@ -12,12 +12,12 @@ from voluptuous import Any, Optional, Required
 
 from taskgraph.transforms.run import run_task_using
 from taskgraph.transforms.run.common import (
-    CACHES,
     support_caches,
     support_vcs_checkout,
 )
 from taskgraph.transforms.task import taskref_or_string
 from taskgraph.util import path, taskcluster
+from taskgraph.util.caches import CACHES
 from taskgraph.util.schema import Schema
 
 EXEC_COMMANDS = {

--- a/src/taskgraph/transforms/run/run_task.py
+++ b/src/taskgraph/transforms/run/run_task.py
@@ -12,6 +12,7 @@ from voluptuous import Any, Optional, Required
 
 from taskgraph.transforms.run import run_task_using
 from taskgraph.transforms.run.common import (
+    CACHES,
     support_caches,
     support_vcs_checkout,
 )
@@ -31,8 +32,11 @@ run_task_schema = Schema(
         # tend to hide their caches.  This cache is never added for level-1 tasks.
         # TODO Once bug 1526028 is fixed, this and 'use-caches' should be merged.
         Required("cache-dotcache"): bool,
-        # Whether or not to use caches.
-        Optional("use-caches"): bool,
+        # Which caches to use. May take a boolean in which case either all
+        # (True) or no (False) caches will be used. Alternatively, it can
+        # accept a list of caches to enable. Defaults to only the checkout cache
+        # enabled.
+        Optional("use-caches", "caches"): Any(bool, list(CACHES.keys())),
         # if true (the default), perform a checkout on the worker
         Required("checkout"): Any(bool, {str: dict}),
         Optional(

--- a/src/taskgraph/util/caches.py
+++ b/src/taskgraph/util/caches.py
@@ -1,0 +1,57 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import hashlib
+from typing import TYPE_CHECKING, Any, Dict
+
+if TYPE_CHECKING:
+    from taskgraph.transforms.base import TransformConfig
+
+
+def get_checkout_dir(task: Dict[str, Any]) -> str:
+    worker = task["worker"]
+    if worker["os"] == "windows":
+        return "build"
+    elif worker["implementation"] == "docker-worker":
+        return f"{task['run']['workdir']}/checkouts"
+    else:
+        return "checkouts"
+
+
+def get_checkout_cache_name(config: "TransformConfig", task: Dict[str, Any]) -> str:
+    repo_configs = config.repo_configs
+    cache_name = "checkouts"
+
+    # Robust checkout does not clean up subrepositories, so ensure  that tasks
+    # that checkout different sets of paths have separate caches.
+    # See https://bugzilla.mozilla.org/show_bug.cgi?id=1631610
+    if len(repo_configs) > 1:
+        checkout_paths = {
+            "\t".join([repo_config.path, repo_config.prefix])
+            for repo_config in sorted(
+                repo_configs.values(), key=lambda repo_config: repo_config.path
+            )
+        }
+        checkout_paths_str = "\n".join(checkout_paths).encode("utf-8")
+        digest = hashlib.sha256(checkout_paths_str).hexdigest()
+        cache_name += f"-repos-{digest}"
+
+    # Sparse checkouts need their own cache because they can interfere
+    # with clients that aren't sparse aware.
+    if task["run"]["sparse-profile"]:
+        cache_name += "-sparse"
+
+    return cache_name
+
+
+CACHES = {
+    "cargo": {"env": "CARGO_HOME"},
+    "checkout": {
+        "cache_dir": get_checkout_dir,
+        "cache_name": get_checkout_cache_name,
+    },
+    "npm": {"env": "npm_config_cache"},
+    "pip": {"env": "PIP_CACHE_DIR"},
+    "uv": {"env": "UV_CACHE_DIR"},
+}

--- a/taskcluster/docker/python/Dockerfile
+++ b/taskcluster/docker/python/Dockerfile
@@ -6,7 +6,7 @@ FROM debian:bookworm-slim
 LABEL maintainer="Release Engineering <release@mozilla.com>"
 
 VOLUME /builds/worker/checkouts
-VOLUME /builds/worker/.cache
+VOLUME /builds/worker/.task-cache/uv
 
 # Add worker user
 RUN mkdir -p /builds && \

--- a/taskcluster/kinds/check/kind.yml
+++ b/taskcluster/kinds/check/kind.yml
@@ -29,7 +29,7 @@ task-defaults:
     run:
         using: run-task
         cwd: '{checkout}'
-        cache-dotcache: true
+        use-caches: [checkout, uv]
 
 tasks:
     type:

--- a/taskcluster/kinds/codecov/kind.yml
+++ b/taskcluster/kinds/codecov/kind.yml
@@ -44,6 +44,7 @@ tasks:
         run:
             using: run-task
             cwd: '{checkout}'
+            use-caches: [checkout, uv]
             command: >-
                 uv run coverage combine --data-file $MOZ_FETCHES_DIR/coverage $MOZ_FETCHES_DIR &&
                 uv run coverage xml --data-file $MOZ_FETCHES_DIR/coverage -o $MOZ_FETCHES_DIR/coverage.xml &&

--- a/taskcluster/kinds/doc/kind.yml
+++ b/taskcluster/kinds/doc/kind.yml
@@ -21,7 +21,7 @@ task-defaults:
     run:
         using: run-task
         cwd: '{checkout}'
-        cache-dotcache: true
+        use-caches: [checkout, uv]
 
 tasks:
     generate:

--- a/taskcluster/kinds/test/kind.yml
+++ b/taskcluster/kinds/test/kind.yml
@@ -34,7 +34,7 @@ task-defaults:
     run:
         using: run-task
         cwd: '{checkout}'
-        cache-dotcache: true
+        use-caches: [checkout, uv]
 
 tasks:
     unit:

--- a/test/test_transforms_run.py
+++ b/test/test_transforms_run.py
@@ -86,7 +86,7 @@ def run_caches(transform):
 
 
 def test_caches_docker_worker(run_caches):
-    assert run_caches({"worker-type": "t-linux"}) == [
+    assert run_caches({"run": {"use-caches": True}, "worker-type": "t-linux"}) == [
         {
             "mount-point": "/cache1",
             "name": "cache1",
@@ -103,7 +103,7 @@ def test_caches_docker_worker(run_caches):
 
 
 def test_caches_generic_worker(run_caches):
-    assert run_caches({"worker-type": "t-win"}) == [
+    assert run_caches({"run": {"use-caches": True}, "worker-type": "t-win"}) == [
         {"cache-name": "cache1", "directory": "/cache1"},
         {"cache-name": "cache2", "directory": "/cache2"},
     ]

--- a/test/test_transforms_run.py
+++ b/test/test_transforms_run.py
@@ -43,13 +43,13 @@ def transform(monkeypatch, run_transform):
     # Needed by 'generic_worker_run_task'
     monkeypatch.setenv("TASK_ID", "fakeid")
 
-    def inner(task_input):
+    def inner(task_input, **kwargs):
         defaults = deepcopy(TASK_DEFAULTS)
         task = merge(defaults, task_input)
 
         with patch("taskgraph.transforms.run.configure_taskdesc_for_run") as m:
             # This forces the generator to be evaluated
-            run_transform(run.transforms, task)
+            run_transform(run.transforms, task, **kwargs)
             return m.call_args[0]
 
     return inner

--- a/test/test_transforms_run_run_task.py
+++ b/test/test_transforms_run_run_task.py
@@ -53,14 +53,14 @@ def assert_docker_worker(task):
         "worker": {
             "caches": [
                 {
-                    "mount-point": "/builds/worker/checkouts",
-                    "name": "checkouts",
+                    "mount-point": "/builds/worker/.task-cache/cargo",
+                    "name": "cargo",
                     "skip-untrusted": False,
                     "type": "persistent",
                 },
                 {
-                    "mount-point": "/builds/worker/.task-cache/cargo",
-                    "name": "cargo",
+                    "mount-point": "/builds/worker/checkouts",
+                    "name": "checkouts",
                     "skip-untrusted": False,
                     "type": "persistent",
                 },
@@ -148,12 +148,12 @@ def assert_generic_worker(task):
             "implementation": "generic-worker",
             "mounts": [
                 {
-                    "cache-name": "checkouts",
-                    "directory": "build",
-                },
-                {
                     "cache-name": "cargo",
                     "directory": ".task-cache/cargo",
+                },
+                {
+                    "cache-name": "checkouts",
+                    "directory": "build",
                 },
                 {
                     "cache-name": "npm",

--- a/test/test_transforms_run_run_task.py
+++ b/test/test_transforms_run_run_task.py
@@ -57,7 +57,31 @@ def assert_docker_worker(task):
                     "name": "checkouts",
                     "skip-untrusted": False,
                     "type": "persistent",
-                }
+                },
+                {
+                    "mount-point": "/builds/worker/.task-cache/cargo",
+                    "name": "cargo",
+                    "skip-untrusted": False,
+                    "type": "persistent",
+                },
+                {
+                    "mount-point": "/builds/worker/.task-cache/npm",
+                    "name": "npm",
+                    "skip-untrusted": False,
+                    "type": "persistent",
+                },
+                {
+                    "mount-point": "/builds/worker/.task-cache/pip",
+                    "name": "pip",
+                    "skip-untrusted": False,
+                    "type": "persistent",
+                },
+                {
+                    "mount-point": "/builds/worker/.task-cache/uv",
+                    "name": "uv",
+                    "skip-untrusted": False,
+                    "type": "persistent",
+                },
             ],
             "command": [
                 "/usr/local/bin/run-task",
@@ -68,6 +92,7 @@ def assert_docker_worker(task):
                 "echo hello world",
             ],
             "env": {
+                "CARGO_HOME": "/builds/worker/.task-cache/cargo",
                 "CI_BASE_REPOSITORY": "http://hg.example.com",
                 "CI_HEAD_REF": "default",
                 "CI_HEAD_REPOSITORY": "http://hg.example.com",
@@ -75,8 +100,11 @@ def assert_docker_worker(task):
                 "CI_REPOSITORY_TYPE": "hg",
                 "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
                 "MOZ_SCM_LEVEL": "1",
+                "PIP_CACHE_DIR": "/builds/worker/.task-cache/pip",
                 "REPOSITORIES": '{"ci": "Taskgraph"}',
+                "UV_CACHE_DIR": "/builds/worker/.task-cache/uv",
                 "VCS_PATH": "/builds/worker/checkouts/vcs",
+                "npm_config_cache": "/builds/worker/.task-cache/npm",
             },
             "implementation": "docker-worker",
             "os": "linux",
@@ -103,6 +131,7 @@ def assert_generic_worker(task):
                 'world"'
             ],
             "env": {
+                "CARGO_HOME": "{task_workdir}/.task-cache/cargo",
                 "CI_BASE_REPOSITORY": "http://hg.example.com",
                 "CI_HEAD_REF": "default",
                 "CI_HEAD_REPOSITORY": "http://hg.example.com",
@@ -110,15 +139,37 @@ def assert_generic_worker(task):
                 "CI_REPOSITORY_TYPE": "hg",
                 "HG_STORE_PATH": "y:/hg-shared",
                 "MOZ_SCM_LEVEL": "1",
+                "PIP_CACHE_DIR": "{task_workdir}/.task-cache/pip",
                 "REPOSITORIES": '{"ci": "Taskgraph"}',
+                "UV_CACHE_DIR": "{task_workdir}/.task-cache/uv",
                 "VCS_PATH": "{task_workdir}/build/src",
+                "npm_config_cache": "{task_workdir}/.task-cache/npm",
             },
             "implementation": "generic-worker",
             "mounts": [
-                {"cache-name": "checkouts", "directory": "build"},
+                {
+                    "cache-name": "checkouts",
+                    "directory": "build",
+                },
+                {
+                    "cache-name": "cargo",
+                    "directory": ".task-cache/cargo",
+                },
+                {
+                    "cache-name": "npm",
+                    "directory": ".task-cache/npm",
+                },
+                {
+                    "cache-name": "pip",
+                    "directory": ".task-cache/pip",
+                },
+                {
+                    "cache-name": "uv",
+                    "directory": ".task-cache/uv",
+                },
                 {
                     "content": {
-                        "url": "https://tc-tests.localhost/api/queue/v1/task/<TASK_ID>/artifacts/public/run-task"  # noqa
+                        "url": "https://tc-tests.localhost/api/queue/v1/task/<TASK_ID>/artifacts/public/run-task"
                     },
                     "file": "./run-task",
                 },
@@ -172,7 +223,7 @@ def assert_run_task_command_generic_worker(task):
     "task",
     (
         pytest.param(
-            {},
+            {"worker": {"os": "linux"}},
             id="docker_worker",
         ),
         pytest.param(

--- a/test/test_transforms_run_run_task.py
+++ b/test/test_transforms_run_run_task.py
@@ -56,34 +56,10 @@ def assert_docker_worker(task):
         "worker": {
             "caches": [
                 {
-                    'mount-point': '/builds/worker/.task-cache/cargo',
-                    'name': 'cargo',
-                    'skip-untrusted': False,
-                    'type': 'persistent',
-                },
-                {
                     "mount-point": "/builds/worker/checkouts",
                     "name": "checkouts",
                     "skip-untrusted": False,
                     "type": "persistent",
-                },
-                {
-                    'mount-point': '/builds/worker/.task-cache/npm',
-                    'name': 'npm',
-                    'skip-untrusted': False,
-                    'type': 'persistent',
-                },
-                {
-                    'mount-point': '/builds/worker/.task-cache/pip',
-                    'name': 'pip',
-                    'skip-untrusted': False,
-                    'type': 'persistent',
-                },
-                {
-                    'mount-point': '/builds/worker/.task-cache/uv',
-                    'name': 'uv',
-                    'skip-untrusted': False,
-                    'type': 'persistent',
                 },
             ],
             "command": [
@@ -95,7 +71,6 @@ def assert_docker_worker(task):
                 "echo hello world",
             ],
             "env": {
-                "CARGO_HOME": "/builds/worker/.task-cache/cargo",
                 "CI_BASE_REPOSITORY": "http://hg.example.com",
                 "CI_HEAD_REF": "default",
                 "CI_HEAD_REPOSITORY": "http://hg.example.com",
@@ -103,11 +78,8 @@ def assert_docker_worker(task):
                 "CI_REPOSITORY_TYPE": "hg",
                 "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
                 "MOZ_SCM_LEVEL": "1",
-                "PIP_CACHE_DIR": "/builds/worker/.task-cache/pip",
                 "REPOSITORIES": '{"ci": "Taskgraph"}',
-                "UV_CACHE_DIR": "/builds/worker/.task-cache/uv",
                 "VCS_PATH": "/builds/worker/checkouts/vcs",
-                "npm_config_cache": "/builds/worker/.task-cache/npm",
             },
             "implementation": "docker-worker",
             "os": "linux",
@@ -134,7 +106,6 @@ def assert_generic_worker(task):
                 'world"'
             ],
             "env": {
-                "CARGO_HOME": "{task_workdir}/.task-cache/cargo",
                 "CI_BASE_REPOSITORY": "http://hg.example.com",
                 "CI_HEAD_REF": "default",
                 "CI_HEAD_REPOSITORY": "http://hg.example.com",
@@ -142,31 +113,12 @@ def assert_generic_worker(task):
                 "CI_REPOSITORY_TYPE": "hg",
                 "HG_STORE_PATH": "y:/hg-shared",
                 "MOZ_SCM_LEVEL": "1",
-                "PIP_CACHE_DIR": "{task_workdir}/.task-cache/pip",
                 "REPOSITORIES": '{"ci": "Taskgraph"}',
-                "UV_CACHE_DIR": "{task_workdir}/.task-cache/uv",
                 "VCS_PATH": "{task_workdir}/build/src",
-                "npm_config_cache": "{task_workdir}/.task-cache/npm",
             },
             "implementation": "generic-worker",
             "mounts": [
-                {
-                    "cache-name": "cargo",
-                    "directory": ".task-cache/cargo",
-                },
                 {"cache-name": "checkouts", "directory": "build"},
-                {
-                    "cache-name": "npm",
-                    "directory": ".task-cache/npm",
-                },
-                {
-                    "cache-name": "pip",
-                    "directory": ".task-cache/pip",
-                },
-                {
-                    "cache-name": "uv",
-                    "directory": ".task-cache/uv",
-                },
                 {
                     "content": {
                         "url": "https://tc-tests.localhost/api/queue/v1/task/<TASK_ID>/artifacts/public/run-task"


### PR DESCRIPTION
This is an overhaul of how we set up caches in the run transforms. At a high level, this is:

1. Creating a new mechanism to register caches for common tools (pip, uv, npm, cargo)
2. Refactoring the existing checkouts cache to use this mechanism.
3. Providing task and project wide configs to include or exclude caches
4. Removing the `cache-dotcache` key

I recommend reviewing commit by commit.

Making this a draft PR for now so I have a chance to test it out with real tasks.