### PR TITLE
chore: add migration guide for breaking change to get_ancestors

### DIFF
--- a/docs/reference/migrations.rst
+++ b/docs/reference/migrations.rst
@@ -19,6 +19,24 @@ This page can help when migrating Taskgraph across major versions.
   for it manually. If ``use-caches`` was previously set to ``false``, omit
   ``checkout`` in the example above. If ``use-caches`` was previously set to
   ``true``, replace ``true`` with the value above (including ``checkout``).
+* Invert any usage of the dict keys and values returned by `get_ancestors`:
+
+  For example, if you were using:
+
+  .. code-block:: python
+
+    for label, taskid in get_ancestors(...):
+      ...
+
+  Change it to:
+
+  .. code-block:: python
+
+    for taskid, label in get_ancestors(...):
+      ...
+
+  Note that due to this change `get_ancestors` may return multiple tasks with
+  the same label now, which your code may need to deal with.
 
 11.x -> 12.x
 ------------


### PR DESCRIPTION
Should've been part of #633 