### PR TITLE
fix(deps): bump taskcluster lower bound to >=91

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "redo>=2.0",
   "requests>=2.25",
   "slugid>=2.0",
-  "taskcluster>=55.0",
+  "taskcluster>=91.0",
   "taskcluster-urls>=11.0",
   "voluptuous>=0.12.1",
 ]

--- a/test/test_util_taskcluster.py
+++ b/test/test_util_taskcluster.py
@@ -134,6 +134,27 @@ def test_get_artifact(responses, root_url):
     assert result == expected_result
 
 
+def test_get_artifact_redirect(responses, root_url):
+    tid = "abc123"
+    tc.get_taskcluster_client.cache_clear()
+    contents = {"foo": "bar"}
+
+    redirect_url = "https://example.com/artifact.json"
+    responses.get(
+        f"{root_url}/api/queue/v1/task/{tid}/artifacts/artifact.json",
+        json={"url": redirect_url},
+        headers={"Location": redirect_url},
+        status=301,
+    )
+    responses.get(
+        redirect_url,
+        json=contents,
+        status=200,
+    )
+    result = tc.get_artifact(tid, "artifact.json")
+    assert result == contents
+
+
 def test_list_artifact(responses, root_url):
     tid = "abc123"
     tc.get_taskcluster_client.cache_clear()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.8"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -998,7 +998,7 @@ version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.13'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -3320,7 +3320,7 @@ wheels = [
 
 [[package]]
 name = "taskcluster"
-version = "90.0.5"
+version = "91.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp", version = "3.10.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
@@ -3333,14 +3333,14 @@ dependencies = [
     { name = "slugid" },
     { name = "taskcluster-urls" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/9a/f28142083e024bce75ebbc6ac5de0b3ce8a0b5989c83493a172718fde986/taskcluster-90.0.5.tar.gz", hash = "sha256:3529b62d05b3a869669e7c128cf46849de6641d50d598e8ce81cd4ed7ba756f6", size = 129199, upload-time = "2025-10-08T13:55:23.916Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/b9/96fc43251b42348b2e422a45bd7c6795311e32e322b141e97be83ba28e64/taskcluster-91.0.0.tar.gz", hash = "sha256:2e21feac068750503a32f4ca4273c904d8455d6b1db8e7295c3aa119af65abf4", size = 129244, upload-time = "2025-10-14T17:13:33.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/4c/7c4473080e9e74666e49fa3477f601d7188bb6bd1db68ec5e4c875829505/taskcluster-90.0.5-py3-none-any.whl", hash = "sha256:d4ca28ffa391fbd2f6553b5c390a606a01748ba12791ad90675efd65b734a3c7", size = 147341, upload-time = "2025-10-08T13:55:21.866Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/16/92be916f30d90ae41ee406a843f42bbedbe95109d61cb188187ab72bad75/taskcluster-91.0.0-py3-none-any.whl", hash = "sha256:c6301a5f730bb65feb2811b1190bef8124af0aeddd931eb877e066202348f5bd", size = 147340, upload-time = "2025-10-14T17:13:31.658Z" },
 ]
 
 [[package]]
 name = "taskcluster-taskgraph"
-version = "16.2"
+version = "16.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },
@@ -3411,7 +3411,7 @@ requires-dist = [
     { name = "redo", specifier = ">=2.0" },
     { name = "requests", specifier = ">=2.25" },
     { name = "slugid", specifier = ">=2.0" },
-    { name = "taskcluster", specifier = ">=55.0" },
+    { name = "taskcluster", specifier = ">=91.0" },
     { name = "taskcluster-urls", specifier = ">=11.0" },
     { name = "voluptuous", specifier = ">=0.12.1" },
     { name = "zstandard", marker = "extra == 'load-image'" },


### PR DESCRIPTION
This picks up a fix causing the Python client to follow redirects.

Issue: #812