### PR TITLE
run-task: wait on child processes when we're pid 1.

### DIFF
--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -28,6 +28,7 @@ import socket
 import stat
 import subprocess
 import sys
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -119,6 +120,17 @@ def print_line(prefix, m):
     )
     sys.stdout.buffer.write(b"[%s %s] %s" % (prefix, now, m))
     sys.stdout.buffer.flush()
+
+
+def reap_zombies(main_subprocess):
+    """Wait for main_subprocess to exit, while awaiting any other child processes"""
+    while main_subprocess.poll() is None:
+        with main_subprocess._waitpid_lock:
+            if main_subprocess.returncode is not None:
+                return
+            pid, status = os.wait()
+            if pid == main_subprocess.pid:
+                main_subprocess._handle_exitstatus(status)
 
 
 def _call_windows_retry(func, args=(), retry_max=5, retry_delay=0.5):
@@ -278,6 +290,13 @@ def run_command(prefix, args, *, extra_env=None, cwd=None):
 
     stdout = io.TextIOWrapper(p.stdout, encoding="latin1")
 
+    if os.getpid() == 1:
+        # in docker we're init, so we get to adopt unawaited zombies
+        reaper_thread = threading.Thread(target=reap_zombies, args=(p,))
+        reaper_thread.start()
+    else:
+        reaper_thread = None
+
     while True:
         data = stdout.readline().encode("latin1")
 
@@ -286,6 +305,8 @@ def run_command(prefix, args, *, extra_env=None, cwd=None):
 
         print_line(prefix, data)
 
+    if reaper_thread:
+        reaper_thread.join()
     return p.wait()
 
 


### PR DESCRIPTION
Avoid leaving zombie processes around in the container while the task is running.

Ported from gecko (bug 1967974)