### PR TITLE
feat: run tests against 3.14 free-threaded python

### DIFF
--- a/taskcluster/kinds/docker-image/kind.yml
+++ b/taskcluster/kinds/docker-image/kind.yml
@@ -29,7 +29,7 @@ tasks:
     python:
         symbol: I(py)
         args:
-            PYTHON_VERSIONS: "3.14 3.13 3.12 3.11 3.10 3.9"
+            PYTHON_VERSIONS: "3.14t 3.14 3.13 3.12 3.11 3.10 3.9"
             UV_VERSION: *uv_version
     run-task:
         symbol: I(rt)

--- a/taskcluster/kinds/test/kind.yml
+++ b/taskcluster/kinds/test/kind.yml
@@ -42,7 +42,7 @@ tasks:
         matrix:
             set-name: "unit-py{matrix[python]}"
             substitution-fields: [description, run.command, treeherder, worker]
-            python: ["314", "313", "312", "311", "310", "39"]
+            python: ["314t", "314", "313", "312", "311", "310", "39"]
         worker:
             artifacts:
                 - type: file


### PR DESCRIPTION
I'm looking to start experimenting with threads for parallel kind generation. To make this worthwhile, we need to support free-threaded python. It looks like tests already pass here, so this should be a no-brainer for now. I've done some basic usage testing as well, and everything seems to work (even with free-threaded python...which makes sense seeing as we don't use threads anywhere at the moment).