### PR TITLE
Update file_url() handling of Thunderbird comm paths

### DIFF
--- a/src/taskgraph/parameters.py
+++ b/src/taskgraph/parameters.py
@@ -253,8 +253,8 @@ class Parameters(ReadOnlyDict):
         :return str: The URL displaying the given path.
         """
         if self["repository_type"] == "hg":
-            if path.startswith("comm/"):
-                path = path[len("comm/") :]
+            if "comm/" in path:
+                path = path.split("comm/")[1]
                 repo = self["comm_head_repository"]
                 rev = self["comm_head_rev"]
             else:

--- a/test/test_parameters.py
+++ b/test/test_parameters.py
@@ -97,6 +97,25 @@ class TestParameters(TestCase):
         p = Parameters(strict=False, xyz=10, **self.vals)
         p.check()  # should not raise
 
+    def test_Parameters_file_url_hg_comm(self):
+        vals = self.vals.copy()
+        vals["repository_type"] = "hg"
+
+        vals["comm_head_repository"] = "https://hg.mozilla.org/releases/comm-beta"
+        vals["comm_head_rev"] = "branch"
+        vals["head_repository"] = "https://hg.mozilla.org/releases/mozilla-beta"
+        p = Parameters(**vals)
+
+        path = (
+            "/builds/worker/checkouts/gecko/comm/taskcluster/kinds/"
+            "shippable-l10n-signing"
+        )
+        kind_path = (
+            "https://hg.mozilla.org/releases/comm-beta/file/branch/"
+            "taskcluster/kinds/shippable-l10n-signing"
+        )
+        self.assertTrue(p.file_url(path, pretty=True) == kind_path)
+
     def test_Parameters_file_url_git_remote(self):
         vals = self.vals.copy()
         vals["repository_type"] = "git"


### PR DESCRIPTION
In commit df291c6e31b69daa2c9cb85879a2872f2d7480ca, root_dir was changed from a relative path to an absolute path, resulting in file_url() no longer detecting the path correctly as it didn't start with "comm/". This change allows file_url() to correctly detect and handle an absolute path that includes "comm/".