### PR TITLE
chore: bump pytest-taskgraph version

### DIFF
--- a/packages/pytest-taskgraph/pyproject.toml
+++ b/packages/pytest-taskgraph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pytest-taskgraph"
-version = "0.1.0"
+version = "0.2.0"
 description = "Add your description here"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
This package was updated in https://github.com/taskcluster/taskgraph/pull/623 but not released.