### PR TITLE
fix: added use_proxy flag to get_artifact_url

### DIFF
--- a/src/taskgraph/util/parameterization.py
+++ b/src/taskgraph/util/parameterization.py
@@ -90,7 +90,11 @@ def resolve_task_references(
                         f"task '{label}' has no dependency named '{dependency}'"
                     )
 
-            return get_artifact_url(task_id, artifact_name)
+            use_proxy = False
+            if not artifact_name.startswith("public/"):
+                use_proxy = True
+
+            return get_artifact_url(task_id, artifact_name, use_proxy=use_proxy)
 
         return ARTIFACT_REFERENCE_PATTERN.sub(repl, val)
 


### PR DESCRIPTION
I thought adding a block_proxy flag to get_root_url, would be the best option for get_rool_url so we could avoid having to duplicate the code from get_root_url if use_proxy is not used in get_artifact_url without it accidently picking up the proxy url even if that is set to false