### PR TITLE
ci: run complete-pr task on untrusted PRs

### DIFF
--- a/taskcluster/kinds/complete/kind.yml
+++ b/taskcluster/kinds/complete/kind.yml
@@ -15,7 +15,7 @@ kind-dependencies:
 tasks:
   pr:
     description: Ensures required PR tasks have completed
-    run-on-tasks-for: ["github-pull-request"]
+    run-on-tasks-for: ["github-pull-request", "github-pull-request-untrusted"]
     worker-type: succeed
     from-deps:
       group-by: all


### PR DESCRIPTION
These PRs are lacking codecov, but that doesn't seem bad enough to prevent running the `complete` task (which doesn't depend on codecov anyway).