### PR TITLE
fix: don't require free-threaded python tests to pass

### DIFF
--- a/taskcluster/kinds/codecov/kind.yml
+++ b/taskcluster/kinds/codecov/kind.yml
@@ -21,6 +21,9 @@ tasks:
             group-by: all
             unique-kinds: false
             set-name: null
+            with-attributes:
+                # exclude free-threaded python until it is officially supported
+                python: ["314", "313", "312", "311", "310", "39"]
             fetches:
                 test:
                     - artifact: coverage.py{matrix[python]}

--- a/taskcluster/kinds/complete/kind.yml
+++ b/taskcluster/kinds/complete/kind.yml
@@ -21,3 +21,9 @@ tasks:
       group-by: all
       set-name: false
       unique-kinds: false
+      with-attributes:
+        # exclude free-threaded python until it is officially supported
+        python: ["314", "313", "312", "311", "310", "39"]
+    # needs to be added explicitly until we can drop the `with-attributes` above
+    dependencies:
+      check-type: check-type

--- a/taskcluster/kinds/test/kind.yml
+++ b/taskcluster/kinds/test/kind.yml
@@ -41,8 +41,10 @@ tasks:
         description: "Run unit tests with py{matrix[python]}"
         matrix:
             set-name: "unit-py{matrix[python]}"
-            substitution-fields: [description, run.command, treeherder, worker]
+            substitution-fields: [description, run.command, treeherder, worker, attributes]
             python: ["314t", "314", "313", "312", "311", "310", "39"]
+        attributes:
+            python: "{matrix[python]}"
         worker:
             artifacts:
                 - type: file


### PR DESCRIPTION
Over in https://github.com/taskcluster/taskgraph/pull/844, free-threaded python tests are causing `complete-pr` not to run because `msgspec` hasn't released a version that supports it yet. This highlights the fact that free-threading is not officially supported in Taskgraph yet, so we shouldn't block other tasks on these tests.

I could be convinced that we should just disable these tests completely in the meantime if having permafail tests is too annoying.