### PR TITLE
docker: ensure .bashrc is readable by the worker user in load-task

### DIFF
--- a/src/taskgraph/docker.py
+++ b/src/taskgraph/docker.py
@@ -346,6 +346,7 @@ def load_task(task_id, remove=True, user=None):
 
         if task_command:
             initfile = tempfile.NamedTemporaryFile("w+", delete=False)
+            os.fchmod(initfile.fileno(), 0o644)
             initfile.write(
                 dedent(
                     f"""


### PR DESCRIPTION
The uid outside docker might not match the worker user in the container,
either due to namespaces or just not running as uid 1000, e.g. when
using podman I'm getting a root-owned 0600 .bashrc, meaning I can't
actually run exec-task.