### PR TITLE
fix: allow run-task-hg suffix

### DIFF
--- a/src/taskgraph/util/verify.py
+++ b/src/taskgraph/util/verify.py
@@ -334,6 +334,7 @@ def verify_run_task_caches(task, taskgraph, scratch_pad, graph_config, parameter
 
     main_command = command[0] if isinstance(command[0], str) else ""
     run_task = main_command.endswith("run-task")
+    run_task_hg = main_command.endswith("run-task-hg")
 
     for cache in payload.get("cache", {}).get(
         "task-reference", payload.get("cache", {})
@@ -349,7 +350,7 @@ def verify_run_task_caches(task, taskgraph, scratch_pad, graph_config, parameter
         if not RE_RESERVED_CACHES.match(cache):
             continue
 
-        if not run_task:
+        if not run_task and not run_task_hg:
             raise Exception(
                 f"{task.label} is using a cache ({cache}) reserved for run-task "
                 "change the task to use run-task or use a different "


### PR DESCRIPTION
It seems that run-tasks can have an -hg suffix.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1998132