### PR TITLE
Use `links_and_reverse_links_dict` in `replace_tasks`

### DIFF
--- a/src/taskgraph/optimize/base.py
+++ b/src/taskgraph/optimize/base.py
@@ -297,8 +297,9 @@ def replace_tasks(
 
     opt_counts = defaultdict(int)
     replaced = set()
-    dependents_of = target_task_graph.graph.reverse_links_dict()
-    dependencies_of = target_task_graph.graph.links_dict()
+    dependencies_of, dependents_of = (
+        target_task_graph.graph.links_and_reverse_links_dict()
+    )
 
     for label in target_task_graph.graph.visit_postorder():
         logger.debug(f"replace_tasks: {label}")


### PR DESCRIPTION
In b7134975846a0bc2266213bc64cd4e2b0c953067 we added a function to get both `links_dict` and `reverse_links_dict` in one go, avoiding iterating over the graph twice to build those. That function also benefits from being cached. I'm not expecting a big change in performance here but we might as well.