### PR TITLE
[run-task] Support interpolating `$TASK_WORKDIR` in environment variables

### DIFF
--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -1091,10 +1091,10 @@ def _display_python_version():
 
 
 def main(args):
-    os.environ["TASK_WORKDIR"] = os.getcwd()
+    task_workdir = os.environ["TASK_WORKDIR"] = os.getcwd()
     print_line(
         b"setup",
-        b"run-task started in %s\n" % os.environ["TASK_WORKDIR"].encode("utf-8"),
+        b"run-task started in %s\n" % task_workdir.encode("utf-8"),
     )
     print_line(
         b"setup",
@@ -1313,20 +1313,27 @@ def main(args):
     for repo in repositories:
         vcs_checkout_from_args(repo)
 
-    resource_process = None
-
-    try:
-        for k in ["MOZ_FETCHES_DIR", "UPLOAD_DIR"] + [
-            "{}_PATH".format(repository["project"].upper())
-            for repository in repositories
-        ]:
-            if k in os.environ:
-                os.environ[k] = os.path.abspath(os.environ[k])
+    # Interpolate environment variables with defined substitution patterns. For
+    # example, the variable `CACHE_DIR={task_workdir}/.cache` will be
+    # interpolated with the task's working directory.
+    env_subs = {
+        "task_workdir": task_workdir,
+    }
+    for k, v in os.environ.items():
+        for subname, subval in env_subs.items():
+            # We check for an exact match rather than using a format string to
+            # avoid accidentally trying to interpolate environment variables
+            # that happen to contain brackets for some other reason.
+            pattern = f"{{{subname}}}"
+            if pattern in v:
+                os.environ[k] = v.replace(pattern, subval)
                 print_line(
                     b"setup",
                     b"%s is %s\n" % (k.encode("utf-8"), os.environ[k].encode("utf-8")),
                 )
 
+    resource_process = None
+    try:
         if "MOZ_FETCHES" in os.environ:
             fetch_artifacts()
 

--- a/src/taskgraph/transforms/run/__init__.py
+++ b/src/taskgraph/transforms/run/__init__.py
@@ -367,7 +367,7 @@ def use_fetches(config, tasks):
             "task-reference": json.dumps(task_fetches, sort_keys=True)
         }
 
-        env.setdefault("MOZ_FETCHES_DIR", "fetches")
+        env.setdefault("MOZ_FETCHES_DIR", "{task_workdir}/fetches")
 
         yield task
 

--- a/src/taskgraph/transforms/run/run_task.py
+++ b/src/taskgraph/transforms/run/run_task.py
@@ -70,7 +70,7 @@ def common_setup(config, task, taskdesc, command):
                 for (repo, config) in run["checkout"].items()
             }
 
-        support_vcs_checkout(
+        vcs_path = support_vcs_checkout(
             config,
             task,
             taskdesc,
@@ -78,7 +78,6 @@ def common_setup(config, task, taskdesc, command):
             sparse=bool(run["sparse-profile"]),
         )
 
-        vcs_path = taskdesc["worker"]["env"]["VCS_PATH"]
         for repo_config in repo_configs.values():
             checkout_path = path.join(vcs_path, repo_config.path)
             command.append(f"--{repo_config.prefix}-checkout={checkout_path}")

--- a/test/test_scripts_run_task.py
+++ b/test/test_scripts_run_task.py
@@ -438,7 +438,7 @@ def test_display_python_version_should_output_python_versions(run_task_mod, caps
 
 
 @pytest.fixture
-def run_main(tmp_path, capsys, mocker, mock_stdin, run_task_mod):
+def run_main(tmp_path, mocker, mock_stdin, run_task_mod):
     base_args = [
         f"--task-cwd={str(tmp_path)}",
     ]
@@ -463,21 +463,26 @@ def run_main(tmp_path, capsys, mocker, mock_stdin, run_task_mod):
         args.extend(base_command_args)
 
         result = run_task_mod.main(args)
-        out, err = capsys.readouterr()
-        return result, out, err, env
+        return result, env
 
     return inner
 
 
 def test_main_interpolate_environment(run_main):
-    result, out, err, env = run_main(
-        env={"MOZ_FETCHES_DIR": "file", "UPLOAD_DIR": "file", "FOO": "file"}
+    result, env = run_main(
+        env={
+            "MOZ_FETCHES_DIR": "{task_workdir}/file",
+            "UPLOAD_DIR": "$TASK_WORKDIR/file",
+            "FOO": "{foo}/file",
+            "BAR": "file",
+        }
     )
     assert result == 0
 
     assert env == {
         "MOZ_FETCHES_DIR": "/builds/worker/file",
-        "UPLOAD_DIR": "/builds/worker/file",
-        "FOO": "file",
+        "UPLOAD_DIR": "$TASK_WORKDIR/file",
+        "FOO": "{foo}/file",
+        "BAR": "file",
         "TASK_WORKDIR": "/builds/worker",
     }

--- a/test/test_transforms_run_run_task.py
+++ b/test/test_transforms_run_run_task.py
@@ -99,7 +99,7 @@ def assert_generic_worker(task):
         "worker": {
             "command": [
                 "C:/mozilla-build/python3/python3.exe run-task "
-                '--ci-checkout=./build/src/ -- bash -cx "echo hello '
+                '--ci-checkout=build/src/ -- bash -cx "echo hello '
                 'world"'
             ],
             "env": {
@@ -111,11 +111,11 @@ def assert_generic_worker(task):
                 "HG_STORE_PATH": "y:/hg-shared",
                 "MOZ_SCM_LEVEL": "1",
                 "REPOSITORIES": '{"ci": "Taskgraph"}',
-                "VCS_PATH": "./build/src",
+                "VCS_PATH": "{task_workdir}/build/src",
             },
             "implementation": "generic-worker",
             "mounts": [
-                {"cache-name": "checkouts", "directory": "./build"},
+                {"cache-name": "checkouts", "directory": "build"},
                 {
                     "content": {
                         "url": "https://tc-tests.localhost/api/queue/v1/task/<TASK_ID>/artifacts/public/run-task"  # noqa
@@ -159,7 +159,7 @@ def assert_run_task_command_generic_worker(task):
         [
             "/foo/bar/python3",
             "run-task",
-            "--ci-checkout=./checkouts/vcs/",
+            "--ci-checkout=checkouts/vcs/",
             "--",
             "bash",
             "-cx",


### PR DESCRIPTION
We currently hard code some environment variables that should be turned into absolute paths. But it would be great if we had the ability to do this for any environment variable.

My current use case is setting `PIP_CACHE_DIR` to an absolute path under the task's workdir. I could add it to the list of hard coded envs, but it would be better to do something like `PIP_CACHE_DIR=$TASK_WORKDIR/.cache/pip` and have run-task do the interpolation automatically.