### PR TITLE
fix: get_taskcluster_client should respect PRODUCTION_TASKCLUSTER_ROOT_URL

### DIFF
--- a/src/taskgraph/util/taskcluster.py
+++ b/src/taskgraph/util/taskcluster.py
@@ -65,7 +65,7 @@ def get_taskcluster_client(service: str):
     if "TASKCLUSTER_PROXY_URL" in os.environ:
         options = {"rootUrl": os.environ["TASKCLUSTER_PROXY_URL"]}
     else:
-        options = taskcluster.optionsFromEnvironment()
+        options = taskcluster.optionsFromEnvironment({"rootUrl": get_root_url()})
 
     return getattr(taskcluster, service[0].upper() + service[1:])(options)
 


### PR DESCRIPTION
If no root url is set in the environment but
PRODUCTION_TASKCLUSTER_ROOT_URL is set, we should use that.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1996183