### PR TITLE
Add a more descriptive error when a kind cannot be found

### DIFF
--- a/src/taskgraph/generator.py
+++ b/src/taskgraph/generator.py
@@ -306,7 +306,14 @@ class TaskGraphGenerator:
         all_tasks = {}
         for kind_name in kind_graph.visit_postorder():
             logger.debug(f"Loading tasks for kind {kind_name}")
-            kind = kinds[kind_name]
+
+            kind = kinds.get(kind_name)
+            if not kind:
+                message = f'Could not find the kind "{kind_name}"\nAvailable kinds:\n'
+                for k in sorted(kinds):
+                    message += f' - "{k}"\n'
+                raise Exception(message)
+
             try:
                 new_tasks = kind.load_tasks(
                     parameters,


### PR DESCRIPTION
In translations we have a really complicated taskgraph, and it's nice to output better debug information when things go wrong. With the debug information it's easy to see I should have used "compile" rather than "compile-marian-fork".

Error before:

```
Traceback (most recent call last):
  File "/builds/worker/checkouts/utils/preflight_check.py", line 554, in <module>
    main()
  File "/builds/worker/checkouts/utils/preflight_check.py", line 522, in main
    run_taskgraph(parsed_args.config, get_taskgraph_parameters())
  File "/builds/worker/checkouts/utils/preflight_check.py", line 137, in run_taskgraph
    taskgraph.actions.trigger_action_callback(
  File "/usr/local/lib/python3.10/dist-packages/taskgraph/actions/registry.py", line 344, in trigger_action_callback
    cb(Parameters(**parameters), graph_config, input, task_group_id, task_id)
  File "/builds/worker/checkouts/taskcluster/translations_taskgraph/actions/train.py", line 601, in train_action
    taskgraph_decision(
  File "/usr/local/lib/python3.10/dist-packages/taskgraph/decision.py", line 124, in taskgraph_decision
    full_task_json = tgg.full_task_graph.to_json()
  File "/usr/local/lib/python3.10/dist-packages/taskgraph/generator.py", line 170, in full_task_graph
    return self._run_until("full_task_graph")
  File "/usr/local/lib/python3.10/dist-packages/taskgraph/generator.py", line 427, in _run_until
    k, v = next(self._run)  # type: ignore
  File "/usr/local/lib/python3.10/dist-packages/taskgraph/generator.py", line 309, in _run
    kind = kinds[kind_name]
KeyError: 'compile-marian-fork'
```

Error after:

```
Traceback (most recent call last):
  File "/builds/worker/checkouts/utils/preflight_check.py", line 554, in <module>
    main()
  File "/builds/worker/checkouts/utils/preflight_check.py", line 522, in main
    run_taskgraph(parsed_args.config, get_taskgraph_parameters())
  File "/builds/worker/checkouts/utils/preflight_check.py", line 137, in run_taskgraph
    taskgraph.actions.trigger_action_callback(
  File "/usr/local/lib/python3.10/dist-packages/taskgraph/actions/registry.py", line 344, in trigger_action_callback
    cb(Parameters(**parameters), graph_config, input, task_group_id, task_id)
  File "/builds/worker/checkouts/taskcluster/translations_taskgraph/actions/train.py", line 601, in train_action
    taskgraph_decision(
  File "/usr/local/lib/python3.10/dist-packages/taskgraph/decision.py", line 124, in taskgraph_decision
    full_task_json = tgg.full_task_graph.to_json()
  File "/usr/local/lib/python3.10/dist-packages/taskgraph/generator.py", line 170, in full_task_graph
    return self._run_until("full_task_graph")
  File "/usr/local/lib/python3.10/dist-packages/taskgraph/generator.py", line 435, in _run_until
    k, v = next(self._run)  # type: ignore
  File "/usr/local/lib/python3.10/dist-packages/taskgraph/generator.py", line 317, in _run
    raise Exception(message)
Exception: Could not find the kind "compile-marian-fork"
Available kinds:
 - "all-pipeline"
 - "all-pr-pipeline"
 - "backtranslations-mono-trg-chunk"
 - "backtranslations-mono-trg-dechunk-translations"
 - "backtranslations-mono-trg-translate"
 - "backtranslations-train-backwards-model"
 - "build-vocab"
 - "compile"
 - "continuation-corpus"
 - "continuation-model"
 - "continuation-vocab"
 - "corpus-align-backtranslations"
 - "corpus-align-distillation"
 - "corpus-align-parallel"
 - "corpus-analyze-mono"
 - "corpus-analyze-parallel"
 - "corpus-clean-mono"
 - "corpus-clean-parallel"
 - "corpus-clean-parallel-bicleaner-ai"
 - "corpus-clean-parallel-fetch-bicleaner-model"
 - "corpus-merge-devset"
 - "corpus-merge-distillation"
 - "corpus-merge-mono"
 - "corpus-merge-parallel"
 - "dataset"
 - "distillation-corpus-build-shortlist"
 - "distillation-corpus-final-filtering"
 - "distillation-mono-src-chunk"
 - "distillation-mono-src-dechunk-translations"
 - "distillation-mono-src-translate"
 - "distillation-parallel-src-chunk"
 - "distillation-parallel-src-dechunk-translations"
 - "distillation-parallel-src-extract-best"
 - "distillation-parallel-src-translate"
 - "distillation-parallel-src-translations-score"
 - "distillation-student-model-finetune"
 - "distillation-student-model-quantize"
 - "distillation-student-model-train"
 - "docker-image"
 - "evaluate"
 - "evaluate-quantized"
 - "evaluate-teacher-ensemble"
 - "export"
 - "fetch"
 - "inference"
 - "tests"
 - "toolchain"
 - "train-teacher-model"
```