### PR TITLE
fix: return dict from 'status_task_batched' when testing

### DIFF
--- a/src/taskgraph/util/taskcluster.py
+++ b/src/taskgraph/util/taskcluster.py
@@ -339,7 +339,7 @@ def status_task_batched(task_ids, use_proxy=False):
     """
     if testing:
         logger.info(f"Would have gotten status for {len(task_ids)} tasks.")
-        return
+        return {}
     endpoint = liburls.api(get_root_url(use_proxy), "queue", "v1", "tasks/status")
     statuses = {}
     continuation_token = None


### PR DESCRIPTION
Otherwise this breaks `taskgraph test-action-callback` as we're expecting a dict rather than `NoneType` throughout the code base.