### PR TITLE
fix Task object construction to have non-None {if,soft}_dependencies

### DIFF
--- a/src/taskgraph/generator.py
+++ b/src/taskgraph/generator.py
@@ -100,9 +100,9 @@ class Kind:
                 attributes=task_dict["attributes"],
                 task=task_dict["task"],
                 optimization=task_dict.get("optimization"),
-                dependencies=task_dict.get("dependencies"),
-                soft_dependencies=task_dict.get("soft-dependencies"),
-                if_dependencies=task_dict.get("if-dependencies"),
+                dependencies=task_dict.get("dependencies", {}),
+                soft_dependencies=task_dict.get("soft-dependencies", []),
+                if_dependencies=task_dict.get("if-dependencies", []),
             )
             for task_dict in transforms(trans_config, inputs)
         ]

--- a/src/taskgraph/task.py
+++ b/src/taskgraph/task.py
@@ -75,9 +75,9 @@ class Task:
             attributes=task_dict["attributes"],
             task=task_dict["task"],
             optimization=task_dict["optimization"],
-            dependencies=task_dict.get("dependencies"),
-            soft_dependencies=task_dict.get("soft_dependencies"),
-            if_dependencies=task_dict.get("if_dependencies"),
+            dependencies=task_dict.get("dependencies", {}),
+            soft_dependencies=task_dict.get("soft_dependencies", []),
+            if_dependencies=task_dict.get("if_dependencies", []),
         )
         if "task_id" in task_dict:
             rv.task_id = task_dict["task_id"]


### PR DESCRIPTION
This matches the type annotations, and matches an assumption in verify_task_dependencies.