### PR TITLE
feat: --target-kind with -Y or -J implicitly adds --tasks-regex

### DIFF
--- a/src/taskgraph/main.py
+++ b/src/taskgraph/main.py
@@ -415,7 +415,10 @@ def show_kind_graph(options):
     "--tasks-regex",
     "--tasks",
     default=None,
-    help="only return tasks with labels matching this regular expression.",
+    help="only return tasks with labels matching this regular expression. "
+    "When --target-kind is given with --json/--yaml and this is omitted, it "
+    "defaults to a regex matching labels that begin with one of the target "
+    "kinds.",
 )
 @argument(
     "--exclude-key",
@@ -499,8 +502,25 @@ def show_taskgraph(options):
         )
         print(f"Generating {options['graph_attr']} @ {cur_rev}", file=sys.stderr)
 
+    target_kinds = options.get("target_kinds")
+    if (
+        target_kinds
+        and options.get("tasks_regex") is None
+        and options.get("format") in ("yaml", "json")
+    ):
+        options["tasks_regex"] = "^({})".format(
+            "|".join(re.escape(kind) for kind in target_kinds)
+        )
+        print(
+            "Filtering tasks with implied --tasks-regex "
+            f"'{options['tasks_regex']}' (derived from --target-kind). "
+            "Pass --tasks-regex explicitly to override, or '--tasks-regex .' "
+            "to disable filtering.",
+            file=sys.stderr,
+        )
+
     overrides = {
-        "target-kinds": options.get("target_kinds"),
+        "target-kinds": target_kinds,
     }
     parameters: list[Any[str, Parameters]] = options.pop("parameters")
     if not parameters:

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -158,6 +158,62 @@ def test_tasks_regex(run_taskgraph, capsys):
     assert out.strip() == "_fake-t-1"
 
 
+def test_target_kind_implies_tasks_regex(run_taskgraph, capsys):
+    kinds = [
+        ("_fake", {"kind-dependencies": ["_dep"]}),
+        ("_dep", {"kind-dependencies": []}),
+        ("docker-image", {"kind-dependencies": []}),
+    ]
+    res = run_taskgraph(
+        ["full", "-Y", "-k", "_fake"],
+        kinds=kinds,
+        params={"target-kinds": ["_fake"]},
+    )
+    assert res == 0
+
+    out, err = capsys.readouterr()
+    assert "implied --tasks-regex '^(_fake)'" in err
+    assert "_fake-t-0" in out
+    assert "_dep-t-0" not in out
+
+
+def test_target_kind_no_implied_regex_for_labels(run_taskgraph, capsys):
+    kinds = [
+        ("_fake", {"kind-dependencies": ["_dep"]}),
+        ("_dep", {"kind-dependencies": []}),
+        ("docker-image", {"kind-dependencies": []}),
+    ]
+    res = run_taskgraph(
+        ["full", "-k", "_fake"],
+        kinds=kinds,
+        params={"target-kinds": ["_fake"]},
+    )
+    assert res == 0
+
+    out, err = capsys.readouterr()
+    assert "implied --tasks-regex" not in err
+    assert "_dep-t-0" in out
+
+
+def test_target_kind_explicit_regex_not_overridden(run_taskgraph, capsys):
+    kinds = [
+        ("_fake", {"kind-dependencies": ["_dep"]}),
+        ("_dep", {"kind-dependencies": []}),
+        ("docker-image", {"kind-dependencies": []}),
+    ]
+    res = run_taskgraph(
+        ["full", "-Y", "-k", "_fake", "--tasks-regex", "_dep-t-0"],
+        kinds=kinds,
+        params={"target-kinds": ["_fake"]},
+    )
+    assert res == 0
+
+    out, err = capsys.readouterr()
+    assert "implied --tasks-regex" not in err
+    assert "_dep-t-0" in out
+    assert "_fake-t-1" not in out
+
+
 def test_output_file(run_taskgraph, tmpdir):
     output_file = tmpdir.join("out.txt")
     assert not output_file.check()


### PR DESCRIPTION
When debugging an individually kind or task it's very common to pass `--target-kind` along with `-Y` or `-J`. In larger repos, doing this without also limiting the tasks that will be printed can cause taskgraph to take multiple minutes to write out all tasks to disk, which are usually ignored (and in fact, in the way of finding the output that does matter). This is easily worked around by passing `--tasks-regex` to limit the output. In most cases, this ends up being largely a repeat of `--target-kind`, and it is also not something that everybody knows about. For these reasons, we should imply it in this specific circumstance, and allow it to be overridden if necessary.