### PR TITLE
feat: use `primary-dependency` attribute to find primary dependency of a task

### DIFF
--- a/src/taskgraph/transforms/from_deps.py
+++ b/src/taskgraph/transforms/from_deps.py
@@ -206,6 +206,7 @@ def from_deps(config, tasks):
             )
 
             primary_dep = [dep for dep in group if dep.kind == primary_kind][0]
+            new_task["attributes"]["primary-dependency-label"] = primary_dep.label
 
             if set_name:
                 func = SET_NAME_MAP[set_name]

--- a/src/taskgraph/util/dependencies.py
+++ b/src/taskgraph/util/dependencies.py
@@ -68,10 +68,9 @@ def get_dependencies(config: TransformConfig, task: Dict) -> Iterator[Task]:
 
 
 def get_primary_dependency(config: TransformConfig, task: Dict) -> Optional[Task]:
-    """Return the ``Task`` object associated with the primary dependency.
-
-    This uses the task's ``primary-kind-dependency`` attribute to find the primary
-    dependency, or returns ``None`` if the attribute is unset.
+    """Return the ``Task`` object associated with the primary dependency,
+    which is assumed to be available in the ``primary-dependency`` attribute.
+    (Which is always the case for tasks created with ``from_deps``.)
 
     Args:
         config (TransformConfig): The ``TransformConfig`` object associated
@@ -83,10 +82,7 @@ def get_primary_dependency(config: TransformConfig, task: Dict) -> Optional[Task
             primary dependency or ``None``.
     """
     try:
-        primary_kind = task["attributes"]["primary-kind-dependency"]
+        label = task["attributes"]["primary-dependency-label"]
+        return config.kind_dependencies_tasks[label]
     except KeyError:
         return None
-
-    for dep in get_dependencies(config, task):
-        if dep.kind == primary_kind:
-            return dep

--- a/test/test_util_dependencies.py
+++ b/test/test_util_dependencies.py
@@ -22,12 +22,12 @@ def test_get_primary_dependency(make_transform_config):
         "foo": make_task("foo", kind="kind1"),
         "bar": make_task("bar", kind="kind2"),
     }
-    config = make_transform_config(kind_dependencies_tasks=dep_tasks)
     task = {
         "attributes": {},
         "dependencies": {"kind1": "foo", "kind2": "bar"},
     }
+    config = make_transform_config(kind_dependencies_tasks=dep_tasks)
     assert get_primary_dependency(config, task) is None
 
-    task["attributes"]["primary-kind-dependency"] = "kind2"
+    task["attributes"]["primary-dependency-label"] = dep_tasks["bar"].label
     assert get_primary_dependency(config, task) == list(dep_tasks.values())[1]


### PR DESCRIPTION
Storing this on `from_deps` tasks allows us to avoid iterating over potentially all the task dependencies when finding it later, which can add up to a lot of time in larger graphs.

In a profile I ran for gecko taskgraph, `get_dependencies` (via `get_primary_dependency`) was the second hottest function. With this patch it moves down to 10th place, and takes 1/4 of the amount of time it used to.