### PR TITLE
fetch-content: send Accept-Encoding header (bug 2049952)

### DIFF
--- a/src/taskgraph/run-task/fetch-content
+++ b/src/taskgraph/run-task/fetch-content
@@ -181,7 +181,7 @@ def stream_download(url, sha256=None, size=None, headers=None):
     length = 0
 
     t0 = time.time()
-    req_headers = {}
+    req_headers = {"Accept-Encoding": "gzip"}
     for header in headers:
         key, val = header.split(":")
         req_headers[key.strip()] = val.strip()

--- a/test/test_scripts_fetch_content.py
+++ b/test/test_scripts_fetch_content.py
@@ -65,7 +65,8 @@ def test_stream_download(
         assert req._full_url == url
         assert timeout is not None
         if headers:
-            assert len(req.headers) == len(headers)
+            # stream_download adds accept-encoding
+            assert len(req.headers) == len(headers) + 1
             for header in headers:
                 k, v = header.split(":")
                 k = k.lower().capitalize().strip()


### PR DESCRIPTION
Many taskcluster artifacts are stored gzipped on GCS, requesting the compressed version means less data to transfer, and side-steps an incompatibility between GCS decompressive transcoding (which implies chunked transfer) and Fastly segmented caching.