### PR TITLE
Fix parameter order for build_image/build_context in main

### DIFF
--- a/src/taskgraph/main.py
+++ b/src/taskgraph/main.py
@@ -590,10 +590,10 @@ def build_image(args):
     graph_config = load_graph_config(root)
 
     if args["context_only"] is None:
-        build_image(args["image_name"], args["tag"], os.environ, graph_config)
+        build_image(args["image_name"], args["tag"], graph_config, os.environ)
     else:
         build_context(
-            args["image_name"], args["context_only"], os.environ, graph_config
+            args["image_name"], args["context_only"], graph_config, os.environ
         )
 
 


### PR DESCRIPTION
This fixes a regression from d2dee6ad6631b1d67255ff54f978e9e53ff11fb6 which added the graph config arg but then got the order wrong in these calls which lead to `TypeError: unhashable type: '_Environ'` in image_path when calling `taskgraph build-image`

```
Traceback (most recent call last):
  File "src/taskgraph/main.py", line 1020, in main
    return args.command(vars(args))
           ~~~~~~~~~~~~^^^^^^^^^^^^
  File "src/taskgraph/main.py", line 593, in build_image
    build_image(args["image_name"], args["tag"], os.environ, graph_config)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "src/taskgraph/docker.py", line 122, in build_image
    image_dir = docker.image_path(name, graph_config)
  File "src/taskgraph/util/docker.py", line 225, in image_path
    paths = image_paths(graph_config)
TypeError: unhashable type: '_Environ'
```