### PR TITLE
run-task: silence python 3.12 deprecation warning

### DIFF
--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -115,10 +115,12 @@ NULL_REVISION = "0000000000000000000000000000000000000000"
 
 
 def print_line(prefix, m):
-    now = datetime.datetime.utcnow().isoformat().encode("utf-8")
-    # slice microseconds to 3 decimals.
-    now = now[:-3] if now[-7:-6] == b"." else now
-    sys.stdout.buffer.write(b"[%s %sZ] %s" % (prefix, now, m))
+    now = (
+        datetime.datetime.now(tz=datetime.timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .encode("utf-8")
+    )
+    sys.stdout.buffer.write(b"[%s %s] %s" % (prefix, now, m))
     sys.stdout.buffer.flush()
 
 


### PR DESCRIPTION
```
/usr/local/bin/run-task:118: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  now = datetime.datetime.utcnow().isoformat().encode("utf-8")
```

This slightly changes the output, replacing `Z` with `+00:00` for the timezone component.