### PR TITLE
ci(tcyml): revert back to $if in extraArgs

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -253,10 +253,12 @@ tasks:
                           - -cx
                           - $let:
                                 extraArgs:
-                                    $switch:
-                                        'tasks_for == "cron"': '${cron.quoted_args}'
-                                        'tasks_for == "github-pull-request"': '--allow-parameter-override'
-                                        $default: ''
+                                    $if: 'tasks_for == "cron"'
+                                    then: '${cron.quoted_args}'
+                                    else:
+                                        $if: 'tasks_for == "github-pull-request"'
+                                        then: '--allow-parameter-override'
+                                        else: ''
                             in:
                                 $if: 'tasks_for == "action" || tasks_for == "pr-action"'
                                 then: >


### PR DESCRIPTION
Taskcluster Github is still using json-e v4.8.0, which does not contain this fix:
https://github.com/json-e/json-e/commit/c764fe6a7eb3828253a5b9bea6254a14acb90b8d