### PR TITLE
fix: support windows in `run-task`

### DIFF
--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -16,12 +16,10 @@ current time to improve log usefulness.
 import argparse
 import datetime
 import errno
-import grp
 import io
 import json
 import os
 import platform
-import pwd
 import re
 import shutil
 import socket
@@ -311,6 +309,9 @@ def run_command(prefix, args, *, extra_env=None, cwd=None):
 
 
 def get_posix_user_group(user, group):
+    import grp  # noqa: PLC0415
+    import pwd  # noqa: PLC0415
+
     try:
         user_record = pwd.getpwnam(user)
     except KeyError:


### PR DESCRIPTION
Taskgraph's version of `run-task` does not currently support Windows. After some investigation, it looks like much of https://bugzilla.mozilla.org/show_bug.cgi?id=1459737 was already ported to it - the only thing that we need to change is to relocate the POSIX-specific imports into a POSIX-specific function.