### PR TITLE
feat: pass along `write_artifacts` to loaders

### DIFF
--- a/packages/pytest-taskgraph/src/pytest_taskgraph/fixtures/gen.py
+++ b/packages/pytest-taskgraph/src/pytest_taskgraph/fixtures/gen.py
@@ -17,7 +17,7 @@ from taskgraph.util.templates import merge
 here = Path(__file__).parent
 
 
-def fake_loader(kind, path, config, parameters, loaded_tasks):
+def fake_loader(kind, path, config, parameters, loaded_tasks, write_artifacts):
     for i in range(3):
         dependencies = {}
         if i >= 1:

--- a/src/taskgraph/generator.py
+++ b/src/taskgraph/generator.py
@@ -66,6 +66,7 @@ class Kind:
             config,
             parameters,
             list(kind_dependencies_tasks.values()),
+            write_artifacts,
         )
 
         transforms = TransformSequence()

--- a/src/taskgraph/loader/default.py
+++ b/src/taskgraph/loader/default.py
@@ -16,7 +16,7 @@ DEFAULT_TRANSFORMS = [
 ]
 
 
-def loader(kind, path, config, params, loaded_tasks):
+def loader(kind, path, config, params, loaded_tasks, write_artifacts):
     """
     This default loader builds on the `transform` loader by providing sensible
     default transforms that the majority of simple tasks will need.
@@ -30,4 +30,4 @@ def loader(kind, path, config, params, loaded_tasks):
                 f"Transform {t} is already present in the loader's default transforms; it must not be defined in the kind"
             )
     transform_refs.extend(DEFAULT_TRANSFORMS)
-    return transform_loader(kind, path, config, params, loaded_tasks)
+    return transform_loader(kind, path, config, params, loaded_tasks, write_artifacts)

--- a/src/taskgraph/loader/transform.py
+++ b/src/taskgraph/loader/transform.py
@@ -11,7 +11,7 @@ from taskgraph.util.yaml import load_yaml
 logger = logging.getLogger(__name__)
 
 
-def loader(kind, path, config, params, loaded_tasks):
+def loader(kind, path, config, params, loaded_tasks, write_artifacts):
     """
     Get the input elements that will be transformed into tasks in a generic
     way.  The elements themselves are free-form, and become the input to the

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -243,7 +243,7 @@ def test_default_loader(config, expected_transforms):
     assert loader is default_loader, (
         "Default Kind loader should be taskgraph.loader.default.loader"
     )
-    loader("", "", config, {}, [])
+    loader("", "", config, {}, [], False)
 
     assert config["transforms"] == expected_transforms
 
@@ -273,7 +273,7 @@ def test_default_loader(config, expected_transforms):
 def test_default_loader_errors(config):
     loader = Kind("", "", config, {})._get_loader()
     try:
-        loader("", "", config, {}, [])
+        loader("", "", config, {}, [], False)
     except KeyError:
         return
 


### PR DESCRIPTION
Taskgraph already passes this information along to transforms, and over in https://bugzilla.mozilla.org/show_bug.cgi?id=1989038 we have a use case to have loaders know about it too: we need to write out an artifact whose contents are only known after all tasks for a specific kind have been loaded and transformed.

(Technically we could avoid passing this along, but it would mean we have no reasonable way to switch off the writing of this artifact outside of decision tasks...)