### PR TITLE
feat: Allow task-priority to be keyed by level

### DIFF
--- a/src/taskgraph/config.py
+++ b/src/taskgraph/config.py
@@ -26,6 +26,7 @@ graph_config_schema = Schema(
         Required("trust-domain"): str,
         Required("task-priority"): optionally_keyed_by(
             "project",
+            "level",
             Any(
                 "highest",
                 "very-high",

--- a/test/test_util_schema.py
+++ b/test/test_util_schema.py
@@ -233,3 +233,20 @@ def test_optionally_keyed_by():
 
     with pytest.raises(MultipleInvalid):
         validator({"by-bar": {"a": "b"}})
+
+
+def test_optionally_keyed_by_mulitple_keys():
+    validator = optionally_keyed_by("foo", "bar", str)
+    assert validator("baz") == "baz"
+    assert validator({"by-foo": {"a": "b", "c": "d"}}) == {"a": "b", "c": "d"}
+    assert validator({"by-bar": {"x": "y"}}) == {"x": "y"}
+    assert validator({"by-foo": {"a": {"by-bar": {"x": "y"}}}}) == {"a": {"x": "y"}}
+
+    with pytest.raises(Invalid):
+        validator({"by-foo": {"a": 123, "c": "d"}})
+
+    with pytest.raises(MultipleInvalid):
+        validator({"by-bar": {"a": 1}})
+
+    with pytest.raises(MultipleInvalid):
+        validator({"by-unknown": {"a": "b"}})


### PR DESCRIPTION
 Allow 'level' as a key in task-priority config.
Extend the test_optionally_keyed_by function to include validation for multiple keys (foo, bar).

closes #252 