### PR TITLE
WIP: rework taskgraph generation not as a generator

### DIFF
--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -38,7 +38,7 @@ def test_kind_ordering(mocker, maketgg):
             ("_fake1", {"kind-dependencies": []}),
         ]
     )
-    tgg._run_until("full_task_set")
+    tgg.full_task_set
     assert mocked_ppe.loaded_kinds == ["_fake1", "_fake2", "_fake3"]
 
 
@@ -279,9 +279,9 @@ def test_loader_backwards_compat_interface(graph_config):
 )
 def test_default_loader(config, expected_transforms):
     loader = Kind("", "", config, {})._get_loader()
-    assert loader is default_loader, (
-        "Default Kind loader should be taskgraph.loader.default.loader"
-    )
+    assert (
+        loader is default_loader
+    ), "Default Kind loader should be taskgraph.loader.default.loader"
     loader("", "", config, {}, [], False)
 
     assert config["transforms"] == expected_transforms


### PR DESCRIPTION
this allows us to load some or all of its results from a cache. the current generator model makes this impossible because even if we preload, eg: the full task graph, we still need to run that logic in `_run` before proceeding to later phases

I don't remember why I separated it now, but I believe this was meant to go with #975.