### PR TITLE
Add ability to use custom images in `taskgraph load-task`

### DIFF
--- a/src/taskgraph/docker.py
+++ b/src/taskgraph/docker.py
@@ -10,7 +10,7 @@ import tarfile
 import tempfile
 from io import BytesIO
 from textwrap import dedent
-from typing import Dict, Generator, List, Mapping, Optional, Union
+from typing import Dict, Generator, List, Mapping, Optional
 
 try:
     import zstandard as zstd
@@ -65,7 +65,7 @@ def get_image_digest(image_name: str) -> str:
     return task.attributes["cached_task"]["digest"]
 
 
-def load_image_by_name(image_name: str, tag: Optional[str] = None) -> Union[str, bool]:
+def load_image_by_name(image_name: str, tag: Optional[str] = None) -> Optional[str]:
     """Load a docker image by its name.
 
     Finds the appropriate docker image task by name and loads it from
@@ -77,7 +77,7 @@ def load_image_by_name(image_name: str, tag: Optional[str] = None) -> Union[str,
             uses the tag from the image artifact.
 
     Returns:
-        str or bool: The full image tag (name:tag) if successful, False if
+        str or None: The full image tag (name:tag) if successful, None if
             the image artifacts could not be found.
     """
     from taskgraph.generator import load_tasks_for_kind  # noqa: PLC0415
@@ -104,7 +104,7 @@ def load_image_by_name(image_name: str, tag: Optional[str] = None) -> Union[str,
                 image_name=image_name, project=params["project"]
             )
         )
-        return False
+        return None
 
     return load_image_by_task_id(task_id, tag)
 

--- a/src/taskgraph/main.py
+++ b/src/taskgraph/main.py
@@ -569,7 +569,7 @@ def show_taskgraph(options):
     "--root",
     "-r",
     default="taskcluster",
-    help="relative path for the root of the taskgraph definition",
+    help="Relative path to the root of the Taskgraph definition.",
 )
 @argument(
     "-t", "--tag", help="tag that the image should be built as.", metavar="name:tag"
@@ -683,11 +683,34 @@ def image_digest(args):
     help="Keep the docker container after exiting.",
 )
 @argument("--user", default=None, help="Container user to start shell with.")
+@argument(
+    "--image",
+    default=None,
+    help="Use a custom image instead of the task's image. Can be the name of "
+    "an image under `taskcluster/docker`, `task-id=<task id>`, or "
+    "`index=<index path>`.",
+)
+@argument(
+    "--root",
+    "-r",
+    default="taskcluster",
+    help="Relative path to the root of the Taskgraph definition.",
+)
 def load_task(args):
+    from taskgraph.config import load_graph_config  # noqa: PLC0415
     from taskgraph.docker import load_task  # noqa: PLC0415
 
     validate_docker()
-    return load_task(args["task_id"], remove=args["remove"], user=args["user"])
+
+    root = args["root"]
+    graph_config = load_graph_config(root)
+    return load_task(
+        graph_config,
+        args["task_id"],
+        remove=args["remove"],
+        user=args["user"],
+        custom_image=args["image"],
+    )
 
 
 @command("decision", help="Run the decision task")


### PR DESCRIPTION
This makes it really nice to iterate on a docker image and test it against a live task, by using e.g:
```
taskgraph load-task <task-id> --image python
```

This will re-build the `taskcluster/docker/python` image, launch it in a container, and load `<task-id>` into it.