### PR TITLE
fix: block tc proxy in script_url

### DIFF
--- a/src/taskgraph/transforms/run/run_task.py
+++ b/src/taskgraph/transforms/run/run_task.py
@@ -184,7 +184,7 @@ def script_url(config, script):
         raise Exception("TASK_ID must be defined to use run-task on generic-worker")
     task_id = os.environ.get("TASK_ID", "<TASK_ID>")
     # Assumes the cluster allows anonymous downloads of public artifacts
-    tc_url = taskcluster.get_root_url()
+    tc_url = taskcluster.get_root_url(block_proxy=True)
     # TODO: Use util/taskcluster.py:get_artifact_url once hack for Bug 1405889 is removed
     return f"{tc_url}/api/queue/v1/task/{task_id}/artifacts/public/{script}"
 


### PR DESCRIPTION
It's possible this is a terrible idea, but when I tried to run [a generic-worker task with run-task](https://firefox-ci-tc.services.mozilla.com/tasks/CyQ3aIZyRE6NdWBwyeif6Q) and the proxy enabled, it failed to download `run-task`:
```
[taskcluster 2025-10-30T01:05:04.835Z] [mounts] Downloading url http://taskcluster/api/queue/v1/task/YpWux6HWR6ux40YwCpi5fg/artifacts/public/run-task to D:\downloads\ZenjqqtWT76WhzgTtovcNQ
[taskcluster:warn 2025-10-30T01:05:07.534Z] [mounts] Download of url http://taskcluster/api/queue/v1/task/YpWux6HWR6ux40YwCpi5fg/artifacts/public/run-task failed on this attempt: Get "http://taskcluster/api/queue/v1/task/YpWux6HWR6ux40YwCpi5fg/artifacts/public/run-task": dial tcp: lookup taskcluster: no such host
```

Opening this is a starting point, because [it works](https://firefox-ci-tc.services.mozilla.com/tasks/EFT5KvV3QVS7fzowTAyfVQ), and it's [similar to what we do in Gecko](https://searchfox.org/firefox-main/rev/75f89f7dee3f30c371af717da54ba8bbf046e5fd/taskcluster/gecko_taskgraph/transforms/job/run_task.py#119); but I'm not tied to it.