### PR TITLE
style: exclude robustcheckout.py and revert changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,5 +43,6 @@ repos:
         stages: [commit-msg]
 exclude: |
   (?x)^(
+    src/taskgraph/run-task/robustcheckout.py |
     taskcluster/scripts/external_tools
   )

--- a/src/taskgraph/run-task/robustcheckout.py
+++ b/src/taskgraph/run-task/robustcheckout.py
@@ -453,7 +453,7 @@ def _docheckout(
         )
 
         # Do a backoff on retries to mitigate the thundering herd
-        # problem. This is an exponential backoff with a multiplier
+        # problem. This is an exponential backoff with a multipler
         # plus random jitter thrown in for good measure.
         # With the default settings, backoffs will be:
         # 1) 2.5 - 6.5


### PR DESCRIPTION
This is third party code that gets pulled in periodically. Let's keep excluding it and revert the recent style fix.