### PR TITLE
feat: add support for custom context to task-context

### DIFF
--- a/docs/reference/transforms/task_context.rst
+++ b/docs/reference/transforms/task_context.rst
@@ -98,35 +98,6 @@ with the this ``kind``:
 ...the description will bring in the value ``foo`` from the parameters if
 present, or ``default`` otherwise.
 
-from-file
-~~~~~~~~~
-
-Context may also be provided from a defined yaml file. The provided file
-should usually only contain top level keys and values (eg: nested objects
-will not be interpolated - they will be substituted as text representations
-of the object).
-
-For example, with this kind definition:
-
-.. code-block:: yaml
-
-   tasks:
-     build:
-       description: my description {foo}
-       task-context:
-         from-file: some_file.yaml
-         substitution-fields:
-           - description
-
-And this in ``some_file.yaml``:
-
-.. code-block:: yaml
-
-   foo: from a file
-
-...description will end up with "my description from a file".
-
-
 from-object
 ~~~~~~~~~~~
 
@@ -158,6 +129,86 @@ For example:
 This will give build1 and build2 descriptions with their ``extra_desc``
 included while allowing them to share the rest of their task definition.
 
+from-custom
+~~~~~~~~~~~
+
+Context may be provided by custom providers, which must be registered prior
+to this transform being run. This allows the creation of context that is
+derived from parameters, code constants, or anything else accessible to
+taskgraph.
+
+For example, you may have a custom context handler set-up in
+``taskcluster/my_taskgraph/custom_context.py``:
+
+.. code-block:: python
+
+   NON_PRODUCTION_BRANCHES = ["maple", "pine"]
+
+   @custom_context("release-level")
+   def release_level_context(config, task):
+       # Despite being level 3, some branches are not truly considered "production"
+       # in the sense of creating releases that ship to users.
+       if config.params["level"] == "1" or config.params["project"] in NON_PRODUCTION_BRANCHES:
+           return "staging"
+       return "production"
+
+
+In your ``register`` function you will need to ensure you import this module.
+Eg: ``taskcluster/my_taskgraph/__init__.py``:
+
+.. code-block:: python
+
+   def register(graph_config):
+       from my_taskgraph import custom_contexts  # trigger custom task-context registration
+
+
+Now you can use ``release-level`` as context in a kind:
+
+.. code-block:: yaml
+
+   task-defaults:
+     task-context:
+       from-custom:
+         - release-level
+       substitution-fields:
+         - scopes
+
+     scopes:
+       by-release-level:
+         staging:
+           - secrets:get:staging_creds
+         production:
+           - secrets:get:production_creds
+
+
+from-file
+~~~~~~~~~
+
+Context may also be provided from a defined yaml file. The provided file
+should usually only contain top level keys and values (eg: nested objects
+will not be interpolated - they will be substituted as text representations
+of the object).
+
+For example, with this kind definition:
+
+.. code-block:: yaml
+
+   tasks:
+     build:
+       description: my description {foo}
+       task-context:
+         from-file: some_file.yaml
+         substitution-fields:
+           - description
+
+And this in ``some_file.yaml``:
+
+.. code-block:: yaml
+
+   foo: from a file
+
+...description will end up with "my description from a file".
+
 Implicit Context
 ~~~~~~~~~~~~~~~~
 
@@ -185,7 +236,7 @@ Keys will be resolved on ``substitution-fields`` first, then substitution
 will be performed on the resolved value.
 
 If the same key is found in multiple places the order of precedence is as
-follows: ``from-parameters``, ``from-object`` keys, ``from-file`` and finally
+follows: ``from-parameters``, ``from-object`` keys, ``from-custom`` providers, ``from-file`` and finally
 implicit context.
 
 That is to say: parameters will always override anything else.

--- a/src/taskgraph/transforms/task_context.py
+++ b/src/taskgraph/transforms/task_context.py
@@ -2,6 +2,7 @@ from typing import Optional, Union
 
 from taskgraph.transforms.base import TransformSequence
 from taskgraph.util.schema import Schema, resolve_keyed_by
+from taskgraph.util.task_context import CUSTOM_CONTEXT_MAP
 from taskgraph.util.templates import deep_get, substitute_task_fields
 from taskgraph.util.yaml import load_yaml
 
@@ -28,6 +29,12 @@ class TaskContextConfig(Schema):
     from_file: Optional[str] = None
     # Key/value pairs to be used as task context
     from_object: Optional[object] = None
+    # Retrieve task context values from registered custom providers. Each
+    # entry is the name of a provider registered via
+    # ``taskgraph.util.task_context.custom_context``. Providers are called
+    # with the ``TransformConfig`` and the task being rendered, and must
+    # return a dict of key/value pairs to add to the context.
+    from_custom: Optional[list[str]] = None
     resolve_keyed_by_options: Optional[ResolveKeyedByConfigOptions] = None
 
 
@@ -51,6 +58,7 @@ class TaskContextSchema(Schema, forbid_unknown_fields=False, kw_only=True):
     # is as follows:
     #   - Parameters
     #   - `from-object` keys
+    #   - Custom providers (`from-custom`)
     #   - File
     #
     # That is to say: parameters will always override anything else.
@@ -89,10 +97,18 @@ def render_task(config, tasks):
         if from_file:
             file_context = load_yaml(from_file)
 
+        custom_context = {}
+        for name in sub_config.pop("from-custom", None) or []:
+            if name not in CUSTOM_CONTEXT_MAP:
+                raise ValueError(f"no provider found for custom context '{name}'")
+
+            custom_context.update(CUSTOM_CONTEXT_MAP[name](config, task))
+
         fields = sub_config.pop("substitution-fields")
 
         subs = {}
         subs.update(file_context)
+        subs.update(custom_context)
         # We've popped away the configuration; everything left in `sub_config` is
         # substitution key/value pairs.
         subs.update(sub_config.pop("from-object", {}))

--- a/src/taskgraph/util/task_context.py
+++ b/src/taskgraph/util/task_context.py
@@ -1,0 +1,20 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Define a collection of custom task-context providers.
+# Note: this is stored here instead of where it is used in the
+# `task_context` transform to give consumers a chance to register their own
+# providers before the `task_context` schema is created.
+CUSTOM_CONTEXT_MAP = {}
+
+
+def custom_context(name):
+    def wrapper(func):
+        assert name not in CUSTOM_CONTEXT_MAP, (
+            f"duplicate custom_context function name {name} ({func} and {CUSTOM_CONTEXT_MAP[name]})"
+        )
+        CUSTOM_CONTEXT_MAP[name] = func
+        return func
+
+    return wrapper

--- a/test/data/task_context.yml
+++ b/test/data/task_context.yml
@@ -1,4 +1,5 @@
 file: file
+file_and_custom: file_and_custom
 direct_and_file: shouldn't be used
 file_and_param: shouldn't be used
 direct_file_and_param: shouldn't be used

--- a/test/test_transform_task_context.py
+++ b/test/test_transform_task_context.py
@@ -70,24 +70,39 @@ TASK_DEFAULTS = {
         ],
     },
 }
-EXPECTED_DESCRIPTION = (
-    "fake description object file param object-overrides-file "
-    "param-overrides-object param-overrides-file param-overrides-all default fake-task-name"
-)
-NO_CONTEXT = deepcopy(TASK_DEFAULTS)
-del NO_CONTEXT["task-context"]
 
 
-@pytest.mark.parametrize(
-    "task,description",
-    (
-        pytest.param(deepcopy(TASK_DEFAULTS), EXPECTED_DESCRIPTION, id="with-context"),
-        pytest.param(
-            deepcopy(NO_CONTEXT), TASK_DEFAULTS["description"], id="no-context"
-        ),
-    ),
-)
-def test_transforms(request, run_transform, graph_config, task, description):
+def test_transforms_with_context(run_transform, graph_config):
+    task = deepcopy(TASK_DEFAULTS)
+    description = (
+        "fake description object file param object-overrides-file "
+        "param-overrides-object param-overrides-file param-overrides-all default "
+        "fake-task-name"
+    )
+
+    config = make_config(
+        graph_config,
+        {
+            "param": "param",
+            "object_and_param": "param-overrides-object",
+            "file_and_param": "param-overrides-file",
+            "object_file_and_param": "param-overrides-all",
+            "default": "default",
+        },
+    )
+
+    task = run_transform(task_context.transforms, task, config=config)[0]
+    print("Dumping task:")
+    pprint(task, indent=2)
+
+    assert task["description"] == description
+
+
+def test_transforms_no_context(run_transform, graph_config):
+    task = deepcopy(TASK_DEFAULTS)
+    del task["task-context"]
+    description = TASK_DEFAULTS["description"]
+
     config = make_config(
         graph_config,
         {

--- a/test/test_transform_task_context.py
+++ b/test/test_transform_task_context.py
@@ -11,6 +11,7 @@ from pytest_taskgraph import FakeParameters
 
 from taskgraph.transforms import task_context
 from taskgraph.transforms.base import TransformConfig
+from taskgraph.util.task_context import CUSTOM_CONTEXT_MAP, custom_context
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -48,14 +49,15 @@ def make_config(graph_config, extra_params=None):
 
 TASK_DEFAULTS = {
     "description": "fake description {object} {file} {param} {object_and_file} "
-    "{object_and_param} {file_and_param} {object_file_and_param} {param_fallback} {name}",
+    "{object_and_param} {file_and_param} {object_custom_file_and_param} {param_fallback} "
+    "{custom} {object_and_custom} {file_and_custom} {name}",
     "name": "fake-task-name",
     "task-context": {
         "from-parameters": {
             "param": "param",
             "object_and_param": "object_and_param",
             "file_and_param": "file_and_param",
-            "object_file_and_param": "object_file_and_param",
+            "object_custom_file_and_param": "object_file_and_param",
             "param_fallback": ["missing-param", "default"],
         },
         "from-file": f"{here}/data/task_context.yml",
@@ -63,8 +65,14 @@ TASK_DEFAULTS = {
             "object": "object",
             "object_and_param": "shouldn't be used",
             "object_and_file": "object-overrides-file",
-            "object_file_and_param": "shouldn't be used",
+            "object_custom_file_and_param": "shouldn't be used",
         },
+        "from-custom": [
+            "custom",
+            "object_and_custom",
+            "file_and_custom",
+            "object_custom_file_and_param",
+        ],
         "substitution-fields": [
             "description",
         ],
@@ -77,25 +85,49 @@ def test_transforms_with_context(run_transform, graph_config):
     description = (
         "fake description object file param object-overrides-file "
         "param-overrides-object param-overrides-file param-overrides-all default "
-        "fake-task-name"
+        "custom object_and_custom file_and_custom fake-task-name"
     )
+    try:
 
-    config = make_config(
-        graph_config,
-        {
-            "param": "param",
-            "object_and_param": "param-overrides-object",
-            "file_and_param": "param-overrides-file",
-            "object_file_and_param": "param-overrides-all",
-            "default": "default",
-        },
-    )
+        @custom_context("custom")
+        def _custom(config, task):
+            return {"custom": "custom"}
 
-    task = run_transform(task_context.transforms, task, config=config)[0]
-    print("Dumping task:")
-    pprint(task, indent=2)
+        @custom_context("object_and_custom")
+        def _object_and_custom(config, task):
+            return {"object_and_custom": "object_and_custom"}
 
-    assert task["description"] == description
+        @custom_context("file_and_custom")
+        def _file_and_custom(config, task):
+            return {"file_and_custom": "file_and_custom"}
+
+        @custom_context("object_custom_file_and_param")
+        def _object_custom_file_and_param(config, task):
+            return {"object_custom_file_and_param": "object_custom_file_and_param"}
+
+        config = make_config(
+            graph_config,
+            {
+                "param": "param",
+                "object_and_param": "param-overrides-object",
+                "file_and_param": "param-overrides-file",
+                "object_file_and_param": "param-overrides-all",
+                "default": "default",
+            },
+        )
+
+        task = run_transform(task_context.transforms, task, config=config)[0]
+        print("Dumping task:")
+        pprint(task, indent=2)
+
+        assert task["description"] == description
+    finally:
+        # ensure `CUSTOM_CONTEXT_MAP` is reset at the end of the test
+        # regardless of result
+        CUSTOM_CONTEXT_MAP.pop("custom", None)
+        CUSTOM_CONTEXT_MAP.pop("object_and_custom", None)
+        CUSTOM_CONTEXT_MAP.pop("file_and_custom", None)
+        CUSTOM_CONTEXT_MAP.pop("object_custom_file_and_param", None)
 
 
 def test_transforms_no_context(run_transform, graph_config):
@@ -103,22 +135,47 @@ def test_transforms_no_context(run_transform, graph_config):
     del task["task-context"]
     description = TASK_DEFAULTS["description"]
 
-    config = make_config(
-        graph_config,
-        {
-            "param": "param",
-            "object_and_param": "param-overrides-object",
-            "file_and_param": "param-overrides-file",
-            "object_file_and_param": "param-overrides-all",
-            "default": "default",
-        },
-    )
+    try:
 
-    task = run_transform(task_context.transforms, task, config=config)[0]
-    print("Dumping task:")
-    pprint(task, indent=2)
+        @custom_context("custom")
+        def _custom(config, task):
+            return {"custom": "custom"}
 
-    assert task["description"] == description
+        @custom_context("object_and_custom")
+        def _object_and_custom(config, task):
+            return {"object_and_custom": "object_and_custom"}
+
+        @custom_context("file_and_custom")
+        def _file_and_custom(config, task):
+            return {"file_and_custom": "file_and_custom"}
+
+        @custom_context("object_custom_file_and_param")
+        def _object_custom_file_and_param(config, task):
+            return {"object_custom_file_and_param": "object_custom_file_and_param"}
+
+        config = make_config(
+            graph_config,
+            {
+                "param": "param",
+                "object_and_param": "param-overrides-object",
+                "file_and_param": "param-overrides-file",
+                "object_file_and_param": "param-overrides-all",
+                "default": "default",
+            },
+        )
+
+        task = run_transform(task_context.transforms, task, config=config)[0]
+        print("Dumping task:")
+        pprint(task, indent=2)
+
+        assert task["description"] == description
+    finally:
+        # ensure `CUSTOM_CONTEXT_MAP` is reset at the end of the test
+        # regardless of result
+        CUSTOM_CONTEXT_MAP.pop("custom", None)
+        CUSTOM_CONTEXT_MAP.pop("object_and_custom", None)
+        CUSTOM_CONTEXT_MAP.pop("file_and_custom", None)
+        CUSTOM_CONTEXT_MAP.pop("object_custom_file_and_param", None)
 
 
 def test_resolve_keyed_by_from_parameters(run_transform, graph_config):
@@ -235,3 +292,57 @@ def test_resolve_keyed_by_missing_context_with_defer(run_transform, graph_config
             "default": "also-should-not-resolve",
         },
     }
+
+
+def test_resolve_keyed_by_custom_context(run_transform, graph_config):
+    try:
+
+        @custom_context("colour")
+        def _colour(config, task):
+            return {"colour": "blue"}
+
+        task = {
+            "name": "fake-task-name",
+            "description": {
+                "by-colour": {
+                    "blue": "i am a blue task!",
+                    "default": " i am a default task",
+                },
+            },
+            "task-context": {
+                "from-custom": ["colour"],
+                "substitution-fields": ["description"],
+            },
+        }
+        config = make_config(graph_config)
+
+        task = run_transform(task_context.transforms, task, config=config)[0]
+        pprint(task, indent=2)
+
+        assert task["description"] == "i am a blue task!"
+    finally:
+        # ensure `CUSTOM_CONTEXT_MAP` is reset at the end of the test
+        # regardless of result
+        CUSTOM_CONTEXT_MAP.pop("colour", None)
+
+
+def test_resolve_keyed_by_custom_context_missing(run_transform, graph_config):
+    task = {
+        "name": "fake-task-name",
+        "description": {
+            "by-colour": {
+                "blue": "i am a blue task!",
+                "default": " i am a default task",
+            },
+        },
+        "task-context": {
+            "from-custom": ["colour"],
+            "substitution-fields": ["description"],
+        },
+    }
+    config = make_config(graph_config)
+
+    with pytest.raises(
+        ValueError, match="no provider found for custom context 'colour'"
+    ):
+        task = run_transform(task_context.transforms, task, config=config)


### PR DESCRIPTION
This is somewhat of a continuation to #968 in that it would allow for more `resolve_keyed_by` calls to be replaced by `task-context`. As a concrete example, we use [`by-release-level` in many places in gecko](https://searchfox.org/firefox-main/search?q=by-release-level&path=&case=false&regexp=false). Its value is [derived from parameters and some constants](https://searchfox.org/firefox-main/source/taskcluster/gecko_taskgraph/util/attributes.py#157). With this patch, we could register it as custom context and replace a whole bunch of `resolve_keyed_by` calls in transforms, eg:

In some python code that's called at taskgraph registration:
```
@custom_context("release-level")
def release_level_context(config, task):
    """Provide ``release-level`` ("production" or "staging"), derived from
    parameters, so ``by-release-level`` fields can be resolved declaratively."""
    return {"release-level": release_level(config.params)}
```

And in various kinds we'd end up with things like:
```
transforms:
    - taskgraph.transforms.task_context

task-defaults:
    task-context:
        from-custom:
            - release-level
        substitution-fields:
            - scopes

    scopes:
        by-release-level:
            production:
                - project:releng:ship-it:server:production
                - project:releng:ship-it:action:create-new-release
            staging:
                - project:releng:ship-it:server:staging
                - project:releng:ship-it:action:create-new-release
```