### PR TITLE
Fix run-task/fetch-content mounts definition

### DIFF
--- a/src/taskgraph/transforms/run/run_task.py
+++ b/src/taskgraph/transforms/run/run_task.py
@@ -179,7 +179,7 @@ def generic_worker_run_task(config, task, taskdesc):
     worker["mounts"].append(
         {
             "content": {
-                "taskId": {"task-reference": "<decision>"},
+                "task-id": {"task-reference": "<decision>"},
                 "artifact": "public/run-task",
                 "sha256": run_task_sha256,
             },
@@ -190,7 +190,7 @@ def generic_worker_run_task(config, task, taskdesc):
         worker["mounts"].append(
             {
                 "content": {
-                    "taskId": {"task-reference": "<decision>"},
+                    "task-id": {"task-reference": "<decision>"},
                     "artifact": "public/fetch-content",
                     "sha256": fetch_content_sha256,
                 },

--- a/src/taskgraph/transforms/task.py
+++ b/src/taskgraph/transforms/task.py
@@ -622,6 +622,8 @@ def build_docker_worker_payload(config, task, task_def):
                     # URL that supplies the content in response to an unauthenticated
                     # GET request.
                     Optional("url"): str,
+                    # SHA256 checksum of the content body
+                    Optional("sha256"): str,
                 },
                 # *** Either file or directory must be specified. ***
                 # If mounting a cache or read-only directory, the filesystem location of

--- a/test/test_transforms_run_run_task.py
+++ b/test/test_transforms_run_run_task.py
@@ -8,7 +8,7 @@ from pprint import pprint
 import pytest
 
 from taskgraph.transforms.run import make_task_description
-from taskgraph.transforms.task import payload_builders
+from taskgraph.transforms.task import payload_builders, set_defaults
 from taskgraph.util.caches import CACHES
 from taskgraph.util.schema import Schema, validate_schema
 from taskgraph.util.templates import merge
@@ -70,6 +70,7 @@ def assert_docker_worker(task):
                 "-cx",
                 "echo hello world",
             ],
+            "docker-image": {"in-tree": "image"},
             "env": {
                 "CI_BASE_REPOSITORY": "http://hg.example.com",
                 "CI_HEAD_REF": "default",
@@ -87,6 +88,13 @@ def assert_docker_worker(task):
         },
         "worker-type": "t-linux",
     }
+    taskdesc = next(set_defaults({}, [task]))
+    taskdesc["worker"]["max-run-time"] = 0
+    validate_schema(
+        payload_builders[taskdesc["worker"]["implementation"]].schema,
+        taskdesc["worker"],
+        "validation error",
+    )
 
 
 def assert_generic_worker(task):
@@ -123,7 +131,7 @@ def assert_generic_worker(task):
                     "content": {
                         "artifact": "public/run-task",
                         "sha256": "581ca6876fac84fa2dd8e8c2c18677d790890e9675229fd34c912c937ae19fae",
-                        "taskId": {"task-reference": "<decision>"},
+                        "task-id": {"task-reference": "<decision>"},
                     },
                     "file": "./run-task",
                 },
@@ -132,6 +140,13 @@ def assert_generic_worker(task):
         },
         "worker-type": "b-win2012",
     }
+    taskdesc = next(set_defaults({}, [task]))
+    taskdesc["worker"]["max-run-time"] = 0
+    validate_schema(
+        payload_builders[taskdesc["worker"]["implementation"]].schema,
+        taskdesc["worker"],
+        "validation error",
+    )
 
 
 def assert_exec_with(task):
@@ -177,7 +192,7 @@ def assert_run_task_command_generic_worker(task):
     "task",
     (
         pytest.param(
-            {"worker": {"os": "linux"}},
+            {"worker": {"os": "linux", "docker-image": {"in-tree": "image"}}},
             id="docker_worker",
         ),
         pytest.param(


### PR DESCRIPTION
Fixes a regression from #666, which:
- used taskId instead of task-id in the task description
- failed to add sha256 to the schema