### PR TITLE
fix(run-task): stop cleaning up fetches dir

### DIFF
--- a/src/taskgraph/run-task/run-task
+++ b/src/taskgraph/run-task/run-task
@@ -1340,21 +1340,14 @@ def main(args):
                 b"%s is %s\n" % (k.encode("utf-8"), os.environ[k].encode("utf-8")),
             )
 
-    try:
-        if "MOZ_FETCHES" in os.environ:
-            fetch_artifacts()
+    if "MOZ_FETCHES" in os.environ:
+        fetch_artifacts()
 
-        # Install Python requirements after fetches in case tasks want to use
-        # fetches to grab dependencies.
-        install_pip_requirements(repositories)
+    # Install Python requirements after fetches in case tasks want to use
+    # fetches to grab dependencies.
+    install_pip_requirements(repositories)
 
-        return run_command(b"task", task_args, cwd=args.task_cwd)
-    finally:
-        fetches_dir = os.environ.get("MOZ_FETCHES_DIR")
-        if fetches_dir and os.path.isdir(fetches_dir):
-            print_line(b"fetches", b"removing %s\n" % fetches_dir.encode("utf-8"))
-            remove(fetches_dir)
-            print_line(b"fetches", b"finished\n")
+    return run_command(b"task", task_args, cwd=args.task_cwd)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This cleanup is problematic because it can fail if there are resources under the fetches dir that are still being used by subprocesses spawned by the task.

The cleanup was added ~7 years ago to workaround fetches getting re-used on a generic-worker simple engine task. These days, everything should be using the multiuser engine which means tasks get entirely separate users and there's no possibility of accidentally re-using fetches between tasks.

Also the Gecko `run-task` dropped this cleanup ~5 years ago.