### PR TITLE
feat: create the perfherder-data.json for fetch-content task (bug-1992052)

### DIFF
--- a/src/taskgraph/run-task/fetch-content
+++ b/src/taskgraph/run-task/fetch-content
@@ -952,6 +952,12 @@ def command_task_artifacts(args):
         ],
     }
     print("PERFHERDER_DATA: {}".format(json.dumps(perfherder_data)), file=sys.stderr)
+    upload_dir = os.environ.get("UPLOAD_DIR")
+    if os.environ.get("MOZ_AUTOMATION", "0") == "1" and upload_dir:
+        upload_path = pathlib.Path(upload_dir) / "perfherder-data-fetch-content.json"
+        upload_path.parent.mkdir(parents=True, exist_ok=True)
+        with upload_path.open("w") as f:
+            json.dump(perfherder_data, f)
 
 
 def main():


### PR DESCRIPTION
Currently, performance data is logged only as `PERFHERDER_DATA:`.
This PR creates a `perfherder-data-fetch-content.json` artifact in the production environment(not local) for downstream tools.
Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1992052

I ran a CI test [0].  
When testing with the `mach try fuzzy` command, I wrote the code to mozilla-central[1] to check the CI result.

[0]
https://firefoxci.taskcluster-artifacts.net/VjtXAyawTb257WRd8FE8lw/0/public/build/perfherder-data-fetch-content.json
https://treeherder.mozilla.org/jobs?repo=try&revision=9d2a399b35c3e9e9f8f98a8668b882ff76060f53&selectedTaskRun=VjtXAyawTb257WRd8FE8lw.0
[1]
https://searchfox.org/firefox-main/source/third_party/python/taskcluster_taskgraph/taskgraph/run-task/fetch-content#954