### PR TITLE
load-task: quote the command passed to `echo`

### DIFF
--- a/src/taskgraph/docker.py
+++ b/src/taskgraph/docker.py
@@ -350,9 +350,9 @@ def load_task(task_id, remove=True, user=None):
                 dedent(
                     f"""
             function exec-task() {{
-                echo "Starting task: {task_command}";
-                pushd {task_cwd};
-                {task_command};
+                echo Starting task: {shlex.quote(task_command)}
+                pushd {task_cwd}
+                {task_command}
                 popd
             }}
             """


### PR DESCRIPTION
This would otherwise fail if the command contained shell meta-characters.