### PR TITLE
Restore `list_artifacts` to its correct behavior

### DIFF
--- a/src/taskgraph/util/taskcluster.py
+++ b/src/taskgraph/util/taskcluster.py
@@ -175,9 +175,8 @@ def get_artifact(task_id, path):
 
 def list_artifacts(task_id):
     queue = get_taskcluster_client("queue")
-    task = queue.task(task_id)
-    if task:
-        return task["artifacts"]
+    response = queue.listLatestArtifacts(task_id)
+    return response["artifacts"]
 
 
 def get_artifact_prefix(task):

--- a/test/test_util_taskcluster.py
+++ b/test/test_util_taskcluster.py
@@ -139,7 +139,7 @@ def test_list_artifact(responses, root_url):
     tc.get_taskcluster_client.cache_clear()
 
     responses.get(
-        f"{root_url}/api/queue/v1/task/{tid}",
+        f"{root_url}/api/queue/v1/task/{tid}/artifacts",
         json={"artifacts": ["file1.txt", "file2.json"]},
     )
 


### PR DESCRIPTION
This fixes a regression from 384afee759351f22ab9e0a43ac066f3fa5f3b6d9 where `list_artifacts` went from listing the latest artifacts from a task to getting the task definition and returning a non existent field from it, leading to:

```
  File "/builds/worker/checkouts/src/taskcluster/src/target_tasks.py", line 27, in _filter_for_pr
    for artifact in list_artifacts(diff_task):
                    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/src/taskcluster-taskgraph/src/taskgraph/util/taskcluster.py", line 166, in list_artifacts
    return task["artifacts"]
           ~~~~^^^^^^^^^^^^^
KeyError: 'artifacts'
```