### PR TITLE
chore(tests): Bump number of nodes during perf tests

### DIFF
--- a/test/test_graph_perf.py
+++ b/test/test_graph_perf.py
@@ -17,7 +17,7 @@ from taskgraph.transforms.base import TransformSequence
 # Graph builders – each returns (tasks_dict, Graph, TaskGraph) for 1000 nodes
 # ---------------------------------------------------------------------------
 
-N = 1000
+N = 20000
 
 
 def _make_task(i):


### PR DESCRIPTION
Increases the number of nodes from 1k to 20k, this should improve perf variance tracking.