### PR TITLE
feat: Add ssh client to run-task so git clones through SSH (bug 1989234)

### DIFF
--- a/taskcluster/docker/run-task/system-setup.sh
+++ b/taskcluster/docker/run-task/system-setup.sh
@@ -7,6 +7,7 @@ test "$(whoami)" == 'root'
 apt-get update
 apt-get install -y --force-yes --no-install-recommends \
     ca-certificates \
+    openssh-client \
     python3 \
     python3-pip \
     python3-setuptools \


### PR DESCRIPTION
For reference, the latest build didn't `openssh-client`:

```
The following additional packages will be installed:
 [...]
Suggested packages:
 [...]
Recommended packages:
 [...] openssh-client [...]
The following NEW packages will be installed:
  ca-certificates curl git git-man libbrotli1 libcurl3-gnutls libcurl4
  liberror-perl libexpat1 libgdbm-compat4 libgdbm6 libgssapi-krb5-2
  libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libldap-2.5-0
  libncursesw6 libnghttp2-14 libnsl2 libperl5.36 libpsl5 libpython3-stdlib
  libpython3.11-minimal libpython3.11-stdlib libreadline8 librtmp1 libsasl2-2
  libsasl2-modules-db libsqlite3-0 libssh2-1 libssl3 libtirpc-common libtirpc3
  media-types mercurial mercurial-common openssl perl perl-modules-5.36
  python3 python3-distutils python3-lib2to3 python3-minimal python3-pip
  python3-pkg-resources python3-setuptools python3-wheel python3.11
  python3.11-minimal readline-common sensible-utils sudo ucf unzip
0 upgraded, 55 newly installed, 0 to remove and 0 not upgraded.
```

https://firefox-ci-tc.services.mozilla.com/tasks/TW54TrRfTFOUpB3ysHWLAw/runs/0/logs/public/logs/live.log