### PR TITLE
Bug 1996563 - Generate perfherder_data artifacts for jobs running fetch-content

### DIFF
--- a/src/taskgraph/run-task/fetch-content
+++ b/src/taskgraph/run-task/fetch-content
@@ -949,11 +949,11 @@ def command_task_artifacts(args):
         ],
     }
     print(f"PERFHERDER_DATA: {json.dumps(perfherder_data)}", file=sys.stderr)
-    upload_dir = os.environ.get("UPLOAD_DIR")
-    if os.environ.get("MOZ_AUTOMATION", "0") == "1" and upload_dir:
-        upload_path = pathlib.Path(upload_dir) / "perfherder-data-fetch-content.json"
+    perfherder_fetch_content_json_path = os.environ.get("PERFHERDER_FETCH_CONTENT_JSON_PATH")
+    if os.environ.get("MOZ_AUTOMATION", "0") == "1" and perfherder_fetch_content_json_path:
+        upload_path = pathlib.Path(perfherder_fetch_content_json_path)
         upload_path.parent.mkdir(parents=True, exist_ok=True)
-        with upload_path.open("w") as f:
+        with upload_path.open("w", encoding="utf-8") as f:
             json.dump(perfherder_data, f)
 
 


### PR DESCRIPTION
Some workers run in dynamically generated working directories (e.g., `D:\task_17612\` or `/home/cltbld/tasks/task_17612/`), which means the upload path isn’t always static.
Previously, we relied on `UPLOAD_DIR` when generating the artifact, but not all jobs expose this environment variable, which caused inconsistencies.
To fix this, we added a new environment variable, `PERFHERDER_FETCH_CONTENT_JSON_PATH`[0]. It gives us a clear and reliable file path, so we can always generate the `perfherder-data-fetch-content.json` artifact correctly on any worker.

[0]
Related patch (mozilla-central): https://phabricator.services.mozilla.com/D270831
Bugzilla link: https://bugzilla.mozilla.org/show_bug.cgi?id=1996563