### PR TITLE
fix: fallback to guessing repo root in config.py

### DIFF
--- a/src/taskgraph/config.py
+++ b/src/taskgraph/config.py
@@ -152,10 +152,16 @@ class GraphConfig:
 
     @property
     def vcs_root(self):
-        repo = get_repository(os.getcwd())
-        path = Path(repo.path)
-
-        return path
+        try:
+            repo = get_repository(os.getcwd())
+            return Path(repo.path)
+        except RuntimeError:
+            root = Path(self.root_dir)
+            if root.parts[-1:] != ("taskcluster",):
+                raise Exception(
+                    "Not guessing path to vcs root. Graph config in non-standard location."
+                )
+            return root.parent
 
     @property
     def taskcluster_yml(self):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -48,3 +48,15 @@ def test_vcs_root_with_non_standard_dir():
         expected_path = Path("/path/to/repo")
 
         assert vcs_root == expected_path
+
+
+def test_vcs_root_fallback(mocker):
+    mocker.patch("os.getcwd", return_value="/path/to/repo")
+
+    cfg = {"foo": "bar"}
+    with mocker.patch("taskgraph.config.get_repository", side_effect=RuntimeError):
+        assert GraphConfig(cfg, "taskcluster").vcs_root == Path("/path/to/repo")
+
+    with mocker.patch("taskgraph.config.get_repository", side_effect=RuntimeError):
+        with pytest.raises(Exception):
+            GraphConfig(cfg, "root/data").vcs_root


### PR DESCRIPTION
We made the repo root detection smarter by using util/vcs.py to search for the `.git` directory. However, this broke a MacOS build task in Gecko CI because no `.git` directory exists. I'm not entirely sure why that happens, as the Taskgraph command still needs to run from the repo root.

At any rate, this patch re-adds the old logic as a fallback in the event util/vcs.py wasn't able to detect the repo.