### PR TITLE
revert: multiprocess kind processing

### DIFF
--- a/packages/pytest-taskgraph/src/pytest_taskgraph/fixtures/gen.py
+++ b/packages/pytest-taskgraph/src/pytest_taskgraph/fixtures/gen.py
@@ -62,13 +62,8 @@ class WithFakeKind(TaskGraphGenerator):
             yield FakeKind(kind_name, "/fake", config, graph_config)
 
 
-class FakeGraphConfig(GraphConfig):
-    def register(self):
-        pass
-
-
 def fake_load_graph_config(root_dir):
-    graph_config = FakeGraphConfig(
+    graph_config = GraphConfig(
         {
             "trust-domain": "test-domain",
             "taskgraph": {
@@ -108,6 +103,7 @@ def fake_load_graph_config(root_dir):
         },
         root_dir,
     )
+    graph_config.__dict__["register"] = lambda: None
     return graph_config
 
 

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -3,27 +3,16 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-from concurrent.futures import ProcessPoolExecutor
-
 import pytest
-from pytest_taskgraph import WithFakeKind, fake_load_graph_config
+from pytest_taskgraph import FakeKind, WithFakeKind, fake_load_graph_config
 
 from taskgraph import generator, graph
 from taskgraph.generator import Kind, load_tasks_for_kind
 from taskgraph.loader.default import loader as default_loader
 
 
-class FakePPE(ProcessPoolExecutor):
-    loaded_kinds = []
-
-    def submit(self, kind_load_tasks, *args):
-        self.loaded_kinds.append(kind_load_tasks.__self__.name)
-        return super().submit(kind_load_tasks, *args)
-
-
-def test_kind_ordering(mocker, maketgg):
+def test_kind_ordering(maketgg):
     "When task kinds depend on each other, they are loaded in postorder"
-    mocked_ppe = mocker.patch.object(generator, "ProcessPoolExecutor", new=FakePPE)
     tgg = maketgg(
         kinds=[
             ("_fake3", {"kind-dependencies": ["_fake2", "_fake1"]}),
@@ -32,7 +21,7 @@ def test_kind_ordering(mocker, maketgg):
         ]
     )
     tgg._run_until("full_task_set")
-    assert mocked_ppe.loaded_kinds == ["_fake1", "_fake2", "_fake3"]
+    assert FakeKind.loaded_kinds == ["_fake1", "_fake2", "_fake3"]
 
 
 def test_full_task_set(maketgg):
@@ -286,5 +275,5 @@ def test_kind_load_tasks(monkeypatch, graph_config, parameters, datadir, kind_co
     kind = Kind(
         name="fake", path="foo/bar", config=kind_config, graph_config=graph_config
     )
-    tasks = kind.load_tasks(parameters, {}, False)
+    tasks = kind.load_tasks(parameters, [], False)
     assert tasks


### PR DESCRIPTION
While this worked very well on Linux, it causes issues anywhere we can't `fork` to get a new process (most notably on Windows). The problem lies in the fact that in these cases, we spawn an entire new process, which re-imports taskgraph from scratch. This is fine in some cases, but in any case where global state has been modified in an earlier part of `TaskGraphGenerator._run`, we lose whatever side effects happened there, and end up failing in some way.

Concretely: in gecko we add a bunch of `payload_builders` as part of registering the graph config. This code doesn't re-run in the spawned processes, so the payload builders don't exist there.

There are workarounds for this: for example, redoing all the earlier work of `_run` in each subprocess, or perhaps finding some way to ensure all the needed state is passed explicitly. There's no quick and easy way to make this work though, and some thought should be given to the tradeoffs of doing it (vs. doing nothing, or spending the effort on a different way to parallelize) before proceeding.