### PR TITLE
fix: mock away TASKCLUSTER_{CLIENT_ID,ACCESS_TOKEN}

### DIFF
--- a/test/test_util_taskcluster.py
+++ b/test/test_util_taskcluster.py
@@ -21,6 +21,8 @@ def mock_environ(monkeypatch, root_url):
     # Ensure user specified environment variables don't interfere with URLs.
     monkeypatch.setenv("TASKCLUSTER_ROOT_URL", root_url)
     monkeypatch.delenv("TASKCLUSTER_PROXY_URL", raising=False)
+    monkeypatch.delenv("TASKCLUSTER_CLIENT_ID", raising=False)
+    monkeypatch.delenv("TASKCLUSTER_ACCESS_TOKEN", raising=False)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
I happened to run tests in a termimal where I was signed into a cluster, and got a test failure because of it:
```
E       AssertionError: expected call not found.
E       Expected: mock({'rootUrl': 'http://taskcluster-prod'})
E         Actual: mock({'rootUrl': 'http://taskcluster-prod', 'credentials': ...})
```