### PR TITLE
fix: make 'run-task' support Python 3.8 again

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,11 +41,13 @@ repos:
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
-# TODO remove 'fetch-content' once Gecko no longer needs to use it with Python 3.8
+# TODO remove 'fetch-content' and 'run-task' once Gecko no longer needs to use
+# them with Python 3.8:
 # https://bugzilla.mozilla.org/show_bug.cgi?id=1990567#c7
 exclude: |
   (?x)^(
     src/taskgraph/run-task/fetch-content |
     src/taskgraph/run-task/robustcheckout.py |
+    src/taskgraph/run-task/run-task |
     taskcluster/scripts/external_tools
   )

--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -31,7 +31,7 @@ import time
 import urllib.error
 import urllib.request
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Optional
 
 SECRET_BASEURL_TPL = "{}/secrets/v1/secret/{{}}".format(
     os.environ.get("TASKCLUSTER_PROXY_URL", "http://taskcluster").rstrip("/")
@@ -573,7 +573,7 @@ def git_fetch(
     remote: str = "origin",
     tags: bool = False,
     shallow: bool = False,
-    env: Optional[dict[str, str]] = None,
+    env: Optional[Dict[str, str]] = None,
 ):
     args = ["git", "fetch"]
     if tags:


### PR DESCRIPTION
This is a temporary workaround. We need to continue supporting 3.8 in the `run-task` script until Gecko stops using the Ubuntu 18.04 base image for tasks (which comes with Python 3.8 by default).