### PR TITLE
Revert "Let generic-worker verify run-task/fetch-content integrity"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Fixed
 
-- regression in 14.2.0 causing schema validation failure for generic-worker
-  tasks using run-task (#688)
+- Revert "generic-worker will now verify run-task/fetch-content integrity" from
+  14.2.0 for being broken
 
 ## [14.2.0] - 2025-05-12
 

--- a/src/taskgraph/transforms/run/run_task.py
+++ b/src/taskgraph/transforms/run/run_task.py
@@ -6,9 +6,7 @@ Support for running tasks that are invoked via the `run-task` script.
 """
 
 import dataclasses
-import hashlib
 import os
-from pathlib import Path
 
 from voluptuous import Any, Optional, Required
 
@@ -26,9 +24,6 @@ EXEC_COMMANDS = {
     "bash": ["bash", "-cx"],
     "powershell": ["powershell.exe", "-ExecutionPolicy", "Bypass"],
 }
-
-RUN_TASK_PATH = Path(__file__).parent.parent.parent / "run-task" / "run-task"
-FETCH_CONTENT_PATH = Path(__file__).parent.parent.parent / "run-task" / "fetch-content"
 
 run_task_schema = Schema(
     {
@@ -174,14 +169,10 @@ def generic_worker_run_task(config, task, taskdesc):
     common_setup(config, task, taskdesc, command)
 
     worker.setdefault("mounts", [])
-    run_task_sha256 = hashlib.sha256(RUN_TASK_PATH.read_bytes()).hexdigest()
-    fetch_content_sha256 = hashlib.sha256(FETCH_CONTENT_PATH.read_bytes()).hexdigest()
     worker["mounts"].append(
         {
             "content": {
-                "taskId": {"task-reference": "<decision>"},
-                "artifact": "public/run-task",
-                "sha256": run_task_sha256,
+                "url": script_url(config, "run-task"),
             },
             "file": "./run-task",
         }
@@ -190,9 +181,7 @@ def generic_worker_run_task(config, task, taskdesc):
         worker["mounts"].append(
             {
                 "content": {
-                    "taskId": {"task-reference": "<decision>"},
-                    "artifact": "public/fetch-content",
-                    "sha256": fetch_content_sha256,
+                    "url": script_url(config, "fetch-content"),
                 },
                 "file": "./fetch-content",
             }

--- a/src/taskgraph/transforms/run/run_task.py
+++ b/src/taskgraph/transforms/run/run_task.py
@@ -179,7 +179,7 @@ def generic_worker_run_task(config, task, taskdesc):
     worker["mounts"].append(
         {
             "content": {
-                "task-id": {"task-reference": "<decision>"},
+                "taskId": {"task-reference": "<decision>"},
                 "artifact": "public/run-task",
                 "sha256": run_task_sha256,
             },
@@ -190,7 +190,7 @@ def generic_worker_run_task(config, task, taskdesc):
         worker["mounts"].append(
             {
                 "content": {
-                    "task-id": {"task-reference": "<decision>"},
+                    "taskId": {"task-reference": "<decision>"},
                     "artifact": "public/fetch-content",
                     "sha256": fetch_content_sha256,
                 },

--- a/src/taskgraph/transforms/task.py
+++ b/src/taskgraph/transforms/task.py
@@ -622,8 +622,6 @@ def build_docker_worker_payload(config, task, task_def):
                     # URL that supplies the content in response to an unauthenticated
                     # GET request.
                     Optional("url"): str,
-                    # SHA256 checksum of the content body
-                    Optional("sha256"): str,
                 },
                 # *** Either file or directory must be specified. ***
                 # If mounting a cache or read-only directory, the filesystem location of

--- a/test/test_transforms_run_run_task.py
+++ b/test/test_transforms_run_run_task.py
@@ -8,7 +8,7 @@ from pprint import pprint
 import pytest
 
 from taskgraph.transforms.run import make_task_description
-from taskgraph.transforms.task import payload_builders, set_defaults
+from taskgraph.transforms.task import payload_builders
 from taskgraph.util.caches import CACHES
 from taskgraph.util.schema import Schema, validate_schema
 from taskgraph.util.templates import merge
@@ -70,7 +70,6 @@ def assert_docker_worker(task):
                 "-cx",
                 "echo hello world",
             ],
-            "docker-image": {"in-tree": "image"},
             "env": {
                 "CI_BASE_REPOSITORY": "http://hg.example.com",
                 "CI_HEAD_REF": "default",
@@ -88,13 +87,6 @@ def assert_docker_worker(task):
         },
         "worker-type": "t-linux",
     }
-    taskdesc = next(set_defaults({}, [task]))
-    taskdesc["worker"]["max-run-time"] = 0
-    validate_schema(
-        payload_builders[taskdesc["worker"]["implementation"]].schema,
-        taskdesc["worker"],
-        "validation error",
-    )
 
 
 def assert_generic_worker(task):
@@ -131,7 +123,7 @@ def assert_generic_worker(task):
                     "content": {
                         "artifact": "public/run-task",
                         "sha256": "581ca6876fac84fa2dd8e8c2c18677d790890e9675229fd34c912c937ae19fae",
-                        "task-id": {"task-reference": "<decision>"},
+                        "taskId": {"task-reference": "<decision>"},
                     },
                     "file": "./run-task",
                 },
@@ -140,13 +132,6 @@ def assert_generic_worker(task):
         },
         "worker-type": "b-win2012",
     }
-    taskdesc = next(set_defaults({}, [task]))
-    taskdesc["worker"]["max-run-time"] = 0
-    validate_schema(
-        payload_builders[taskdesc["worker"]["implementation"]].schema,
-        taskdesc["worker"],
-        "validation error",
-    )
 
 
 def assert_exec_with(task):
@@ -192,7 +177,7 @@ def assert_run_task_command_generic_worker(task):
     "task",
     (
         pytest.param(
-            {"worker": {"os": "linux", "docker-image": {"in-tree": "image"}}},
+            {"worker": {"os": "linux"}},
             id="docker_worker",
         ),
         pytest.param(

--- a/test/test_transforms_run_run_task.py
+++ b/test/test_transforms_run_run_task.py
@@ -121,9 +121,7 @@ def assert_generic_worker(task):
                 {"cache-name": "checkouts", "directory": "build"},
                 {
                     "content": {
-                        "artifact": "public/run-task",
-                        "sha256": "581ca6876fac84fa2dd8e8c2c18677d790890e9675229fd34c912c937ae19fae",
-                        "taskId": {"task-reference": "<decision>"},
+                        "url": "https://tc-tests.localhost/api/queue/v1/task/<TASK_ID>/artifacts/public/run-task"
                     },
                     "file": "./run-task",
                 },


### PR DESCRIPTION
On top of the initial issue with the task schema not getting updated to match, it also causes failures because not all tasks have a direct dependency on the decision task, but generic-worker insists on that dependency existing when mounting an artifact from a task.  So go back to mounting by url.