### PR TITLE
fix: don't run perf tests with unit tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -11,6 +11,14 @@ here = Path(__file__).parent
 
 pytest_plugins = ("pytest-taskgraph",)
 
+
+def pytest_ignore_collect(collection_path, config):
+    if collection_path.name == "test_graph_perf.py" and not config.getoption(
+        "codspeed"
+    ):
+        return True
+
+
 # Disable as much system/user level configuration as we can to avoid
 # interference with tests.
 # This ignores ~/.hgrc


### PR DESCRIPTION
test_graph_perf.py is the dominant cost of running tests (locally, I can run everything else in 22s single threaded; test_graph_perf.py takes almost 90s). We should avoid running it as a unit test.