### PR TITLE
fix(run-task): normalize certain environment variables to use forward…

### DIFF
--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -1320,7 +1320,10 @@ def main(args):
     # Convert certain well known environment variables to absolute paths.
     for k in [
         "CARGO_HOME",
+        "GECKO_PATH",
         "MOZ_FETCHES_DIR",
+        "MOZ_PYTHON_HOME",
+        "MOZ_UV_HOME",
         "PIP_CACHE_DIR",
         "UPLOAD_DIR",
         "UV_CACHE_DIR",
@@ -1329,7 +1332,13 @@ def main(args):
         "{}_PATH".format(repository["project"].upper()) for repository in repositories
     ]:
         if k in os.environ:
-            os.environ[k] = os.path.abspath(os.environ[k])
+            # Normalize paths to use forward slashes. Some shell scripts
+            # tolerate that better on Windows.
+            os.environ[k] = os.path.abspath(os.environ[k]).replace(os.sep, "/")
+            print_line(
+                b"setup",
+                b"%s is %s\n" % (k.encode("utf-8"), os.environ[k].encode("utf-8")),
+            )
 
     try:
         if "MOZ_FETCHES" in os.environ:

--- a/test/test_scripts_run_task.py
+++ b/test/test_scripts_run_task.py
@@ -617,15 +617,21 @@ def run_main(tmp_path, mocker, mock_stdin, run_task_mod):
     return inner
 
 
-def test_main_abspath_environment(run_main):
-    envvars = ["MOZ_FETCHES_DIR", "UPLOAD_DIR"]
+def test_main_abspath_environment(mocker, run_main):
+    envvars = ["GECKO_PATH", "MOZ_FETCHES_DIR", "UPLOAD_DIR"]
     envvars += [cache["env"] for cache in CACHES.values() if "env" in cache]
     env = {key: "file" for key in envvars}
     env["FOO"] = "file"
+
+    mocker.patch("os.sep", "\\")
+    env["MOZ_PYTHON_HOME"] = "dir\\python"
+    env["MOZ_UV_HOME"] = "dir/uv"
 
     result, env = run_main(env=env)
     assert result == 0
 
     assert env.get("FOO") == "file"
+    assert env.get("MOZ_PYTHON_HOME") == "/builds/worker/dir/python"
+    assert env.get("MOZ_UV_HOME") == "/builds/worker/dir/uv"
     for key in envvars:
         assert env[key] == "/builds/worker/file"


### PR DESCRIPTION
… slashes

This picks up a fix from Gecko `run-task`. It also adds a couple environment variables that exist there but not in this version.

Hardcoding Gecko specific envs isn't great, but should ultimately be harmless. We can perhaps implement a mechanism to specify which envs should get normalized via the task definition at some later point.