### PR TITLE
chore: bump version to 18.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [18.0.3] - 2025-12-11
+
+### Fixed
+
+- `get_artifact_from_index` now uses `artifact_path` instead of `index_path`
+  (bug 1999039); fixes regression introduced in 16.0.0
+- Task objects created by `load_tasks` or `from_json` no longer have `None` as
+  `if_dependencies`/`soft_dependencies` attributes
+
+## [18.0.2] - Skipped
+
 ## [18.0.1] - 2025-12-10
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 ### Project
 [project]
 name = "taskcluster-taskgraph"
-version = "18.0.1"
+version = "18.0.3"
 description = "Build taskcluster taskgraphs"
 readme = "README.rst"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -2020,7 +2020,7 @@ wheels = [
 
 [[package]]
 name = "taskcluster-taskgraph"
-version = "18.0.1"
+version = "18.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
Skip 18.0.2 since I mistakenly created/published that tag without updating the version number.