### PR TITLE
Add a workflow to run auto updates for pre-commit

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -1,4 +1,4 @@
-name: Autoupdate
+name: Auto update pre-commit hooks every month
 on:
   schedule:
     - cron: '0 0 1 * *'
@@ -10,30 +10,6 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
-      - name: Setup git
-        run: |
-          git config --global user.name "Pre-commit automation"
-          git config --global user.email "releng+pre-commit-autoupdate@mozilla.com"
-      - uses: actions/setup-python@v5
-      - run: python -m pip install pre-commit
-        shell: bash
-      - name: Get commit message
-        run: |
-          echo "COMMIT_MSG=$(cat .pre-commit-config.yaml | yq -r '.ci.autoupdate_commit_msg // "Update pre-commit config"')" >> $GITHUB_ENV
-      - name: Update files
-        run: |
-          git checkout -B pre-commit-update
-          pre-commit autoupdate -j4
-          git add .pre-commit-config.yaml
-          git commit -m "${COMMIT_MSG}"
-          git push -f origin pre-commit-update
-      - name: Create PR if necessary
-        run: |
-          curl -sL \
-          -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos${{ github.reository_owner }}/${{ github.repository }}/pulls \
-          -d "{\"title\":\"${COMMIT_MSG}\",\"body\":\"\",\"head\":\"pre-commit-update\",\"base\":\"${{ github.event.repository.default_branch }}\"}"
+      - uses: mozilla-releng/actions/pre-commit-autoupdate@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -18,12 +18,15 @@ jobs:
       - uses: actions/setup-python@v5
       - run: python -m pip install pre-commit
         shell: bash
+      - name: Get commit message
+        run: |
+          echo "COMMIT_MSG=$(cat .pre-commit-config.yaml | yq -r '.ci.autoupdate_commit_msg // "Update pre-commit config"')" >> $GITHUB_ENV
       - name: Update files
         run: |
           git checkout -B pre-commit-update
           pre-commit autoupdate -j4
           git add .pre-commit-config.yaml
-          git commit -m "$(cat .pre-commit-config.yaml | yq -r '.ci.autoupdate_commit_msg // "Update pre-commit config"')"
+          git commit -m "${COMMIT_MSG}"
           git push -f origin pre-commit-update
       - name: Create PR if necessary
         run: |
@@ -33,4 +36,4 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos${{ github.reository_owner }}/${{ github.repository }}/pulls \
-          -d '{"title":"Update pre-commit","body":"","head":"pre-commit-update","base":"${{ github.event.repository.default_branch }}"}'
+          -d "{\"title\":\"${COMMIT_MSG}\",\"body\":\"\",\"head\":\"pre-commit-update\",\"base\":\"${{ github.event.repository.default_branch }}\"}"

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -1,0 +1,36 @@
+name: Autoupdate
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+jobs:
+  pre-commit:
+    name: Pre-commit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup git
+        run: |
+          git config --global user.name "Pre-commit automation"
+          git config --global user.email "releng+pre-commit-autoupdate@mozilla.com"
+      - uses: actions/setup-python@v5
+      - run: python -m pip install pre-commit
+        shell: bash
+      - name: Update files
+        run: |
+          git checkout -B pre-commit-update
+          pre-commit autoupdate -j4
+          git add .pre-commit-config.yaml
+          git commit -am "Update pre-commit"
+          git push -f origin pre-commit-update
+      - name: Create PR if necessary
+        run: |
+          curl -sL \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos${{ github.reository_owner }}/${{ github.repository }}/pulls \
+          -d '{"title":"Update pre-commit","body":"","head":"pre-commit-update","base":"${{ github.event.repository.default_branch }}"}'

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -23,7 +23,7 @@ jobs:
           git checkout -B pre-commit-update
           pre-commit autoupdate -j4
           git add .pre-commit-config.yaml
-          git commit -am "Update pre-commit"
+          git commit -m "$(cat .pre-commit-config.yaml | yq -r '.ci.autoupdate_commit_msg // "Update pre-commit config"')"
           git push -f origin pre-commit-update
       - name: Create PR if necessary
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,9 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 ---
 ci:
-  autofix_commit_msg: "style: pre-commit.ci auto fixes [...]"
   autoupdate_commit_msg: "chore: pre-commit autoupdate"
-  autoupdate_schedule: monthly
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0


### PR DESCRIPTION
This replaces the pre-commit.ci app's autoupdate.

The one caveat with this is that it doesn't check for PRs that are already opened on that branch. I did that to keep it as simple as possible. It's not a real issue as github will detect that and close the previous PR and then open a new one but it might be a bit spammy if we don't merge those PRs