### PR TITLE
fix: bump MAX_ROUTES up to 64

### DIFF
--- a/src/taskgraph/morph.py
+++ b/src/taskgraph/morph.py
@@ -30,7 +30,7 @@ from .util.workertypes import get_worker_type
 
 here = os.path.abspath(os.path.dirname(__file__))
 logger = logging.getLogger(__name__)
-MAX_ROUTES = 10
+MAX_ROUTES = 64
 
 registered_morphs = []
 
@@ -155,10 +155,9 @@ def make_index_task(parent_task, taskgraph, label_to_taskid, parameters, graph_c
 @register_morph
 def add_index_tasks(taskgraph, label_to_taskid, parameters, graph_config):
     """
-    The TaskCluster queue only allows 10 routes on a task, but we have tasks
-    with many more routes, for purposes of indexing. This graph morph adds
-    "index tasks" that depend on such tasks and do the index insertions
-    directly, avoiding the limits on task.routes.
+    The TaskCluster queue only allows 64 routes on a task. In the event a task
+    exceeds this limit, this graph morph adds "index tasks" that depend on it
+    and do the index insertions directly, avoiding the limit on task.routes.
     """
     logger.debug("Morphing: adding index tasks")
 


### PR DESCRIPTION
This has apparently been the limit in Taskcluster since 2019, but we never noticed / bothered to update it here.