### PR TITLE
feat: add support for outputting a mermaid flowchart of the kind graph

### DIFF
--- a/src/taskgraph/generator.py
+++ b/src/taskgraph/generator.py
@@ -250,6 +250,15 @@ class TaskGraphGenerator:
         """
         return self._run_until("graph_config")
 
+    @property
+    def kind_graph(self):
+        """
+        The dependency graph of kinds.
+
+        @type: Graph
+        """
+        return self._run_until("kind_graph")
+
     def _load_kinds(self, graph_config, target_kinds=None):
         if target_kinds:
             # docker-image is an implicit dependency that never appears in
@@ -421,6 +430,8 @@ class TaskGraphGenerator:
             kind_graph = kind_graph.transitive_closure(
                 set(target_kinds) | {"docker-image"}
             )
+
+        yield "kind_graph", kind_graph
 
         logger.info("Generating full task set")
         # Current parallel generation relies on multiprocessing, and forking.

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -338,3 +338,44 @@ def test_kind_load_tasks(monkeypatch, graph_config, parameters, datadir, kind_co
     )
     tasks = kind.load_tasks(parameters, {}, False)
     assert tasks
+
+
+def test_kind_graph(maketgg):
+    "The kind_graph property has all kinds and their dependencies"
+    tgg = maketgg(
+        kinds=[
+            ("_fake3", {"kind-dependencies": ["_fake2", "_fake1"]}),
+            ("_fake2", {"kind-dependencies": ["_fake1"]}),
+            ("_fake1", {"kind-dependencies": []}),
+        ]
+    )
+    kind_graph = tgg.kind_graph
+    assert isinstance(kind_graph, graph.Graph)
+    assert kind_graph.nodes == {"_fake1", "_fake2", "_fake3"}
+    assert kind_graph.edges == {
+        ("_fake3", "_fake2", "kind-dependency"),
+        ("_fake3", "_fake1", "kind-dependency"),
+        ("_fake2", "_fake1", "kind-dependency"),
+    }
+
+
+def test_kind_graph_with_target_kinds(maketgg):
+    "The kind_graph property respects target_kinds parameter"
+    tgg = maketgg(
+        kinds=[
+            ("_fake3", {"kind-dependencies": ["_fake2"]}),
+            ("_fake2", {"kind-dependencies": ["_fake1"]}),
+            ("_fake1", {"kind-dependencies": []}),
+            ("_other", {"kind-dependencies": []}),
+            ("docker-image", {"kind-dependencies": []}),  # Add docker-image
+        ],
+        params={"target-kinds": ["_fake2"]},
+    )
+    kind_graph = tgg.kind_graph
+    # Should only include _fake2, _fake1, and docker-image (implicit dependency)
+    assert "_fake2" in kind_graph.nodes
+    assert "_fake1" in kind_graph.nodes
+    assert "docker-image" in kind_graph.nodes
+    # _fake3 and _other should not be included
+    assert "_fake3" not in kind_graph.nodes
+    assert "_other" not in kind_graph.nodes


### PR DESCRIPTION
Especially in repositories with large graphs, it can be useful to visualize the relationship between the various kinds.

I looked at directly outputting svg files of the graphs here, but decided against it because rendering mermaid diagrams requires a browser or puppeteer AFAICT; and I don't want to add that dependency.

I also looked at adding support for visualizing entire graphs, but those quickly get very unwieldy and I decided against it. (This might be useful in conjunction with a new `--target-task` option, but that's more than I'm willing to take on at this time.)