### PR TITLE
Make sure that cached values from links_and_reverse_links_dict are not mutable inside

### DIFF
--- a/src/taskgraph/graph.py
+++ b/src/taskgraph/graph.py
@@ -133,7 +133,11 @@ class Graph(_Graph):
         for left, right, _ in self.edges:
             forward[left].add(right)
             reverse[right].add(left)
-        return (ReadOnlyDict(forward), ReadOnlyDict(reverse))
+
+        return (
+            ReadOnlyDict({key: frozenset(value) for key, value in forward.items()}),
+            ReadOnlyDict({key: frozenset(value) for key, value in reverse.items()}),
+        )
 
     def links_dict(self):
         """


### PR DESCRIPTION
Yay python, it's great... In 20b45bad3cb00c3a366f3adaf460edcb68a45d58 we made sure that we'd return read only dicts from this function since it's caching the result, but we kinda forgot that the value was a set and thus was still mutable... This commits freezes said sets so now those objects should be properly read only...