### PR TITLE
Add the available labels when a kind dependency cannot be found

### DIFF
--- a/src/taskgraph/transforms/run/__init__.py
+++ b/src/taskgraph/transforms/run/__init__.py
@@ -269,7 +269,9 @@ def use_fetches(config, tasks):
                     if len(dep_tasks) != 1:
                         raise Exception(
                             "{name} can't fetch {kind} artifacts because "
-                            "there are {tasks} with label {label} in kind dependencies!".format(
+                            "there are {tasks} with label {label} in kind dependencies!\n"
+                            "Available tasks:"
+                            "\n - {labels}".format(
                                 name=name,
                                 kind=kind,
                                 label=dependencies[kind],
@@ -277,6 +279,9 @@ def use_fetches(config, tasks):
                                     "no tasks"
                                     if len(dep_tasks) == 0
                                     else "multiple tasks"
+                                ),
+                                labels="\n - ".join(
+                                    config.kind_dependencies_tasks.keys()
                                 ),
                             )
                         )


### PR DESCRIPTION
This makes it easier to debug errors in your Taskgraph generation.


```
Exception: distillation-student-model-quantize-en-ru can't fetch inference-build artifacts because there are no tasks with label inference-build in kind dependencies!
Available tasks:
 - toolchain-cuda-toolkit
 - toolchain-cuda-toolkit-11
 - toolchain-marian
 - toolchain-marian-cpu
 - toolchain-fast-align
 - toolchain-preprocess
 - toolchain-extract-lex
 - toolchain-kenlm
 - toolchain-cyhunspell
 - corpus-merge-devset-en-ru
 - build-vocab-en-ru
 - inference-test
 - inference-build-wasm
 - inference-test-wasm
 - distillation-corpus-build-shortlist-en-ru
 - distillation-student-model-finetune-en-ru
```