### PR TITLE
fix: make task_context transforms really work without a task-context

### DIFF
--- a/src/taskgraph/transforms/task_context.py
+++ b/src/taskgraph/transforms/task_context.py
@@ -85,7 +85,10 @@ transforms.add_validate(SCHEMA)
 @transforms.add
 def render_task(config, tasks):
     for task in tasks:
-        sub_config = task.pop("task-context")
+        sub_config = task.pop("task-context", None)
+        if sub_config is None:
+            yield task
+            continue
         params_context = {}
         for var, path in sub_config.pop("from-parameters", {}).items():
             if isinstance(path, str):


### PR DESCRIPTION
It's not enough to make it optional in the schema, the actual code also has to deal with its absence.

Thanks @ErichDonGubler!