### PR TITLE
fix: ensure GraphConfig.vcs_root is set when root_dir is a relative path

### DIFF
--- a/src/taskgraph/config.py
+++ b/src/taskgraph/config.py
@@ -145,7 +145,7 @@ class GraphConfig:
             raise Exception(
                 "Not guessing path to vcs root. Graph config in non-standard location."
             )
-        return os.path.dirname(self.root_dir)
+        return os.path.dirname(os.path.join(".", self.root_dir))
 
     @property
     def taskcluster_yml(self):


### PR DESCRIPTION
Related/alternative to https://github.com/taskcluster/taskgraph/pull/669 and https://github.com/taskcluster/taskgraph/pull/673.