### PR TITLE
test: make 'test_action_rebuild_cached_task' more robust

### DIFF
--- a/test/test_actions_rebuild_cached_tasks.py
+++ b/test/test_actions_rebuild_cached_tasks.py
@@ -51,5 +51,5 @@ def test_rebuild_cached_tasks(run_action):
         make_task(label="bar", task_def={"name": "bar"}),
     )
     out, _ = run_action("rebuild-cached-tasks", graph)
-    assert "foo" in out
-    assert "bar" not in out
+    assert '"name": "foo"' in out
+    assert '"name": "bar"' not in out


### PR DESCRIPTION
This test failed intermittently if the generated task id happens to contain the string 'bar'