### PR TITLE
fix(template): update worker types for d2g migration

### DIFF
--- a/template/{{cookiecutter.project_name}}/taskcluster/config.yml
+++ b/template/{{cookiecutter.project_name}}/taskcluster/config.yml
@@ -14,14 +14,14 @@ workers:
       provisioner: '{trust-domain}-{level}'
       implementation: docker-worker
       os: linux
-      worker-type: '{alias}-gcp'
+      worker-type: '{alias}'
     images:
       provisioner: '{trust-domain}-{level}'
       implementation: docker-worker
       os: linux
-      worker-type: '{alias}-gcp'
+      worker-type: '{alias}'
     t-linux-large:
       provisioner: '{trust-domain}-t'
       implementation: docker-worker
       os: linux
-      worker-type: '{alias}-gcp'
+      worker-type: '{alias}'


### PR DESCRIPTION
The .taskcluster.yml template was updated in #892 but the taskgraph config kept using old pool names.