### PR TITLE
fix: ensure errors are not missed when creating tasks

### DIFF
--- a/src/taskgraph/create.py
+++ b/src/taskgraph/create.py
@@ -64,19 +64,12 @@ def create_tasks(graph_config, taskgraph, label_to_taskid, params, decision_task
         fs = {}
         fs_to_task = {}
         skipped = set()
-        errors = {}
 
         # We can't submit a task until its dependencies have been submitted.
         # So our strategy is to walk the graph and submit tasks once all
         # their dependencies have been submitted.
         tasklist = set(taskgraph.graph.visit_postorder())
         alltasks = tasklist.copy()
-
-        def handle_exception(fut):
-            if exc := fut.exception():
-                task_id, label = fs_to_task[fut]
-                skipped.add(task_id)
-                errors[label] = exc
 
         def schedule_tasks():
             to_remove = set()
@@ -87,7 +80,13 @@ def create_tasks(graph_config, taskgraph, label_to_taskid, params, decision_task
                 new.add(fut)
                 fs[task_id] = fut
                 fs_to_task[fut] = (task_id, label)
-                fut.add_done_callback(handle_exception)
+
+                def mark_failed_as_skipped(fut):
+                    if fut.exception():
+                        task_id, _ = fs_to_task[fut]
+                        skipped.add(task_id)
+
+                fut.add_done_callback(mark_failed_as_skipped)
 
             for task_id in tasklist:
                 task_def = taskgraph.tasks[task_id].task
@@ -126,6 +125,12 @@ def create_tasks(graph_config, taskgraph, label_to_taskid, params, decision_task
 
         # Wait for all futures to complete.
         futures.wait(fs.values())
+
+        # Collect errors.
+        errors = {}
+        for fut, (task_id, label) in fs_to_task.items():
+            if exc := fut.exception():
+                errors[label] = exc
 
         if errors:
             raise CreateTasksException(errors)

--- a/test/test_create.py
+++ b/test/test_create.py
@@ -4,7 +4,9 @@
 
 import json
 import re
+import time
 import unittest
+from concurrent import futures
 from unittest import mock
 
 import responses
@@ -202,3 +204,43 @@ class TestCreate(unittest.TestCase):
         exception_message = str(cm.exception)
         self.assertIn("Could not create 'a'", exception_message)
         self.assertIn("Could not create 'b'", exception_message)
+
+    @responses.activate
+    @mock.patch.dict(
+        "os.environ",
+        {"TASKCLUSTER_ROOT_URL": "https://tc.example.com"},
+        clear=True,
+    )
+    def test_create_tasks_fails_if_done_callback_is_slow(self):
+        "create_tasks fails even if done-callbacks run after futures.wait() returns"
+        mock_taskcluster_api(error_status=403, error_message="oh no!")
+
+        tasks = {
+            "tid-a": Task(
+                kind="test", label="a", attributes={}, task={"payload": "hello world"}
+            ),
+        }
+        label_to_taskid = {"a": "tid-a"}
+        graph = Graph(nodes={"tid-a"}, edges=set())
+        taskgraph = TaskGraph(tasks, graph)
+
+        real_add_done_callback = futures.Future.add_done_callback
+
+        def slow_add_done_callback(self, fn):
+            def wrapper(fut):
+                time.sleep(0.1)
+                fn(fut)
+
+            return real_add_done_callback(self, wrapper)
+
+        with mock.patch.object(
+            futures.Future, "add_done_callback", slow_add_done_callback
+        ):
+            with self.assertRaises(CreateTasksException):
+                create.create_tasks(
+                    GRAPH_CONFIG,
+                    taskgraph,
+                    label_to_taskid,
+                    {"level": "4"},
+                    decision_task_id="decisiontask",
+                )


### PR DESCRIPTION
I noticed this as an intermittent test failure in CI, which looks like a minor regression from https://github.com/taskcluster/taskgraph/pull/873:
```
[task 2026-06-29T11:51:43.891+00:00] ______________ TestCreate.test_create_tasks_fails_if_create_fails ______________
[task 2026-06-29T11:51:43.891+00:00] 
[task 2026-06-29T11:51:43.891+00:00] self = <test.test_create.TestCreate testMethod=test_create_tasks_fails_if_create_fails>
[task 2026-06-29T11:51:43.891+00:00] 
[task 2026-06-29T11:51:43.891+00:00]     @responses.activate
[task 2026-06-29T11:51:43.891+00:00]     @mock.patch.dict(
[task 2026-06-29T11:51:43.891+00:00]         "os.environ",
[task 2026-06-29T11:51:43.891+00:00]         {"TASKCLUSTER_ROOT_URL": "https://tc.example.com"},
[task 2026-06-29T11:51:43.891+00:00]         clear=True,
[task 2026-06-29T11:51:43.891+00:00]     )
[task 2026-06-29T11:51:43.891+00:00]     def test_create_tasks_fails_if_create_fails(self):
[task 2026-06-29T11:51:43.891+00:00]         "create_tasks fails if a single create_task call fails"
[task 2026-06-29T11:51:43.891+00:00]         mock_taskcluster_api(error_status=403, error_message="oh no!")
[task 2026-06-29T11:51:43.891+00:00]     
[task 2026-06-29T11:51:43.891+00:00]         tasks = {
[task 2026-06-29T11:51:43.891+00:00]             "tid-a": Task(
[task 2026-06-29T11:51:43.891+00:00]                 kind="test", label="a", attributes={}, task={"payload": "hello world"}
[task 2026-06-29T11:51:43.891+00:00]             ),
[task 2026-06-29T11:51:43.891+00:00]         }
[task 2026-06-29T11:51:43.891+00:00]         label_to_taskid = {"a": "tid-a"}
[task 2026-06-29T11:51:43.891+00:00]         graph = Graph(nodes={"tid-a"}, edges=set())
[task 2026-06-29T11:51:43.891+00:00]         taskgraph = TaskGraph(tasks, graph)
[task 2026-06-29T11:51:43.891+00:00]     
[task 2026-06-29T11:51:43.891+00:00] >       with self.assertRaises(CreateTasksException):
[task 2026-06-29T11:51:43.891+00:00]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[task 2026-06-29T11:51:43.891+00:00] E       AssertionError: CreateTasksException not raised
```

It's probably impossible to hit in any non-trivial taskgraph in production, but it's certainly something that *could* happen, particularly in smaller/shallower graphs.

The fix is moving the error checking out to the main flow of control, and doing it synchronously. This leaves `handle_exception` doing nothing except populated `skipped`, so I moved it into `schedule_tasks` and renamed it to make that a bit more obvious.