### PR TITLE
fix: removed exception for vcs root property 

### DIFF
--- a/src/taskgraph/config.py
+++ b/src/taskgraph/config.py
@@ -11,6 +11,7 @@ from typing import Dict
 
 from voluptuous import ALLOW_EXTRA, All, Any, Extra, Length, Optional, Required
 
+from .util import path
 from .util.caches import CACHES
 from .util.python_path import find_object
 from .util.schema import Schema, optionally_keyed_by, validate_schema
@@ -150,6 +151,10 @@ class GraphConfig:
 
     @property
     def vcs_root(self):
+        if path.split(self.root_dir)[-1:] != ["taskcluster"]:
+            raise Exception(
+                "Not guessing path to vcs root. Graph config in non-standard location."
+            )
         return os.path.dirname(self.root_dir)
 
     @property

--- a/src/taskgraph/config.py
+++ b/src/taskgraph/config.py
@@ -11,7 +11,6 @@ from typing import Dict
 
 from voluptuous import ALLOW_EXTRA, All, Any, Extra, Length, Optional, Required
 
-from .util import path
 from .util.caches import CACHES
 from .util.python_path import find_object
 from .util.schema import Schema, optionally_keyed_by, validate_schema
@@ -151,10 +150,6 @@ class GraphConfig:
 
     @property
     def vcs_root(self):
-        if path.split(self.root_dir)[-1:] != ["taskcluster"]:
-            raise Exception(
-                "Not guessing path to vcs root. Graph config in non-standard location."
-            )
         return os.path.dirname(self.root_dir)
 
     @property

--- a/src/taskgraph/config.py
+++ b/src/taskgraph/config.py
@@ -7,14 +7,15 @@ import logging
 import os
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Dict
 
 from voluptuous import ALLOW_EXTRA, All, Any, Extra, Length, Optional, Required
 
-from .util import path
 from .util.caches import CACHES
 from .util.python_path import find_object
 from .util.schema import Schema, optionally_keyed_by, validate_schema
+from .util.vcs import get_repository
 from .util.yaml import load_yaml
 
 logger = logging.getLogger(__name__)
@@ -151,11 +152,10 @@ class GraphConfig:
 
     @property
     def vcs_root(self):
-        if path.split(self.root_dir)[-1:] != ["taskcluster"]:
-            raise Exception(
-                "Not guessing path to vcs root. Graph config in non-standard location."
-            )
-        return os.path.dirname(self.root_dir)
+        repo = get_repository(os.getcwd())
+        path = Path(repo.path)
+
+        return path
 
     @property
     def taskcluster_yml(self):

--- a/src/taskgraph/parameters.py
+++ b/src/taskgraph/parameters.py
@@ -363,7 +363,10 @@ def load_parameters_file(
 
 def parameters_loader(spec, strict=True, overrides=None):
     def get_parameters(graph_config):
-        repo_root = graph_config.vcs_root
+        try:
+            repo_root = graph_config.vcs_root
+        except Exception:
+            repo_root = None
 
         parameters = load_parameters_file(
             spec,

--- a/src/taskgraph/parameters.py
+++ b/src/taskgraph/parameters.py
@@ -363,10 +363,7 @@ def load_parameters_file(
 
 def parameters_loader(spec, strict=True, overrides=None):
     def get_parameters(graph_config):
-        try:
-            repo_root = graph_config.vcs_root
-        except Exception:
-            repo_root = None
+        repo_root = graph_config.vcs_root
 
         parameters = load_parameters_file(
             spec,

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -30,3 +30,15 @@ def test_graph_config_basic():
 
     with pytest.raises(TypeError):
         graph_config["baz"] = 2
+
+
+def test_vcs_root_property():
+    """Test the vcs_root property returns the parent directory of root_dir without throwing an exception."""
+
+    # Test with a standard taskcluster directory structure
+    graph_config = GraphConfig({}, "/path/to/project/taskcluster")
+    assert graph_config.vcs_root == "/path/to/project"
+
+    # Test with a different directory structure
+    graph_config = GraphConfig({}, "/path/to/custom/.taskgraph")
+    assert graph_config.vcs_root == "/path/to/custom"

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -3,6 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os.path
+from pathlib import Path
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -30,3 +32,19 @@ def test_graph_config_basic():
 
     with pytest.raises(TypeError):
         graph_config["baz"] = 2
+
+
+def test_vcs_root_with_non_standard_dir():
+    """Test that  property uses vcs_root correctly with a non standard path"""
+
+    path_repo = "/path/to/repo"
+    mock_repo = Mock()
+    mock_repo.path = path_repo
+
+    with patch("taskgraph.config.get_repository", return_value=mock_repo):
+        graph_config = GraphConfig({"foo": "bar"}, "root/data")
+        vcs_root = graph_config.vcs_root
+
+        expected_path = Path("/path/to/repo")
+
+        assert vcs_root == expected_path

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -30,15 +30,3 @@ def test_graph_config_basic():
 
     with pytest.raises(TypeError):
         graph_config["baz"] = 2
-
-
-def test_vcs_root_property():
-    """Test the vcs_root property returns the parent directory of root_dir without throwing an exception."""
-
-    # Test with a standard taskcluster directory structure
-    graph_config = GraphConfig({}, "/path/to/project/taskcluster")
-    assert graph_config.vcs_root == "/path/to/project"
-
-    # Test with a different directory structure
-    graph_config = GraphConfig({}, "/path/to/custom/.taskgraph")
-    assert graph_config.vcs_root == "/path/to/custom"


### PR DESCRIPTION
Removing this exception should all for non-standard root directories to work. Closes #522. I am not sure exactly what this #522 is asking for, please correct me if interpretation was wrong 