### PR TITLE
feat: port `taskgraph action` from gecko_taskgraph

### DIFF
--- a/src/taskgraph/main.py
+++ b/src/taskgraph/main.py
@@ -738,7 +738,7 @@ def actions(args):
         logging.root.setLevel(logging.DEBUG)
 
     try:
-        parameters = parameters_loader(args["parameters"])
+        parameters = parameters_loader(args["parameters"], strict=False)
         tgg = TaskGraphGenerator(root_dir=args.get("root"), parameters=parameters)
 
         actions = render_actions_json(tgg.parameters, tgg.graph_config, "DECISION-TASK")
@@ -746,6 +746,8 @@ def actions(args):
     except Exception:
         traceback.print_exc()
         sys.exit(1)
+
+    return 0
 
 
 @command("action-callback", description="Run action callback used by action tasks")

--- a/src/taskgraph/main.py
+++ b/src/taskgraph/main.py
@@ -710,6 +710,44 @@ def decision(options):
     taskgraph_decision(options)
 
 
+@command("actions", help="Print the rendered actions.json")
+@argument(
+    "--root",
+    "-r",
+    help="root of the taskgraph definition relative to topsrcdir",
+    default="taskcluster",
+)
+@argument(
+    "--verbose",
+    "-v",
+    action="store_true",
+    help="include debug-level logging output",
+)
+@argument(
+    "--parameters",
+    "-p",
+    default="",
+    help="parameters file (.yml or .json; see `taskcluster/docs/parameters.rst`)`",
+)
+def actions(args):
+    from taskgraph.actions import render_actions_json
+    from taskgraph.generator import TaskGraphGenerator
+    from taskgraph.parameters import parameters_loader
+
+    if args.pop("verbose", False):
+        logging.root.setLevel(logging.DEBUG)
+
+    try:
+        parameters = parameters_loader(args["parameters"])
+        tgg = TaskGraphGenerator(root_dir=args.get("root"), parameters=parameters)
+
+        actions = render_actions_json(tgg.parameters, tgg.graph_config, "DECISION-TASK")
+        print(json.dumps(actions, sort_keys=True, indent=2, separators=(",", ": ")))
+    except Exception:
+        traceback.print_exc()
+        sys.exit(1)
+
+
 @command("action-callback", description="Run action callback used by action tasks")
 @argument(
     "--root",

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -375,15 +375,15 @@ def test_dump_actions_json(
 ):
     expected_actions_len, expected_fields = expected
 
-    actions = []
-    callbacks = {}
-    monkeypatch.setattr(registry, "actions", actions)
-    monkeypatch.setattr(registry, "callbacks", callbacks)
-
-    def fake_actions_load(_graph_config):
-        return callbacks, actions
-
     if not with_generic_actions:
+        actions = []
+        callbacks = {}
+        monkeypatch.setattr(registry, "actions", actions)
+        monkeypatch.setattr(registry, "callbacks", callbacks)
+
+        def fake_actions_load(_graph_config):
+            return callbacks, actions
+
         monkeypatch.setattr(registry, "_load", fake_actions_load)
 
     if new_action:


### PR DESCRIPTION
The documentation already says `You can generate actions.json locally by running taskgraph actions.` however that command was never ported over from gecko's `./mach taskgraph actions`