### PR TITLE
fix: revert accidental schema changes

### DIFF
--- a/src/taskgraph/transforms/run/__init__.py
+++ b/src/taskgraph/transforms/run/__init__.py
@@ -153,7 +153,7 @@ run_description_schema = Schema(
             Extra: object,
         },
         Required("worker-type"): task_description_schema["worker-type"],
-        Required(
+        Optional(
             "worker",
             description=dedent(
                 """

--- a/src/taskgraph/transforms/run/toolchain.py
+++ b/src/taskgraph/transforms/run/toolchain.py
@@ -97,7 +97,7 @@ toolchain_run_schema = Schema(
                 """
             ),
         ): {str: object},
-        Optional(
+        Required(
             "workdir",
             description=dedent(
                 """


### PR DESCRIPTION
In:
https://github.com/taskcluster/taskgraph/commit/ec06326b47544fa01f1676b5c5544c22d1e678d0#diff

I refactored the schemas to use a description. I accidentally changed two keys (one Required->Optional, the other Optional->Required).

This was supposed to be a doc only change, so let's revert them back to the way they were.