### PR TITLE
run-task: replace another use of datetime.utcnow()

### DIFF
--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -327,9 +327,9 @@ def get_posix_user_group(user, group):
 
 
 def write_audit_entry(path, msg):
-    now = datetime.datetime.utcnow().isoformat().encode("utf-8")
+    now = datetime.datetime.now(tz=datetime.timezone.utc).isoformat().encode("utf-8")
     with open(path, "ab") as fh:
-        fh.write(b"[%sZ %s] %s\n" % (now, os.environb.get(b"TASK_ID", b"UNKNOWN"), msg))
+        fh.write(b"[%s %s] %s\n" % (now, os.environb.get(b"TASK_ID", b"UNKNOWN"), msg))
 
 
 WANTED_DIR_MODE = stat.S_IXUSR | stat.S_IRUSR | stat.S_IWUSR


### PR DESCRIPTION
```
/usr/local/bin/run-task:330: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  now = datetime.datetime.utcnow().isoformat().encode("utf-8")
```