### PR TITLE
actions: fix scope check on mercurial (bug 1965754)

### DIFF
--- a/src/taskgraph/actions/registry.py
+++ b/src/taskgraph/actions/registry.py
@@ -300,14 +300,12 @@ def sanity_check_task_scope(callback, parameters, graph_config):
     else:
         raise ValueError(f"No action with cb_name {callback}")
 
-    raw_url = parameters["base_repository"]
-    parsed_url = parse(raw_url)
+    parsed_base_url = parse(parameters["base_repository"])
+    parsed_head_url = parse(parameters["head_repository"])
     action_scope = (
-        f"assume:{parsed_url.taskcluster_role_prefix}:action:{action.permission}"
+        f"assume:{parsed_head_url.taskcluster_role_prefix}:action:{action.permission}"
     )
-    pr_action_scope = (
-        f"assume:{parsed_url.taskcluster_role_prefix}:pr-action:{action.permission}"
-    )
+    pr_action_scope = f"assume:{parsed_base_url.taskcluster_role_prefix}:pr-action:{action.permission}"
 
     # the scope should appear literally; no need for a satisfaction check. The use of
     # get_current_scopes here calls the auth service through the Taskcluster Proxy, giving

--- a/test/test_actions_registry.py
+++ b/test/test_actions_registry.py
@@ -55,37 +55,64 @@ def test_register_callback_action(request, monkeypatch, kwargs):
         ("non-existing-action", {}, [], pytest.raises(ValueError)),
         (
             "retrigger",
-            {"base_repository": "https://some.git.repo"},
+            {
+                "base_repository": "https://some.git.repo",
+                "head_repository": "https://some.git.repo",
+            },
             [],
             pytest.raises(InvalidRepoUrlError),
         ),
         (
             "retrigger",
-            {"base_repository": "https://hg.mozilla.org/try"},
+            {
+                "base_repository": "https://hg.mozilla.org/mozilla-unified",
+                "head_repository": "https://hg.mozilla.org/try",
+            },
             ["unrelated:scope"],
             pytest.raises(ValueError),
         ),
         (
             "retrigger",
-            {"base_repository": "https://hg.mozilla.org/mozilla-central"},
+            {
+                "base_repository": "https://hg.mozilla.org/mozilla-unified",
+                "head_repository": "https://hg.mozilla.org/try",
+            },
+            ["assume:repo:hg.mozilla.org/try:action:generic"],
+            does_not_raise(),
+        ),
+        (
+            "retrigger",
+            {
+                "base_repository": "https://hg.mozilla.org/mozilla-central",
+                "head_repository": "https://hg.mozilla.org/mozilla-central",
+            },
             ["assume:repo:hg.mozilla.org/mozilla-central:action:generic"],
             does_not_raise(),
         ),
         (
             "retrigger",
-            {"base_repository": "https://github.com/taskcluster/taskgraph"},
+            {
+                "base_repository": "https://github.com/taskcluster/taskgraph",
+                "head_repository": "https://github.com/taskcluster/taskgraph",
+            },
             ["assume:repo:github.com/taskcluster/taskgraph:action:generic"],
             does_not_raise(),
         ),
         (
             "retrigger",
-            {"base_repository": "git@github.com:mozilla-mobile/firefox-android.git"},
+            {
+                "base_repository": "git@github.com:mozilla-mobile/firefox-android.git",
+                "head_repository": "git@github.com:mozilla-mobile/firefox-android.git",
+            },
             ["assume:repo:github.com/mozilla-mobile/firefox-android:action:generic"],
             does_not_raise(),
         ),
         (
             "retrigger",
-            {"base_repository": "git@github.com:mozilla-mobile/firefox-android.git"},
+            {
+                "base_repository": "git@github.com:mozilla-mobile/firefox-android.git",
+                "head_repository": "git@github.com:someuser/firefox-android.git",
+            },
             ["assume:repo:github.com/mozilla-mobile/firefox-android:pr-action:generic"],
             does_not_raise(),
         ),


### PR DESCRIPTION
The action task's scopes are tied to the head repo.