### PR TITLE
fix: return tasks by task_id in get_ancestors to avoid collisions in labels

### DIFF
--- a/src/taskgraph/util/taskcluster.py
+++ b/src/taskgraph/util/taskcluster.py
@@ -14,7 +14,6 @@ import requests
 import taskcluster_urls as liburls
 from requests.packages.urllib3.util.retry import Retry  # type: ignore
 
-from taskgraph import task
 from taskgraph.task import Task
 from taskgraph.util import yaml
 

--- a/src/taskgraph/util/taskcluster.py
+++ b/src/taskgraph/util/taskcluster.py
@@ -14,6 +14,7 @@ import requests
 import taskcluster_urls as liburls
 from requests.packages.urllib3.util.retry import Retry  # type: ignore
 
+from taskgraph import task
 from taskgraph.task import Task
 from taskgraph.util import yaml
 
@@ -469,7 +470,7 @@ def _get_deps(task_ids, use_proxy):
                 continue
             raise e
 
-        upstream_tasks[task_def["metadata"]["name"]] = task_id
+        upstream_tasks[task_id] = task_def["metadata"]["name"]
 
         upstream_tasks.update(_get_deps(tuple(task_def["dependencies"]), use_proxy))
 
@@ -479,14 +480,14 @@ def _get_deps(task_ids, use_proxy):
 def get_ancestors(
     task_ids: Union[List[str], str], use_proxy: bool = False
 ) -> Dict[str, str]:
-    """Gets the ancestor tasks of the given task_ids as a dictionary of label -> taskid.
+    """Gets the ancestor tasks of the given task_ids as a dictionary of taskid -> label.
 
     Args:
         task_ids (str or [str]): A single task id or a list of task ids to find the ancestors of.
         use_proxy (bool): See get_root_url.
 
     Returns:
-        dict: A dict whose keys are task labels and values are task ids.
+        dict: A dict whose keys are task ids and values are task labels.
     """
     upstream_tasks: Dict[str, str] = {}
 

--- a/test/test_util_taskcluster.py
+++ b/test/test_util_taskcluster.py
@@ -448,10 +448,10 @@ def test_get_ancestors(responses, root_url):
 
     got = tc.get_ancestors(["bbb", "fff"])
     expected = {
-        "task-aaa": "aaa",
-        "task-ccc": "ccc",
-        "task-ddd": "ddd",
-        "task-eee": "eee",
+        "aaa": "task-aaa",
+        "ccc": "task-ccc",
+        "ddd": "task-ddd",
+        "eee": "task-eee",
     }
     assert got == expected, f"got: {got}, expected: {expected}"
 
@@ -505,8 +505,8 @@ def test_get_ancestors_404(responses, root_url):
 
     got = tc.get_ancestors(["bbb", "fff"])
     expected = {
-        "task-ddd": "ddd",
-        "task-eee": "eee",
+        "ddd": "task-ddd",
+        "eee": "task-eee",
     }
     assert got == expected, f"got: {got}, expected: {expected}"
 
@@ -578,10 +578,10 @@ def test_get_ancestors_string(responses, root_url):
 
     got = tc.get_ancestors("fff")
     expected = {
-        "task-aaa": "aaa",
-        "task-bbb": "bbb",
-        "task-ccc": "ccc",
-        "task-ddd": "ddd",
-        "task-eee": "eee",
+        "aaa": "task-aaa",
+        "bbb": "task-bbb",
+        "ccc": "task-ccc",
+        "ddd": "task-ddd",
+        "eee": "task-eee",
     }
     assert got == expected, f"got: {got}, expected: {expected}"


### PR DESCRIPTION
BREAKING CHANGE: `get_ancestors` now returns a dict of task_id to label rather than label to task_id

This allows it to give a complete list of ancestors in graphs that have multiple tasks with the same label.